### PR TITLE
Add learnable KO schedule and differentiable sampling

### DIFF
--- a/examples/image/models/discrete_unet.py
+++ b/examples/image/models/discrete_unet.py
@@ -21,10 +21,22 @@ class PixelEmbedding(nn.Module):
         self.embedding_table = nn.Embedding(n_tokens, hidden_size)
 
     def forward(self, x: torch.Tensor):
-        B, _, H, W = x.shape
-        emb = self.embedding_table(x)
-        result = emb.permute(0, 1, 4, 2, 3).reshape(B, -1, H, W)
-        return result
+        if x.dtype in (torch.int32, torch.int64):
+            B, _, H, W = x.shape
+            emb = self.embedding_table(x)
+            result = emb.permute(0, 1, 4, 2, 3).reshape(B, -1, H, W)
+            return result
+
+        if x.ndim == 5 and x.shape[-1] == self.embedding_table.num_embeddings:
+            B, C, H, W, _ = x.shape
+            emb_weight = self.embedding_table.weight
+            emb = torch.matmul(x, emb_weight)
+            result = emb.permute(0, 1, 4, 2, 3).reshape(B, -1, H, W)
+            return result
+
+        raise ValueError(
+            "PixelEmbedding expects integer tokens of shape (B,C,H,W) or relaxed assignments (B,C,H,W,K)."
+        )
 
 
 @dataclass(eq=False)
@@ -88,7 +100,13 @@ class DiscreteUNetModel(nn.Module):
     def forward(
         self, x_t: torch.Tensor, t: torch.Tensor, extra: Mapping[str, torch.Tensor]
     ) -> torch.Tensor:
-        B, C, H, W = x_t.shape
+        if x_t.ndim == 4:
+            B, C, H, W = x_t.shape
+        elif x_t.ndim == 5 and x_t.shape[-1] == self.vocab_size:
+            B, C, H, W, _ = x_t.shape
+        else:
+            raise ValueError("x_t must be integer tokens or relaxed assignments with vocab dimension")
+
         logits = (
             self.unet(self.pixel_embedding(x_t), t, extra)
             .reshape(B, C, self.vocab_size, H, W)

--- a/examples/image/train.py
+++ b/examples/image/train.py
@@ -27,14 +27,21 @@ import os
 import sys
 import time
 from pathlib import Path
+from typing import Optional
 
 import numpy as np
 import torch
 import torch.backends.cudnn as cudnn
+import torch.nn as nn
 import torchvision.datasets as datasets
 from models.model_configs import instantiate_model
 from train_arg_parser import get_args_parser
 
+from flow_matching.path import (
+    MetricInducedGibbsProbPath,
+    MonotoneRQBetaSchedule,
+    MonotoneRQConfig,
+)
 from training import distributed_mode
 from training.data_transform import get_train_transform
 from training.eval_loop import eval_model
@@ -116,6 +123,39 @@ def main(args):
     )
     logger.info(str(sampler_train))
 
+    beta_schedule: Optional[MonotoneRQBetaSchedule] = None
+    metric_path: Optional[MetricInducedGibbsProbPath] = None
+    if getattr(args, "ko_metric_induced", False):
+        embed_range = "pm1" if args.mi_embed_range == "pm1" else "unit"
+        if getattr(args, "mi_learnable_beta", False):
+            spline_config = MonotoneRQConfig(
+                num_bins=int(getattr(args, "mi_spline_bins", 8)),
+                tail_bound=float(getattr(args, "mi_spline_tail_bound", 6.0)),
+                beta_min=float(getattr(args, "mi_beta_min", 0.0)),
+                beta_max=float(getattr(args, "mi_beta_max", 20.0)),
+                t_eps=float(getattr(args, "mi_t_eps", 1e-4)),
+                logit_eps=float(getattr(args, "mi_logit_eps", 1e-6)),
+            )
+            beta_schedule = MonotoneRQBetaSchedule(config=spline_config)
+            beta_schedule.to(device=device)
+
+        metric_path = MetricInducedGibbsProbPath(
+            embedding_path_or_weight=None,
+            vocab_size=256,
+            emb_dim=1,
+            metric=args.mi_metric,
+            lp_order=args.mi_lp,
+            embed_range=embed_range,
+            a=args.mi_a,
+            c=args.mi_c,
+            device=device,
+            dtype=torch.float32,
+            beta_schedule=beta_schedule,
+            use_gumbel=getattr(args, "mi_use_gumbel", False),
+            gumbel_tau=float(getattr(args, "mi_gumbel_tau", 1.0)),
+            gumbel_hard=True,
+        )
+
     # define the model
     logger.info("Initializing Model")
     model = instantiate_model(
@@ -145,8 +185,16 @@ def main(args):
         )
         model_without_ddp = model.module
 
+    optimizer_params = list(model_without_ddp.parameters())
+    extra_modules = {}
+    if metric_path is not None:
+        schedule_params = list(metric_path.learnable_parameters())
+        if schedule_params:
+            optimizer_params.extend(schedule_params)
+            if isinstance(metric_path.beta_schedule, nn.Module):
+                extra_modules["metric_beta_schedule"] = metric_path.beta_schedule
     optimizer = torch.optim.AdamW(
-        model_without_ddp.parameters(), lr=args.lr, betas=args.optimizer_betas
+        optimizer_params, lr=args.lr, betas=args.optimizer_betas
     )
     if args.decay_lr:
         lr_schedule = torch.optim.lr_scheduler.LinearLR(
@@ -171,6 +219,7 @@ def main(args):
         optimizer=optimizer,
         loss_scaler=loss_scaler,
         lr_schedule=lr_schedule,
+        extra_modules=extra_modules,
     )
 
     # Optional Weights & Biases
@@ -207,6 +256,7 @@ def main(args):
                 epoch=epoch,
                 loss_scaler=loss_scaler,
                 args=args,
+                path=metric_path,
             )
             log_stats = {
                 **{f"train_{k}": v for k, v in train_stats.items()},
@@ -231,6 +281,7 @@ def main(args):
                     lr_schedule=lr_schedule,
                     loss_scaler=loss_scaler,
                     epoch=epoch,
+                    extra_modules=extra_modules,
                 )
             if args.distributed:
                 data_loader_train.sampler.set_epoch(0)
@@ -247,6 +298,7 @@ def main(args):
                 epoch=epoch,
                 fid_samples=fid_samples,
                 args=args,
+                metric_path=metric_path,
             )
             log_stats.update({f"eval_{k}": v for k, v in eval_stats.items()})
 

--- a/examples/image/train_arg_parser.py
+++ b/examples/image/train_arg_parser.py
@@ -248,6 +248,58 @@ def get_args_parser():
         type=str,
         help="Embedding range for tokens: 'pm1' maps to [-1,1], '01' maps to [0,1]",
     )
+    parser.add_argument(
+        "--mi_learnable_beta",
+        action="store_true",
+        help="Enable learnable monotone RQ spline schedule for the metric-induced β(t).",
+    )
+    parser.add_argument(
+        "--mi_beta_min",
+        default=0.0,
+        type=float,
+        help="Lower bound for the learnable β(t) schedule.",
+    )
+    parser.add_argument(
+        "--mi_beta_max",
+        default=20.0,
+        type=float,
+        help="Upper bound for the learnable β(t) schedule.",
+    )
+    parser.add_argument(
+        "--mi_spline_bins",
+        default=8,
+        type=int,
+        help="Number of knots (bins) for the monotone RQ spline β(t).",
+    )
+    parser.add_argument(
+        "--mi_spline_tail_bound",
+        default=6.0,
+        type=float,
+        help="Tail bound of the spline domain in logit time.",
+    )
+    parser.add_argument(
+        "--mi_t_eps",
+        default=1e-4,
+        type=float,
+        help="Clamp applied to t before evaluating the spline schedule.",
+    )
+    parser.add_argument(
+        "--mi_logit_eps",
+        default=1e-6,
+        type=float,
+        help="Stability epsilon used when applying the logit inside the spline schedule.",
+    )
+    parser.add_argument(
+        "--mi_use_gumbel",
+        action="store_true",
+        help="Use straight-through Gumbel-Softmax sampling for metric-induced training inputs.",
+    )
+    parser.add_argument(
+        "--mi_gumbel_tau",
+        default=1.0,
+        type=float,
+        help="Temperature for the Gumbel-Softmax sampler when --mi_use_gumbel is set.",
+    )
 
     # Optional Weights & Biases logging
     parser.add_argument(

--- a/examples/image/training/eval_loop.py
+++ b/examples/image/training/eval_loop.py
@@ -23,7 +23,7 @@ import math
 import os
 from argparse import Namespace
 from pathlib import Path
-from typing import Iterable, cast
+from typing import Iterable, Optional, cast
 
 import PIL.Image
 
@@ -110,6 +110,7 @@ def eval_model(
     epoch: int,
     fid_samples: int,
     args: Namespace,
+    metric_path: Optional[MetricInducedGibbsProbPath] = None,
 ):
     gc.collect()
     cfg_scaled_model = CFGScaledModel(model=model)
@@ -156,7 +157,7 @@ def eval_model(
 
     # Lazily constructed KO solver and path (once K is known)
     ko_solver = None
-    ko_path = None
+    ko_path = metric_path
 
     for data_iter_step, (samples, labels) in enumerate(data_loader):
         samples = samples.to(device, non_blocking=True)
@@ -187,23 +188,30 @@ def eval_model(
                         )
                         K = int(logits_dummy.shape[-1])
                         # Build path
-                        mi_metric = getattr(args, "mi_metric", "lp")
-                        mi_lp = float(getattr(args, "mi_lp", 3.0))
-                        mi_a = float(getattr(args, "mi_a", 5.0))
-                        mi_c = float(getattr(args, "mi_c", 1.0))
-                        mi_embed_range = getattr(args, "mi_embed_range", "pm1")
-                        ko_path = MetricInducedGibbsProbPath(
-                            embedding_path_or_weight=None,
-                            vocab_size=K,
-                            emb_dim=1,
-                            metric=mi_metric,
-                            lp_order=mi_lp,
-                            embed_range=mi_embed_range,
-                            a=mi_a,
-                            c=mi_c,
-                            device=device,
-                            dtype=torch.float32,
-                        )
+                        if ko_path is not None and ko_path.vocab_size != K:
+                            raise ValueError(
+                                f"Provided metric-induced path expects vocab size {ko_path.vocab_size},"
+                                f" but model produced logits with last dim {K}."
+                            )
+                        if ko_path is None:
+                            mi_metric = getattr(args, "mi_metric", "lp")
+                            mi_lp = float(getattr(args, "mi_lp", 3.0))
+                            mi_a = float(getattr(args, "mi_a", 5.0))
+                            mi_c = float(getattr(args, "mi_c", 1.0))
+                            mi_embed_range = getattr(args, "mi_embed_range", "pm1")
+                            embed_range = "pm1" if mi_embed_range == "pm1" else "unit"
+                            ko_path = MetricInducedGibbsProbPath(
+                                embedding_path_or_weight=None,
+                                vocab_size=K,
+                                emb_dim=1,
+                                metric=mi_metric,
+                                lp_order=mi_lp,
+                                embed_range=embed_range,
+                                a=mi_a,
+                                c=mi_c,
+                                device=device,
+                                dtype=torch.float32,
+                            )
                         ko_solver = KODiscreteGibbsEulerSolver(
                             model=cfg_scaled_logits_model,
                             path=ko_path,

--- a/examples/image/training/load_and_save.py
+++ b/examples/image/training/load_and_save.py
@@ -4,8 +4,10 @@
 # This source code is licensed under the CC-by-NC license found in the
 # LICENSE file in the root directory of this source tree.
 from pathlib import Path
+from typing import Dict, Optional
 
 import torch
+from torch.nn import Module
 from training.distributed_mode import is_main_process
 
 
@@ -15,7 +17,14 @@ def save_on_master(*args, **kwargs):
 
 
 def save_model(
-    args, epoch, model, model_without_ddp, optimizer, lr_schedule, loss_scaler
+    args,
+    epoch,
+    model,
+    model_without_ddp,
+    optimizer,
+    lr_schedule,
+    loss_scaler,
+    extra_modules: Optional[Dict[str, Module]] = None,
 ):
     output_dir = Path(args.output_dir)
     epoch_name = str(epoch)
@@ -25,6 +34,10 @@ def save_model(
             output_dir / "checkpoint.pth",
         ]
         for checkpoint_path in checkpoint_paths:
+            extra_state = {
+                name: module.state_dict()
+                for name, module in (extra_modules or {}).items()
+            }
             to_save = {
                 "model": model_without_ddp.state_dict(),
                 "optimizer": optimizer.state_dict(),
@@ -32,6 +45,7 @@ def save_model(
                 "epoch": epoch,
                 "scaler": loss_scaler.state_dict(),
                 "args": args,
+                "extra_modules": extra_state,
             }
 
             save_on_master(to_save, checkpoint_path)
@@ -44,7 +58,14 @@ def save_model(
         )
 
 
-def load_model(args, model_without_ddp, optimizer, loss_scaler, lr_schedule):
+def load_model(
+    args,
+    model_without_ddp,
+    optimizer,
+    loss_scaler,
+    lr_schedule,
+    extra_modules: Optional[Dict[str, Module]] = None,
+):
     if args.resume:
         if args.resume.startswith("https"):
             checkpoint = torch.hub.load_state_dict_from_url(
@@ -54,6 +75,11 @@ def load_model(args, model_without_ddp, optimizer, loss_scaler, lr_schedule):
             checkpoint = torch.load(args.resume, map_location="cpu")
         model_without_ddp.load_state_dict(checkpoint["model"])
         print("Resume checkpoint %s" % args.resume)
+        if extra_modules and "extra_modules" in checkpoint:
+            for name, module in extra_modules.items():
+                state_dict = checkpoint["extra_modules"].get(name)
+                if state_dict is not None:
+                    module.load_state_dict(state_dict)
         if (
             "optimizer" in checkpoint
             and "epoch" in checkpoint

--- a/examples/image/training/train_loop.py
+++ b/examples/image/training/train_loop.py
@@ -7,13 +7,14 @@ import argparse
 import gc
 import logging
 import math
-from typing import Iterable
+from typing import Iterable, Optional
 
 import torch
 from flow_matching.path import (
     CondOTProbPath,
     MixtureDiscreteProbPath,
     MetricInducedGibbsProbPath,
+    ProbPath,
 )
 from flow_matching.path.scheduler import PolynomialConvexScheduler
 from models.ema import EMA
@@ -50,6 +51,7 @@ def train_one_epoch(
     epoch: int,
     loss_scaler: NativeScalerWithGradNormCount,
     args: argparse.Namespace,
+    path: Optional[ProbPath] = None,
 ):
     gc.collect()
     model.train(True)
@@ -61,17 +63,8 @@ def train_one_epoch(
     #   args.ko_metric_induced = True
     # For original discrete mixture path training, keep args.discrete_flow_matching = True
     if getattr(args, "ko_metric_induced", False):
-        # KO: embed tokens into [-1,1], lp distance with p=3, beta(t)=c*(t/(1-t))**a with a=5,c=1
-        # MetricInducedGibbsProbPath provides sampling X_t ~ p_t(·|x1) for training inputs.
-        path = MetricInducedGibbsProbPath(
-            embedding_path_or_weight=None,  # default builds mapping based on embed_range
-            vocab_size=256,
-            emb_dim=1,
-            metric="lp",
-            lp_order=3.0,
-            embed_range="pm1",  # [-1,1] embedding as KO
-            a=5.0,
-            c=1.0,
+        assert isinstance(path, MetricInducedGibbsProbPath), (
+            "Metric-induced training expects a pre-instantiated MetricInducedGibbsProbPath."
         )
     elif args.discrete_flow_matching:
         scheduler = PolynomialConvexScheduler(n=3.0)
@@ -108,13 +101,14 @@ def train_one_epoch(
             # Provide dummy x_0 for signature compatibility (not used by metric-induced path)
             x_0 = torch.zeros_like(samples)
             path_sample = path.sample(t=t, x_0=x_0, x_1=samples)
+            x_t_model = path_sample.x_t_soft if path_sample.x_t_soft is not None else path_sample.x_t
 
             # Model should output logits with last dim = 256
             if getattr(args, "bf16", False):
                 with torch.cuda.amp.autocast(dtype=torch.bfloat16):
-                    logits = model(path_sample.x_t, t=t, extra=conditioning)
+                    logits = model(x_t_model, t=t, extra=conditioning)
             else:
-                logits = model(path_sample.x_t, t=t, extra=conditioning)
+                logits = model(x_t_model, t=t, extra=conditioning)
             loss = torch.nn.functional.cross_entropy(
                 logits.float().reshape([-1, 256]), samples.reshape([-1])
             ).mean()

--- a/flow_matching/path/__init__.py
+++ b/flow_matching/path/__init__.py
@@ -6,6 +6,7 @@
 
 from .affine import AffineProbPath, CondOTProbPath
 from .geodesic import GeodesicProbPath
+from .beta_schedules import BetaSchedule, MonotoneRQBetaSchedule, MonotoneRQConfig
 from .mixture import MixtureDiscreteProbPath, MetricInducedGibbsProbPath
 from .path import ProbPath
 from .path_sample import DiscretePathSample, PathSample
@@ -20,4 +21,7 @@ __all__ = [
     "GeodesicProbPath",
     "PathSample",
     "DiscretePathSample",
+    "BetaSchedule",
+    "MonotoneRQBetaSchedule",
+    "MonotoneRQConfig",
 ]

--- a/flow_matching/path/beta_schedules.py
+++ b/flow_matching/path/beta_schedules.py
@@ -1,0 +1,171 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the CC-by-NC license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Tuple
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from torch import Tensor
+
+
+class BetaSchedule(nn.Module):
+    """Abstract interface for time-dependent schedules used by discrete paths."""
+
+    def beta_and_derivative(self, t: Tensor) -> Tuple[Tensor, Tensor]:  # pragma: no cover - interface
+        raise NotImplementedError
+
+
+def _normalize_bin_sizes(
+    unnormalized: Tensor, min_size: float, total_size: float
+) -> Tensor:
+    num_bins = unnormalized.shape[-1]
+    softmax = F.softmax(unnormalized, dim=-1)
+    return softmax * (total_size - min_size * num_bins) + min_size
+
+
+def _rational_quadratic_spline(
+    inputs: Tensor,
+    widths: Tensor,
+    heights: Tensor,
+    derivatives: Tensor,
+    left: float,
+    right: float,
+    bottom: float,
+    top: float,
+) -> Tensor:
+    """One-dimensional monotone rational quadratic spline with linear tails."""
+
+    inputs_flat = inputs.reshape(-1)
+    outputs_flat = torch.empty_like(inputs_flat)
+
+    cumwidths = torch.cumsum(widths, dim=-1)
+    cumheights = torch.cumsum(heights, dim=-1)
+
+    cumwidths = F.pad(cumwidths, (1, 0), value=0.0)
+    cumheights = F.pad(cumheights, (1, 0), value=0.0)
+
+    cumwidths = cumwidths + left
+    cumheights = cumheights + bottom
+
+    # Tails
+    left_mask = inputs_flat <= left
+    right_mask = inputs_flat >= right
+    center_mask = (~left_mask) & (~right_mask)
+
+    if left_mask.any():
+        slope = derivatives[..., 0]
+        outputs_flat[left_mask] = bottom + (inputs_flat[left_mask] - left) * slope
+
+    if right_mask.any():
+        slope = derivatives[..., -1]
+        outputs_flat[right_mask] = top + (inputs_flat[right_mask] - right) * slope
+
+    if center_mask.any():
+        inside_x = inputs_flat[center_mask]
+        bin_idx = torch.searchsorted(cumwidths, inside_x, right=True) - 1
+        bin_idx = bin_idx.clamp(min=0, max=widths.shape[-1] - 1)
+
+        input_cumwidth = cumwidths.index_select(dim=-1, index=bin_idx)
+        input_cumheight = cumheights.index_select(dim=-1, index=bin_idx)
+
+        w = widths.index_select(dim=-1, index=bin_idx)
+        h = heights.index_select(dim=-1, index=bin_idx)
+        s = (inside_x - input_cumwidth) / w
+
+        delta = h / w
+        d0 = derivatives.index_select(dim=-1, index=bin_idx)
+        d1 = derivatives.index_select(dim=-1, index=bin_idx + 1)
+
+        numerator = h * (delta * s**2 + d0 * s * (1 - s))
+        denominator = delta + (d0 + d1 - 2 * delta) * s * (1 - s)
+        outputs_flat[center_mask] = input_cumheight + numerator / denominator
+
+    return outputs_flat.view_as(inputs)
+
+
+@dataclass
+class MonotoneRQConfig:
+    num_bins: int = 8
+    tail_bound: float = 6.0
+    beta_min: float = 0.0
+    beta_max: float = 20.0
+    min_bin_width: float = 1e-3
+    min_bin_height: float = 1e-3
+    min_derivative: float = 1e-3
+    t_eps: float = 1e-4
+    logit_eps: float = 1e-6
+
+
+class MonotoneRQBetaSchedule(BetaSchedule):
+    """Logit-time monotone rational quadratic spline schedule for β(t)."""
+
+    def __init__(self, config: MonotoneRQConfig | None = None):
+        super().__init__()
+        self.config = config or MonotoneRQConfig()
+        self.num_bins = self.config.num_bins
+        assert self.num_bins >= 2, "num_bins must be >= 2"
+        assert self.config.beta_max > self.config.beta_min, "beta_max must exceed beta_min"
+
+        self.unnormalized_widths = nn.Parameter(torch.zeros(self.num_bins))
+        self.unnormalized_heights = nn.Parameter(torch.zeros(self.num_bins))
+        self.unnormalized_derivatives = nn.Parameter(torch.zeros(self.num_bins + 1))
+
+    def _spline(self, s: Tensor) -> Tensor:
+        cfg = self.config
+        widths = _normalize_bin_sizes(
+            self.unnormalized_widths,
+            cfg.min_bin_width,
+            cfg.tail_bound * 2.0,
+        )
+        heights = _normalize_bin_sizes(
+            self.unnormalized_heights,
+            cfg.min_bin_height,
+            cfg.tail_bound * 2.0,
+        )
+        derivatives = F.softplus(self.unnormalized_derivatives) + cfg.min_derivative
+        return _rational_quadratic_spline(
+            inputs=s,
+            widths=widths,
+            heights=heights,
+            derivatives=derivatives,
+            left=-cfg.tail_bound,
+            right=cfg.tail_bound,
+            bottom=-cfg.tail_bound,
+            top=cfg.tail_bound,
+        )
+
+    def _beta_from_t(self, t: Tensor) -> Tensor:
+        cfg = self.config
+        s = torch.logit(t, eps=cfg.logit_eps)
+        spline_val = self._spline(s)
+        sigma = torch.sigmoid(spline_val)
+        return cfg.beta_min + (cfg.beta_max - cfg.beta_min) * sigma
+
+    def beta_and_derivative(self, t: Tensor) -> Tuple[Tensor, Tensor]:
+        cfg = self.config
+        t_clamped = t.clamp(min=cfg.t_eps, max=1.0 - cfg.t_eps)
+        grad_enabled = torch.is_grad_enabled()
+        with torch.enable_grad():
+            t_req = t_clamped.detach().requires_grad_(True)
+            beta = self._beta_from_t(t_req)
+            ones = torch.ones_like(beta)
+            d_beta = torch.autograd.grad(
+                beta,
+                t_req,
+                grad_outputs=ones,
+                create_graph=grad_enabled,
+            )[0]
+        if not grad_enabled:
+            beta = beta.detach()
+            d_beta = d_beta.detach()
+        beta = beta.view_as(t_clamped)
+        d_beta = d_beta.view_as(t_clamped)
+        return beta, d_beta
+

--- a/flow_matching/path/mixture.py
+++ b/flow_matching/path/mixture.py
@@ -7,10 +7,11 @@
 import torch
 import torch.nn.functional as F
 import torch.nn as nn
-from typing import Optional, Union
+from typing import Iterable, Optional, Union
 
 from torch import Tensor
 
+from flow_matching.path.beta_schedules import BetaSchedule
 from flow_matching.path.path import ProbPath
 
 from flow_matching.path.path_sample import DiscretePathSample
@@ -146,6 +147,10 @@ class MetricInducedGibbsProbPath(ProbPath):
         eps_t: float = 1e-7,          # clamp t away from 0,1 for beta(t) stability
         device: Optional[torch.device] = None,
         dtype: torch.dtype = torch.float32,
+        beta_schedule: Optional[BetaSchedule] = None,
+        use_gumbel: bool = False,
+        gumbel_tau: float = 1.0,
+        gumbel_hard: bool = True,
     ):
         super().__init__()
         self.metric_name = metric
@@ -156,6 +161,12 @@ class MetricInducedGibbsProbPath(ProbPath):
         self.c = float(c)
         self.eps_t = float(eps_t)
         self.dtype = dtype
+        self.beta_schedule = beta_schedule
+        if self.beta_schedule is not None and device is not None:
+            self.beta_schedule.to(device=device, dtype=dtype)
+        self.use_gumbel = bool(use_gumbel)
+        self.gumbel_tau = float(gumbel_tau)
+        self.gumbel_hard = bool(gumbel_hard)
 
         self.embedding = self._build_embedding(
             embedding_path_or_weight, vocab_size, emb_dim, device, dtype
@@ -225,15 +236,22 @@ class MetricInducedGibbsProbPath(ProbPath):
         β(t) = c * (t / (1 - t))**a, with clamping for stability.
         Returns (beta_t, d_beta_t) broadcasting over batch.
         """
+        if self.beta_schedule is not None:
+            return self.beta_schedule.beta_and_derivative(t)
+
         eps = self.eps_t
         t = t.clamp(min=eps, max=1.0 - eps)  # (B,)
         u = 1.0 - t                            # denominator; safe since t <= 1 - eps
         y = t / u                              # t/(1 - t)
         beta_t = self.c * (y ** self.a)
-        # KO exact derivative (with clamp): dy/dt = 1 / (1 - t + eps)^2
         dy_dt = 1.0 / (u * u)
         d_beta_t = self.c * self.a * (y ** (self.a - 1.0)) * dy_dt
         return beta_t, d_beta_t
+
+    def learnable_parameters(self) -> Iterable[nn.Parameter]:
+        if self.beta_schedule is None:
+            return []
+        return self.beta_schedule.parameters()
 
     # ---------- Distance on the embedding space ----------
     def _pairwise_dist(self, z_flat: Tensor, E: Tensor) -> Tensor:
@@ -398,11 +416,24 @@ class MetricInducedGibbsProbPath(ProbPath):
         # Fast path via precomputed table
         probs = self.get_prob_distribution_from_tokens(x1_flat, t)
         S = probs.shape[1]
-        x_t_flat = torch.multinomial(
-            probs.view(B * S, self.vocab_size), num_samples=1, replacement=True
-        ).view(B, S)
+        x_t_soft = None
+        if self.use_gumbel:
+            logits = torch.log(probs.clamp_min(1e-12))
+            gumbel = F.gumbel_softmax(
+                logits,
+                tau=self.gumbel_tau,
+                hard=self.gumbel_hard,
+                dim=-1,
+            )
+            x_t_soft = gumbel.view(orig_shape + (self.vocab_size,))
+            x_t_flat = gumbel.argmax(dim=-1)
+        else:
+            x_t_flat = torch.multinomial(
+                probs.view(B * S, self.vocab_size), num_samples=1, replacement=True
+            ).view(B, S)
+
         x_t = x_t_flat.view(orig_shape).to(device=device, dtype=x_1.dtype)
-        return DiscretePathSample(x_t=x_t, x_1=x_1, x_0=x_0, t=t)
+        return DiscretePathSample(x_t=x_t, x_1=x_1, x_0=x_0, t=t, x_t_soft=x_t_soft)
 
     # ---------- API: posterior_to_velocity() ----------
     def posterior_to_velocity(self, posterior_logits: Tensor, x_t: Tensor, t: Tensor) -> Tensor:

--- a/flow_matching/path/path_sample.py
+++ b/flow_matching/path/path_sample.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 from dataclasses import dataclass, field
+from typing import Optional
 
 from torch import Tensor
 
@@ -50,4 +51,10 @@ class DiscretePathSample:
     t: Tensor = field(metadata={"help": "time samples t (batch_size, ...)."})
     x_t: Tensor = field(
         metadata={"help": "samples X_t ~ p_t(X_t), shape (batch_size, ...)."}
+    )
+    x_t_soft: Optional[Tensor] = field(
+        default=None,
+        metadata={
+            "help": "Optional relaxed assignments (e.g., straight-through Gumbel outputs) matching x_t's shape with an extra vocab dimension.",
+        },
     )

--- a/tests/path/test_path.py
+++ b/tests/path/test_path.py
@@ -11,7 +11,10 @@ from flow_matching.path import (
     AffineProbPath,
     CondOTProbPath,
     GeodesicProbPath,
+    MetricInducedGibbsProbPath,
     MixtureDiscreteProbPath,
+    MonotoneRQBetaSchedule,
+    MonotoneRQConfig,
 )
 from flow_matching.path.scheduler import CondOTScheduler
 from flow_matching.utils.manifolds import FlatTorus, Sphere
@@ -175,6 +178,46 @@ class TestMixtureDiscreteProbPath(unittest.TestCase):
             1 - t
         ).unsqueeze(-1)
         self.assertTrue(torch.allclose(velocity, expected_velocity))
+
+
+class TestMetricInducedProbPath(unittest.TestCase):
+    def test_gumbel_sample_has_soft_assignments(self):
+        path = MetricInducedGibbsProbPath(
+            vocab_size=4,
+            emb_dim=1,
+            metric="lp",
+            lp_order=2.0,
+            embed_range="unit",
+            a=1.0,
+            c=1.0,
+            use_gumbel=True,
+            gumbel_tau=0.7,
+        )
+        x1 = torch.randint(0, 4, size=(3, 1, 1, 1), dtype=torch.long)
+        x0 = torch.zeros_like(x1)
+        t = torch.full((3,), 0.5)
+        sample = path.sample(x_0=x0, x_1=x1, t=t)
+        self.assertIsNotNone(sample.x_t_soft)
+        assert sample.x_t_soft is not None  # satisfy type checker
+        self.assertEqual(sample.x_t_soft.shape, x1.shape + (path.vocab_size,))
+        probs = sample.x_t_soft.sum(dim=-1)
+        self.assertTrue(torch.allclose(probs, torch.ones_like(probs)))
+
+
+class TestMonotoneRQSchedule(unittest.TestCase):
+    def test_schedule_monotonicity_and_bounds(self):
+        config = MonotoneRQConfig(num_bins=8, beta_min=0.0, beta_max=5.0)
+        schedule = MonotoneRQBetaSchedule(config=config)
+        t = torch.linspace(1e-3, 1 - 1e-3, steps=32, requires_grad=True)
+        beta, d_beta = schedule.beta_and_derivative(t)
+        self.assertTrue(torch.all(beta >= config.beta_min - 1e-5))
+        self.assertTrue(torch.all(beta <= config.beta_max + 1e-5))
+        self.assertTrue(torch.all(d_beta > 0))
+        self.assertTrue(torch.all(beta[1:] >= beta[:-1]))
+        loss = beta.sum()
+        loss.backward()
+        grads = [param.grad for param in schedule.parameters()]
+        self.assertTrue(all(g is not None for g in grads))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add a monotone rational-quadratic spline beta schedule with autograd-friendly derivative for the KO metric-induced path
- enable straight-through Gumbel-Softmax sampling and soft token embeddings when training discrete models
- thread the learnable schedule through training/eval scripts, optimizer state, and checkpoints so KO experiments can learn the schedule end-to-end
- extend test coverage for the spline schedule and Gumbel sampling path

## Testing
- pytest tests/path/test_path.py

------
https://chatgpt.com/codex/tasks/task_e_68cb97d0f51c83219855ce1d49a0eaa2

## Summary by Sourcery

Introduce a differentiable, learnable monotone spline β schedule and Gumbel-Softmax sampling into the discrete model training and evaluation pipelines, propagate these new components through CLI, optimizer, and checkpoints for end-to-end learning, and ensure their correctness with new tests.

New Features:
- Introduce MonotoneRQBetaSchedule and MonotoneRQConfig for a learnable rational-quadratic spline β schedule.
- Add straight-through Gumbel-Softmax sampling with optional soft token embeddings in MetricInducedGibbsProbPath.
- Extend PixelEmbedding and discrete Unet to handle relaxed (soft) token assignments alongside integer tokens.
- Expose new CLI flags to configure the learnable β schedule, Gumbel sampling, and related hyperparameters.

Bug Fixes:
- Enforce matching vocabulary size in MetricInducedGibbsProbPath during evaluation to avoid dimension mismatches.

Enhancements:
- Thread learnable β schedule parameters and Gumbel sampling options through training/eval scripts, optimizer, and checkpoint save/load for end-to-end learning.
- Refactor training and evaluation loops to accept a pre-instantiated MetricInducedGibbsProbPath and unify its usage.
- Save and restore state of extra modules (e.g., β schedule) in model checkpoints.

Tests:
- Add tests verifying monotonicity, bounds, and gradient flow of MonotoneRQBetaSchedule.
- Add tests verifying the presence and correctness of soft assignments in Gumbel-Softmax sampling.