### PR TITLE
Add metric geometry evaluation diagnostics

### DIFF
--- a/docs/cosine_lut_updates.md
+++ b/docs/cosine_lut_updates.md
@@ -12,6 +12,7 @@
 - Added cosine scale calibration:
   - `_calibrate_cosine_scale` matches the median distance of the cosine table to the baseline table.
   - Enabled via `--mi_lut_cosine_calibrate`, executed post warm-start and after loading checkpoints.
+- Updated LUT diagnostics to project cosine embeddings (angle-based scalarization) before plotting/metrics, replacing the old L2-norm visualization.
 - CLI updates:
   - `--mi_metric` choices expanded to include `"euclidean"` and `"cosine"`.
   - New flags `--mi_lut_cosine_scale`, `--mi_lut_cosine_calibrate`, `--mi_lut_force_warm_start`.
@@ -24,4 +25,3 @@
 - `flow_matching/examples/image/train.py`
 - `flow_matching/examples/image/train_arg_parser.py`
 - `flow_matching/examples/image/training/train_loop.py`
-

--- a/docs/cosine_lut_updates.md
+++ b/docs/cosine_lut_updates.md
@@ -9,6 +9,7 @@
 - Introduced warm-start for cosine LUTs:
   - `_warm_start_cosine_lut` maps tokens to a great-circle initialization (half-arc on the unit sphere).
   - Flag `--mi_lut_force_warm_start` allows reinitializing even when resuming from checkpoints (e.g., finetuning 1D baselines).
+  - Warm start now applies the weight copy under `torch.no_grad()` to avoid autograd in-place pitfalls.
 - Added cosine scale calibration:
   - `_calibrate_cosine_scale` matches the median distance of the cosine table to the baseline table.
   - Enabled via `--mi_lut_cosine_calibrate`, executed post warm-start and after loading checkpoints.

--- a/docs/cosine_lut_updates.md
+++ b/docs/cosine_lut_updates.md
@@ -11,12 +11,17 @@
   - Flag `--mi_lut_force_warm_start` allows reinitializing even when resuming from checkpoints (e.g., finetuning 1D baselines).
   - Warm start now applies the weight copy under `torch.no_grad()` to avoid autograd in-place pitfalls.
 - Added cosine scale calibration:
-  - `_calibrate_cosine_scale` matches the median distance of the cosine table to the baseline table.
-  - Enabled via `--mi_lut_cosine_calibrate`, executed post warm-start and after loading checkpoints.
+  - `_calibrate_cosine_scale` now defaults to **neighbor-aligned** matching (adjacent-token distances) to capture the effective temperature seen during training.
+  - Supports configurable `t_mid` grids (default `0.3 0.5 0.7`); all candidates are logged, the first value drives the applied scale.
+  - Enabled via `--mi_lut_cosine_calibrate`, executed post warm-start and after loading checkpoints. Legacy full-table median mode is still available via `--mi_lut_cosine_calibrate_mode median`.
+- Training diagnostics:
+  - The training loop logs `β(t)·s·median(1−cos Δθ)` vs. the baseline neighbor scale (console + W&B/stats), alongside conditional entropy and uniform-weight loss.
+  - Step logs include `cos_ratio` (effective/baseline) and `cosine_effective_neighbor` to spot hot/cold starts quickly.
 - Updated LUT diagnostics to project cosine embeddings (angle-based scalarization) before plotting/metrics, replacing the old L2-norm visualization.
 - CLI updates:
   - `--mi_metric` choices expanded to include `"euclidean"` and `"cosine"`.
   - New flags `--mi_lut_cosine_scale`, `--mi_lut_cosine_calibrate`, `--mi_lut_force_warm_start`.
+  - Additional cosine controls: `--mi_lut_cosine_calibrate_mode {neighbor,median}` and `--mi_lut_cosine_t_mid <t0> [t1 ...]`.
 - bfloat16 workflow clarified:
   - When `--bf16` is set, GradScaler is disabled and bfloat16 autocast is used for UNet forward passes (train / eval).
 

--- a/docs/cosine_lut_updates.md
+++ b/docs/cosine_lut_updates.md
@@ -14,6 +14,9 @@
   - `_calibrate_cosine_scale` now defaults to **neighbor-aligned** matching (adjacent-token distances) to capture the effective temperature seen during training.
   - Supports configurable `t_mid` grids (default `0.3 0.5 0.7`); all candidates are logged, the first value drives the applied scale.
   - Enabled via `--mi_lut_cosine_calibrate`, executed post warm-start and after loading checkpoints. Legacy full-table median mode is still available via `--mi_lut_cosine_calibrate_mode median`.
+- Added entropy-based scale matching:
+  - `--mi_lut_cosine_entropy_match` performs a weighted conditional-entropy match (default t-grid `0.3/0.5/0.7` with weights `0.2/0.6/0.2`) using bisection over `s∈[1,200]` and relative tolerance `--mi_lut_cosine_entropy_tol`.
+  - Only the main rank performs the search; the final scale is broadcast to other ranks and cached LUT tables are cleared automatically.
 - Training diagnostics:
   - The training loop logs `β(t)·s·median(1−cos Δθ)` vs. the baseline neighbor scale (console + W&B/stats), alongside conditional entropy and uniform-weight loss.
   - Step logs include `cos_ratio` (effective/baseline) and `cosine_effective_neighbor` to spot hot/cold starts quickly.

--- a/docs/cosine_lut_updates.md
+++ b/docs/cosine_lut_updates.md
@@ -1,0 +1,27 @@
+# Cosine LUT Updates (latest changes)
+
+## Summary
+
+- Added cosine-distance support for learnable LUTs in `MetricInducedGibbsProbPath`:
+  - `metric` flag now accepts `cosine`.
+  - Cosine distance is computed as `s * (1 - cos)` with per-LUT scaling `--mi_lut_cosine_scale`.
+  - LUT vectors are normalized on-the-fly; cached tables reuse the same interface (shape `[C, V, V]`).
+- Introduced warm-start for cosine LUTs:
+  - `_warm_start_cosine_lut` maps tokens to a great-circle initialization (half-arc on the unit sphere).
+  - Flag `--mi_lut_force_warm_start` allows reinitializing even when resuming from checkpoints (e.g., finetuning 1D baselines).
+- Added cosine scale calibration:
+  - `_calibrate_cosine_scale` matches the median distance of the cosine table to the baseline table.
+  - Enabled via `--mi_lut_cosine_calibrate`, executed post warm-start and after loading checkpoints.
+- CLI updates:
+  - `--mi_metric` choices expanded to include `"euclidean"` and `"cosine"`.
+  - New flags `--mi_lut_cosine_scale`, `--mi_lut_cosine_calibrate`, `--mi_lut_force_warm_start`.
+- bfloat16 workflow clarified:
+  - When `--bf16` is set, GradScaler is disabled and bfloat16 autocast is used for UNet forward passes (train / eval).
+
+## Files touched
+
+- `flow_matching/flow_matching/path/mixture.py`
+- `flow_matching/examples/image/train.py`
+- `flow_matching/examples/image/train_arg_parser.py`
+- `flow_matching/examples/image/training/train_loop.py`
+

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -1,0 +1,24 @@
+# LUT Refactor and Fix Plan
+
+**Overall Progress:** `100%`
+
+## Tasks:
+
+- 🟩 **Step 1: Centralize LUT distance at path level**
+  - 🟩 Use path-level `metric_name`/`lp_order` in `_build_lut_distance_table`
+  - 🟩 Apply normalized distance only for vector embeddings (`emb_dim > 1`)
+  - 🟩 Preserve cosine handling and caching semantics
+- 🟩 **Step 2: Add interface parity to LearnableParametricLUT**
+  - 🟩 Expose `num_channels`, `vocab_size`, `emb_dim`, and `embed_range`
+  - 🟩 Add renorm/bounded-scale options with per-channel base norms
+  - 🟩 Ensure `weight` property returns the forward tensor
+- 🟩 **Step 3: Deduplicate small utilities**
+  - 🟩 Remove duplicate softplus inverse helper
+  - 🟩 Share linear baseline helper across LUT implementations
+- 🟩 **Step 4: Keep channel mapping as-is**
+  - 🟩 Reuse existing block mapping via `num_channels` property
+- 🟩 **Step 5: Align tests and usages**
+  - 🟩 Update LUT tests to accept `(C, V, D)` shapes and new buffers
+  - 🟩 Verify diagnostics and training paths remain compatible
+- 🟩 **Step 6: Save/Load behavior (keep simple)**
+  - 🟩 Leave checkpoint load/save logic unchanged (strict load maintained)

--- a/examples/image/README.md
+++ b/examples/image/README.md
@@ -45,6 +45,44 @@ python submitit_train.py --data_path=${IMAGENET_DIR}train_blurred_$IMAGENET_RES/
 python submitit_train.py --data_path=${IMAGENET_DIR}train_blurred_$IMAGENET_RES/box/ --resume=./output_dir/checkpoint-899.pth --compute_fid --eval_only
 ```
 
+### Metric-induced geometry diagnostics
+
+When you enable the metric-induced Gibbs path (`--discrete_flow_matching --ko_metric_induced`), you can ask the evaluation loop to measure how far the learned Mahalanobis metric drifts from the baseline distances. Typical settings that balance coverage and runtime are:
+
+```bash
+python train.py \
+  --eval_only --compute_fid --discrete_flow_matching --ko_metric_induced \
+  --resume=./output_dir/checkpoint-899.pth \
+  --mi_learnable_metric --mi_metric_use_ema \
+  --mi_metric_eval_geometry --mi_metric_eval_subset=128 \
+  --mi_metric_eval_pair_samples=20000 --mi_metric_eval_knn_k=5 \
+  --mi_metric_eval_seed=0 --mi_metric_eval_heatmap \
+  --mi_metric_eval_heatmap_subset=64
+```
+
+- `--mi_metric_eval_subset=128` probes a 128-token slice of the vocabulary (set `0` to use everything; useful for CIFAR/ImageNet scales).
+- `--mi_metric_eval_pair_samples=20000` randomly samples 20k off-diagonal pairs when computing Spearman ρ, which keeps memory low but gives a stable estimate.
+- `--mi_metric_eval_knn_k=5` matches the defaults used in the literature for k-NN overlap probes.
+- Heatmaps require `matplotlib`; lowering `--mi_metric_eval_heatmap_subset` keeps the figure legible.
+
+The diagnostics run once per evaluation and log the Spearman/k-NN scores alongside FID. Heatmaps and CSVs land under `${output_dir}/metric_geometry/`.
+
+### Evaluation GIF logging
+
+To capture the full sampling trajectories as animated GIFs during evaluation, toggle `--save_eval_gif`. A typical configuration that trades detail for file size is:
+
+```bash
+python train.py \
+  --eval_only --compute_fid --resume=./output_dir/checkpoint-899.pth \
+  --save_eval_gif --eval_gif_max_batch=16 --eval_gif_stride=8 --eval_gif_fps=12
+```
+
+- `--eval_gif_max_batch=16` tiles up to 16 samples (4×4 grid) per frame; increase for wider grids.
+- `--eval_gif_stride=8` stores every 8th solver step to keep animations compact.
+- `--eval_gif_fps=12` plays the GIF at 12 frames per second for smooth but concise playback.
+
+GIFs are written to `${output_dir}/gifs/` and, if Weights & Biases is enabled, are uploaded as videos to the run dashboard.
+
 
 ## Results
 | Data                  | Model type                       | Epochs | FID  | Command                                                                                                                                                                                                                                                                                                                                                   |

--- a/examples/image/lut_quantile_analysis.py
+++ b/examples/image/lut_quantile_analysis.py
@@ -1,0 +1,401 @@
+"""Shared utilities for analyzing and plotting LUT quantile diagnostics.
+
+This module centralizes quantile baselines, scalarization helpers, and
+visualizations so both training-time diagnostics and the offline
+`analyze_lut_quantile_hypothesis.py` script can use the same logic.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Dict, Optional, Sequence
+
+import matplotlib.pyplot as plt
+import matplotlib.colors as mcolors
+import numpy as np
+import torch
+from scipy import stats
+from scipy.ndimage import gaussian_filter1d
+from sklearn.isotonic import IsotonicRegression
+
+
+# ---------------------------------------------------------------------------
+# Scalarization helpers
+# ---------------------------------------------------------------------------
+
+def scalarize_embedding(e_raw: torch.Tensor, mode: str = "uniform") -> torch.Tensor:
+    """Convert [V, D] embedding into a scalar curve [V] using the requested mode."""
+    if e_raw.ndim != 2:
+        raise ValueError(f"Expected [V, D] tensor, got {tuple(e_raw.shape)}")
+    V, D = e_raw.shape
+    if D == 1:
+        return e_raw.squeeze(-1)
+
+    mode_norm = mode.lower()
+    if mode_norm == "norm":
+        return torch.linalg.vector_norm(e_raw, ord=2, dim=-1)
+    if mode_norm == "norm_normalized":
+        return torch.linalg.vector_norm(e_raw, ord=2, dim=-1) / math.sqrt(float(D))
+    if mode_norm == "mean":
+        return e_raw.mean(dim=-1)
+    if mode_norm == "uniform":
+        u = torch.ones(D, device=e_raw.device, dtype=e_raw.dtype) / math.sqrt(float(D))
+        return e_raw @ u
+    if mode_norm == "pc1":
+        X = e_raw.detach().double().cpu().numpy()
+        X_center = X - X.mean(axis=0, keepdims=True)
+        if np.allclose(X_center, 0.0):
+            return torch.zeros(V, device=e_raw.device, dtype=e_raw.dtype)
+        U, S, _ = np.linalg.svd(X_center, full_matrices=False)
+        comp = U[:, 0] * S[0]
+        return torch.from_numpy(comp).to(device=e_raw.device, dtype=e_raw.dtype)
+    raise ValueError(f"Unknown scalarization mode '{mode}'")
+
+
+# ---------------------------------------------------------------------------
+# Quantile baselines
+# ---------------------------------------------------------------------------
+
+def compute_empirical_cdf(
+    histogram: torch.Tensor,
+    smoothing_sigma: float = 0.5,
+) -> torch.Tensor:
+    """Compute smoothed empirical CDF from histogram [C, V]."""
+    if histogram.ndim != 2:
+        raise ValueError(f"Expected histogram [C, V], got {tuple(histogram.shape)}")
+    hist = histogram.detach().cpu().float()
+    if smoothing_sigma > 0:
+        hist_np = hist.numpy()
+        hist_smooth = np.array(
+            [
+                gaussian_filter1d(hist_np[c], sigma=smoothing_sigma, mode="nearest")
+                for c in range(hist_np.shape[0])
+            ]
+        )
+        hist = torch.from_numpy(hist_smooth)
+    hist = torch.clamp(hist, min=1e-8)
+    pmf = hist / hist.sum(dim=1, keepdim=True)
+    cdf = torch.cumsum(pmf, dim=1)
+    return torch.clamp(cdf, 0.0, 1.0)
+
+
+def baseline_uniform(
+    cdf: torch.Tensor,
+    target_range: Sequence[float] = (-1.0, 1.0),
+) -> torch.Tensor:
+    """Quantile map to a uniform distribution over target_range."""
+    low, high = float(target_range[0]), float(target_range[1])
+    return cdf * (high - low) + low
+
+
+def baseline_probit(
+    cdf: torch.Tensor,
+    target_mean: float = 0.0,
+    target_std: float = 1.0,
+) -> torch.Tensor:
+    """Quantile map to a normal distribution via probit."""
+    cdf_np = torch.clamp(cdf, 1e-6, 1 - 1e-6).numpy()
+    quantiles = stats.norm.ppf(cdf_np, loc=target_mean, scale=target_std)
+    return torch.from_numpy(quantiles).to(cdf)
+
+
+def baseline_isotonic(embedding: torch.Tensor, tokens: torch.Tensor) -> torch.Tensor:
+    """Fit isotonic regression (monotone) to the learned embedding."""
+    if embedding.ndim != 2:
+        raise ValueError(f"embedding must be [C, V]; got {tuple(embedding.shape)}")
+    C, V = embedding.shape
+    X = tokens.cpu().numpy()
+    iso = IsotonicRegression(out_of_bounds="clip")
+    result = []
+    for c in range(C):
+        y = embedding[c].detach().cpu().numpy()
+        iso.fit(X, y)
+        result.append(iso.predict(X))
+    return torch.from_numpy(np.stack(result, axis=0)).to(embedding)
+
+
+def _match_range(target: torch.Tensor, reference: torch.Tensor) -> torch.Tensor:
+    """Rescale target to match min/max of reference (avoid zero division)."""
+    t_min, t_max = target.min(), target.max()
+    r_min, r_max = reference.min(), reference.max()
+    if (t_max - t_min) < 1e-12:
+        return reference * 0 + (t_min + t_max) * 0.5
+    scale = (r_max - r_min) / (t_max - t_min + 1e-12)
+    return (target - t_min) * scale + r_min
+
+
+# ---------------------------------------------------------------------------
+# Metrics & analysis bundle
+# ---------------------------------------------------------------------------
+
+def compute_baseline_metrics(
+    learned: torch.Tensor,
+    baseline: torch.Tensor,
+    name: str,
+) -> Dict[str, float]:
+    """Compute regression-style metrics comparing learned vs baseline curves."""
+    x = baseline.detach().cpu().numpy()
+    y = learned.detach().cpu().numpy()
+    residual = y - x
+    ss_res = float((residual ** 2).sum())
+    ss_tot = float(((y - y.mean()) ** 2).sum())
+    r2 = 1.0 - ss_res / (ss_tot + 1e-12)
+    rmse = math.sqrt(ss_res / len(y))
+    mae = float(np.abs(residual).mean())
+    spearman, _ = stats.spearmanr(x, y)
+    kendall, _ = stats.kendalltau(x, y)
+    return {
+        "name": name,
+        "R2": float(r2),
+        "RMSE": float(rmse),
+        "MAE": float(mae),
+        "SpearmanR": float(spearman),
+        "KendallTau": float(kendall),
+    }
+
+
+@dataclass
+class BaselineResults:
+    channel_index: int
+    scalar_mode: str
+    tokens: torch.Tensor
+    embedding: torch.Tensor
+    baselines: Dict[str, torch.Tensor]
+    metrics: Dict[str, Dict[str, float]]
+    cdf: Optional[torch.Tensor] = None
+    histogram: Optional[torch.Tensor] = None
+
+
+def analyze_baselines(
+    lut_weight: torch.Tensor,
+    data_histogram: Optional[torch.Tensor],
+    channel_idx: int = 0,
+    *,
+    scalar_mode: str = "uniform",
+    smoothing_sigma: float = 1.0,
+) -> BaselineResults:
+    """Prepare scalar embedding and baseline curves for one channel."""
+    lut_weight = lut_weight.detach().cpu()
+    C, V, D = lut_weight.shape
+    if channel_idx < 0 or channel_idx >= C:
+        raise IndexError(f"channel_idx {channel_idx} out of range (0..{C-1})")
+
+    tokens = torch.arange(V, dtype=torch.float32)
+    E_raw = lut_weight[channel_idx]
+    E = scalarize_embedding(E_raw, mode=scalar_mode)
+
+    if data_histogram is None:
+        hist = torch.ones(C, V, dtype=torch.float32)
+    else:
+        hist = data_histogram.detach().cpu().float()
+        if hist.shape != (C, V):
+            raise ValueError(
+                f"Histogram shape {tuple(hist.shape)} does not match ({C}, {V})"
+            )
+
+    cdf = compute_empirical_cdf(hist, smoothing_sigma=smoothing_sigma)[channel_idx]
+
+    T1 = baseline_uniform(cdf.unsqueeze(0), target_range=(-1.0, 1.0)).squeeze(0)
+    T1 = _match_range(T1, E)
+
+    T2 = baseline_probit(cdf.unsqueeze(0)).squeeze(0)
+    T2 = _match_range(T2, E)
+
+    T3 = baseline_isotonic(E.unsqueeze(0), tokens).squeeze(0)
+
+    metrics = {
+        "T1_uniform": compute_baseline_metrics(E, T1, "T1: Uniform"),
+        "T2_probit": compute_baseline_metrics(E, T2, "T2: Probit"),
+        "T3_isotonic": compute_baseline_metrics(E, T3, "T3: Isotonic"),
+    }
+
+    return BaselineResults(
+        channel_index=channel_idx,
+        scalar_mode=scalar_mode,
+        tokens=tokens,
+        embedding=E,
+        baselines={"T1": T1, "T2": T2, "T3": T3},
+        metrics=metrics,
+        cdf=cdf,
+        histogram=hist[channel_idx],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Visualization
+# ---------------------------------------------------------------------------
+
+def plot_baseline_comparison(
+    results: BaselineResults,
+    output_path: str,
+    channel_label: str,
+    *,
+    epoch: Optional[int] = None,
+    figure_title: Optional[str] = None,
+) -> None:
+    """Generate a detailed multi-panel diagnostic figure."""
+    tokens = results.tokens.numpy()
+    E = results.embedding.numpy()
+    T1 = results.baselines["T1"].numpy()
+    T2 = results.baselines["T2"].numpy()
+    T3 = results.baselines["T3"].numpy()
+    residuals = {
+        "T1": E - T1,
+        "T2": E - T2,
+        "T3": E - T3,
+    }
+
+    dE = np.diff(E)
+    dT1 = np.diff(T1)
+    dT2 = np.diff(T2)
+    dT3 = np.diff(T3)
+    x_mid = tokens[:-1] + 0.5
+    curvature = np.diff(dE)
+    x_curv = tokens[1:-1] + 1.0
+
+    # Normalize colors for scatter by token index
+    norm = mcolors.Normalize(vmin=tokens.min(), vmax=tokens.max())
+    cmap = plt.get_cmap("viridis")
+    scatter_colors = cmap(norm(tokens))
+
+    fig, axes = plt.subplots(3, 3, figsize=(18, 14))
+
+    # --- row 0: curves, residuals, histogram/CDF --------------------------------
+    ax = axes[0, 0]
+    ax.plot(tokens, E, color="black", linewidth=2.0, label="E (Learned)")
+    ax.plot(tokens, T1, color="#d62728", linestyle="--", linewidth=1.5, label="T1: Uniform")
+    ax.plot(tokens, T2, color="#2ca02c", linestyle="--", linewidth=1.5, label="T2: Probit")
+    ax.plot(tokens, T3, color="#1f77b4", linestyle="--", linewidth=1.5, label="T3: Isotonic")
+    ax.set_xlabel("Token Value")
+    ax.set_ylabel("Embedding Value")
+    ax.set_title(f"Channel {channel_label}: Learned vs Baselines")
+    ax.grid(True, alpha=0.3)
+    ax.legend(loc="best", fontsize=9)
+    ax.yaxis.get_major_formatter().set_useOffset(False)
+
+    ax = axes[0, 1]
+    ax.plot(tokens, residuals["T1"], color="#d62728", linewidth=1.2, label="E - T1")
+    ax.plot(tokens, residuals["T2"], color="#2ca02c", linewidth=1.2, label="E - T2")
+    ax.plot(tokens, residuals["T3"], color="#1f77b4", linewidth=1.2, label="E - T3")
+    ax.axhline(0.0, color="black", linestyle="--", linewidth=0.8)
+    ax.set_xlabel("Token Value")
+    ax.set_ylabel("Residual")
+    ax.set_title("Residuals")
+    ax.grid(True, alpha=0.3)
+    ax.legend(loc="best", fontsize=9)
+    ax.yaxis.get_major_formatter().set_useOffset(False)
+
+    ax = axes[0, 2]
+    if results.histogram is not None:
+        hist = results.histogram.numpy()
+        hist = hist / max(hist.sum(), 1e-12)
+        ax.bar(tokens, hist, width=1.0, color="lightgray", edgecolor="black", alpha=0.6, label="Histogram")
+        ax.set_ylabel("Token PMF")
+    if results.cdf is not None:
+        ax_cdf = ax.twinx()
+        ax_cdf.plot(tokens, results.cdf.numpy(), color="navy", linewidth=1.8, label="CDF")
+        ax_cdf.set_ylabel("CDF")
+        ax_cdf.set_ylim(0.0, 1.0)
+        ax_cdf.grid(False)
+        ax_cdf.tick_params(axis="y", colors="navy")
+    ax.set_xlabel("Token Value")
+    ax.set_title("Data Histogram & CDF")
+    ax.grid(True, alpha=0.3)
+
+    # --- row 1: derivatives ------------------------------------------------------
+    ax = axes[1, 0]
+    ax.plot(x_mid, dE, color="black", linewidth=1.5, label="ΔE")
+    ax.plot(x_mid, dT1, color="#d62728", linestyle="--", linewidth=1.0, label="ΔT1")
+    ax.plot(x_mid, dT2, color="#2ca02c", linestyle="--", linewidth=1.0, label="ΔT2")
+    ax.plot(x_mid, dT3, color="#1f77b4", linestyle="--", linewidth=1.0, label="ΔT3")
+    ax.axhline(0.0, color="black", linestyle=":", linewidth=0.8)
+    ax.set_xlabel("Token Value")
+    ax.set_ylabel("First Difference")
+    ax.set_title("Local Slope")
+    ax.grid(True, alpha=0.3)
+    ax.legend(loc="best", fontsize=9)
+
+    ax = axes[1, 1]
+    ax.plot(x_curv, curvature, color="black", linewidth=1.2)
+    ax.axhline(0.0, color="black", linestyle=":", linewidth=0.8)
+    ax.set_xlabel("Token Value")
+    ax.set_ylabel("Second Difference")
+    ax.set_title("Curvature of E")
+    ax.grid(True, alpha=0.3)
+
+    ax = axes[1, 2]
+    ax.plot(x_mid, dE - dT1, color="#d62728", linewidth=1.0, label="ΔE - ΔT1")
+    ax.plot(x_mid, dE - dT2, color="#2ca02c", linewidth=1.0, label="ΔE - ΔT2")
+    ax.plot(x_mid, dE - dT3, color="#1f77b4", linewidth=1.0, label="ΔE - ΔT3")
+    ax.axhline(0.0, color="black", linestyle=":", linewidth=0.8)
+    ax.set_xlabel("Token Value")
+    ax.set_ylabel("Slope Residual")
+    ax.set_title("Slope Residuals")
+    ax.grid(True, alpha=0.3)
+    ax.legend(loc="best", fontsize=9)
+
+    # --- row 2: scatter + metrics -----------------------------------------------
+    ax = axes[2, 0]
+    ax.scatter(T1, E, c=scatter_colors, s=12, alpha=0.7)
+    diag_min, diag_max = min(T1.min(), E.min()), max(T1.max(), E.max())
+    ax.plot([diag_min, diag_max], [diag_min, diag_max], color="black", linestyle="--", linewidth=1.0)
+    m1 = results.metrics["T1_uniform"]
+    ax.set_xlabel("T1: Uniform")
+    ax.set_ylabel("E (Learned)")
+    ax.set_title(f"E vs T1 (R²={m1['R2']:.3f}, RMSE={m1['RMSE']:.3f})")
+    ax.grid(True, alpha=0.3)
+
+    ax = axes[2, 1]
+    ax.scatter(T2, E, c=scatter_colors, s=12, alpha=0.7)
+    diag_min, diag_max = min(T2.min(), E.min()), max(T2.max(), E.max())
+    ax.plot([diag_min, diag_max], [diag_min, diag_max], color="black", linestyle="--", linewidth=1.0)
+    m2 = results.metrics["T2_probit"]
+    ax.set_xlabel("T2: Probit")
+    ax.set_ylabel("E (Learned)")
+    ax.set_title(f"E vs T2 (R²={m2['R2']:.3f}, RMSE={m2['RMSE']:.3f})")
+    ax.grid(True, alpha=0.3)
+
+    ax = axes[2, 2]
+    ax.scatter(T3, E, c=scatter_colors, s=12, alpha=0.7)
+    diag_min, diag_max = min(T3.min(), E.min()), max(T3.max(), E.max())
+    ax.plot([diag_min, diag_max], [diag_min, diag_max], color="black", linestyle="--", linewidth=1.0)
+    m3 = results.metrics["T3_isotonic"]
+    ax.set_xlabel("T3: Isotonic")
+    ax.set_ylabel("E (Learned)")
+    ax.set_title(f"E vs T3 (R²={m3['R2']:.3f}, RMSE={m3['RMSE']:.3f})")
+    ax.grid(True, alpha=0.3)
+
+    summary_lines = [
+        f"Scalar mode: {results.scalar_mode}",
+        f"E range: [{E.min():.4f}, {E.max():.4f}]",
+        f"E std: {E.std():.4f}",
+    ]
+    summary_lines += [
+        f"{name}: R²={metrics['R2']:.3f}, Spearman={metrics['SpearmanR']:.3f}, Kendall={metrics['KendallTau']:.3f}"
+        for name, metrics in results.metrics.items()
+    ]
+    if epoch is not None:
+        summary_lines.insert(0, f"Epoch: {epoch}")
+
+    fig.suptitle(
+        figure_title
+        or f"LUT Quantile Diagnostics — Channel {channel_label} (mode={results.scalar_mode})",
+        fontsize=16,
+        fontweight="bold",
+    )
+    axes[1, 2].text(
+        0.02,
+        0.95,
+        "\n".join(summary_lines),
+        transform=axes[1, 2].transAxes,
+        fontsize=9,
+        va="top",
+        ha="left",
+        bbox=dict(boxstyle="round", facecolor="white", alpha=0.85),
+    )
+
+    plt.tight_layout(rect=[0, 0, 1, 0.96])
+    plt.savefig(output_path, dpi=150, bbox_inches="tight")
+    plt.close(fig)
+

--- a/examples/image/models/discrete_unet.py
+++ b/examples/image/models/discrete_unet.py
@@ -60,6 +60,8 @@ class DiscreteUNetModel(nn.Module):
     resblock_updown: bool = False
     use_new_attention_order: bool = False
     with_fourier_features: bool = False
+    use_cosine_attention: bool = False
+    use_output_head_weight_norm: bool = False
 
     def __post_init__(self):
         super().__init__()
@@ -95,7 +97,10 @@ class DiscreteUNetModel(nn.Module):
             with_fourier_features=self.with_fourier_features,
             ignore_time=False, # enable this for doing metric-induced prob paths
             input_projection=False,
+            use_cosine_attention=self.use_cosine_attention,
+            use_output_head_weight_norm=self.use_output_head_weight_norm,
         )
+        self.weight_norm_targets = self.unet.weight_norm_targets
 
     def forward(
         self, x_t: torch.Tensor, t: torch.Tensor, extra: Mapping[str, torch.Tensor]

--- a/examples/image/models/model_configs.py
+++ b/examples/image/models/model_configs.py
@@ -88,17 +88,24 @@ MODEL_CONFIGS = {
 
 
 def instantiate_model(
-    architechture: str, is_discrete: bool, ko: bool,use_ema: bool
-) -> Union[UNetModel, DiscreteUNetModel]:
+    architechture: str,
+    is_discrete: bool,
+    ko: bool,
+    use_ema: bool,
+    use_cosine_attention: bool = False,
+    use_head_weight_norm: bool = False,
+) -> Union[UNetModel, DiscreteUNetModel, EMA]:
     assert (
         architechture in MODEL_CONFIGS
     ), f"Model architecture {architechture} is missing its config."
 
     if is_discrete:
         if architechture + "_discrete" in MODEL_CONFIGS:
-            config = MODEL_CONFIGS[architechture + "_discrete"]
+            config = dict(MODEL_CONFIGS[architechture + "_discrete"])
         else:
-            config = MODEL_CONFIGS[architechture]
+            config = dict(MODEL_CONFIGS[architechture])
+        config["use_cosine_attention"] = use_cosine_attention
+        config["use_output_head_weight_norm"] = use_head_weight_norm
         if ko:
             model = DiscreteUNetModel(
                 vocab_size=256,
@@ -106,13 +113,21 @@ def instantiate_model(
             )
         else:
             model = DiscreteUNetModel(
-            vocab_size=257,
-            **config,
-        )
+                vocab_size=257,
+                **config,
+            )
     else:
-        model = UNetModel(**MODEL_CONFIGS[architechture])
+        config = dict(MODEL_CONFIGS[architechture])
+        config["use_cosine_attention"] = use_cosine_attention
+        config["use_output_head_weight_norm"] = use_head_weight_norm
+        model = UNetModel(**config)
+
+    weight_norm_targets = getattr(model, "weight_norm_targets", [])
 
     if use_ema:
-        return EMA(model=model)
-    else:
-        return model
+        ema_model = EMA(model=model)
+        setattr(ema_model, "weight_norm_targets", weight_norm_targets)
+        return ema_model
+
+    setattr(model, "weight_norm_targets", weight_norm_targets)
+    return model

--- a/examples/image/models/unet.py
+++ b/examples/image/models/unet.py
@@ -10,12 +10,13 @@ Modified from https://github.com/openai/guided-diffusion/blob/main/guided_diffus
 import math
 from abc import abstractmethod
 from dataclasses import dataclass
-from typing import Optional, Tuple
+from typing import Iterable, Optional, Tuple, cast
 
 import numpy as np
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+from torch.nn.modules.utils import _pair
 from models.nn import (
     avg_pool_nd,
     checkpoint,
@@ -25,6 +26,121 @@ from models.nn import (
     timestep_embedding,
     zero_module,
 )
+
+
+def _rms_per_out(weight: torch.Tensor, eps: float = 1e-8) -> torch.Tensor:
+    """Return per-output RMS for linear/conv weights."""
+
+    if weight.ndim >= 4:
+        reduce_dims = tuple(range(1, weight.ndim))
+    elif weight.ndim == 3:
+        reduce_dims = (1, 2)
+    else:
+        reduce_dims = (1,)
+    rms = torch.sqrt(weight.float().pow(2).mean(dim=reduce_dims, keepdim=True) + eps)
+    return rms.to(dtype=weight.dtype)
+
+
+class WNOnUseConv2d(nn.Conv2d):
+    """Conv2d that normalizes weights per forward pass."""
+
+    @classmethod
+    def from_conv(
+        cls,
+        conv: nn.Conv2d,
+        *,
+        reinit_if_zero: bool = False,
+        std: float = 1e-3,
+    ) -> "WNOnUseConv2d":
+        padding: Tuple[int, int] | str
+        if isinstance(conv.padding, str):
+            padding = conv.padding
+        else:
+            padding = _pair(conv.padding)
+
+        new_module = cls(
+            in_channels=conv.in_channels,
+            out_channels=conv.out_channels,
+            kernel_size=_pair(conv.kernel_size),
+            stride=_pair(conv.stride),
+            padding=padding,
+            dilation=_pair(conv.dilation),
+            groups=conv.groups,
+            bias=conv.bias is not None,
+        )
+        new_module.load_state_dict(conv.state_dict(), strict=False)
+
+        if reinit_if_zero:
+            with torch.no_grad():
+                weight = new_module.weight
+                max_abs = weight.abs().max()
+                if max_abs.isnan() or max_abs.isinf() or max_abs <= 0:
+                    nn.init.normal_(weight, mean=0.0, std=std)
+                if new_module.bias is not None:
+                    bias_max = new_module.bias.abs().max()
+                    if bias_max.isnan() or bias_max.isinf() or bias_max <= 0:
+                        nn.init.constant_(new_module.bias, 0.0)
+
+        return new_module
+
+    def force_weight_renorm(self, eps: float = 1e-8) -> None:
+        with torch.no_grad():
+            weight = self.weight
+            rms = _rms_per_out(weight, eps)
+            fan_in = weight[0].numel()
+            scale = 1.0 / math.sqrt(fan_in)
+            weight.data.copy_((weight / rms) * scale)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:  # type: ignore[override]
+        w = self.weight
+        rms = _rms_per_out(w)
+        fan_in = w[0].numel()
+        scale = 1.0 / math.sqrt(fan_in)
+        w = (w / rms) * scale
+        return F.conv2d(
+            x,
+            w,
+            self.bias,
+            self.stride,
+            self.padding,
+            self.dilation,
+            self.groups,
+        )
+
+
+class WNOnUseLinear(nn.Linear):
+    """Linear that normalizes weights per forward pass."""
+
+    def force_weight_renorm(self, eps: float = 1e-8) -> None:
+        with torch.no_grad():
+            weight = self.weight
+            rms = _rms_per_out(weight, eps)
+            fan_in = weight[0].numel()
+            scale = 1.0 / math.sqrt(fan_in)
+            weight.data.copy_((weight / rms) * scale)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:  # type: ignore[override]
+        w = self.weight
+        rms = _rms_per_out(w)
+        fan_in = w[0].numel()
+        scale = 1.0 / math.sqrt(fan_in)
+        w = (w / rms) * scale
+        return F.linear(x, w, self.bias)
+
+
+def force_weight_norm(modules: Iterable[nn.Module], eps: float = 1e-8) -> None:
+    """Project selected module weights to unit RMS per output channel."""
+
+    with torch.no_grad():
+        for module in modules:
+            if hasattr(module, "force_weight_renorm"):
+                module.force_weight_renorm(eps=eps)  # type: ignore[arg-type]
+                continue
+            weight = getattr(module, "weight", None)
+            if weight is None:
+                continue
+            rms = _rms_per_out(weight, eps)
+            weight.data.div_(rms)
 
 
 class ConstantEmbedding(nn.Module):
@@ -127,7 +243,7 @@ class Upsample(nn.Module):
         if self.use_conv:
             x = self.conv(x)
         return x
-
+    
 
 class Downsample(nn.Module):
     """
@@ -299,6 +415,7 @@ class AttentionBlock(nn.Module):
         num_head_channels=-1,
         use_checkpoint=False,
         use_new_attention_order=False,
+        use_cosine_attention: bool = False,
     ):
         super().__init__()
         self.channels = channels
@@ -314,10 +431,14 @@ class AttentionBlock(nn.Module):
         self.qkv = conv_nd(1, channels, channels * 3, 1)
         if use_new_attention_order:
             # split qkv before split heads
-            self.attention = QKVAttention(self.num_heads)
+            self.attention = QKVAttention(
+                self.num_heads, use_cosine_attention=use_cosine_attention
+            )
         else:
             # split heads before split qkv
-            self.attention = QKVAttentionLegacy(self.num_heads)
+            self.attention = QKVAttentionLegacy(
+                self.num_heads, use_cosine_attention=use_cosine_attention
+            )
 
         self.proj_out = zero_module(conv_nd(1, channels, channels, 1))
 
@@ -363,9 +484,11 @@ class QKVAttentionLegacy(nn.Module):
     A module which performs QKV attention. Matches legacy QKVAttention + input/ouput heads shaping
     """
 
-    def __init__(self, n_heads):
+    def __init__(self, n_heads, use_cosine_attention: bool = False, eps: float = 1e-4):
         super().__init__()
         self.n_heads = n_heads
+        self.use_cosine_attention = use_cosine_attention
+        self.eps = eps
 
     def forward(self, qkv):
         """
@@ -377,11 +500,23 @@ class QKVAttentionLegacy(nn.Module):
         assert width % (3 * self.n_heads) == 0
         ch = width // (3 * self.n_heads)
         q, k, v = qkv.reshape(bs * self.n_heads, ch * 3, length).split(ch, dim=1)
-        scale = 1 / math.sqrt(math.sqrt(ch))
-        weight = torch.einsum(
-            "bct,bcs->bts", q * scale, k * scale
-        )  # More stable with f16 than dividing afterwards
-        weight = torch.softmax(weight.float(), dim=-1).type(weight.dtype)
+
+        if self.use_cosine_attention:
+            q_float = q.float()
+            k_float = k.float()
+            q_hat = q_float / (q_float.norm(dim=1, keepdim=True) + self.eps)
+            k_hat = k_float / (k_float.norm(dim=1, keepdim=True) + self.eps)
+            logits = torch.einsum("bct,bcs->bts", q_hat, k_hat)
+            logits = logits * math.sqrt(ch)
+            weight = torch.softmax(logits, dim=-1).to(dtype=v.dtype)
+        else:
+            scale = 1 / math.sqrt(math.sqrt(ch))
+            weight = torch.einsum(
+                "bct,bcs->bts", q * scale, k * scale
+            )  # More stable with f16 than dividing afterwards
+
+        if not self.use_cosine_attention:
+            weight = torch.softmax(weight.float(), dim=-1).type(v.dtype)
         a = torch.einsum("bts,bcs->bct", weight, v)
         return a.reshape(bs, -1, length)
 
@@ -395,9 +530,11 @@ class QKVAttention(nn.Module):
     A module which performs QKV attention and splits in a different order.
     """
 
-    def __init__(self, n_heads):
+    def __init__(self, n_heads, use_cosine_attention: bool = False, eps: float = 1e-4):
         super().__init__()
         self.n_heads = n_heads
+        self.use_cosine_attention = use_cosine_attention
+        self.eps = eps
 
     def forward(self, qkv):
         """
@@ -409,16 +546,23 @@ class QKVAttention(nn.Module):
         assert width % (3 * self.n_heads) == 0
         ch = width // (3 * self.n_heads)
         q, k, v = qkv.chunk(3, dim=1)
-        scale = 1 / math.sqrt(math.sqrt(ch))
-        weight = torch.einsum(
-            "bct,bcs->bts",
-            (q * scale).view(bs * self.n_heads, ch, length),
-            (k * scale).view(bs * self.n_heads, ch, length),
-        )  # More stable with f16 than dividing afterwards
-        weight = torch.softmax(weight.float(), dim=-1).type(weight.dtype)
-        a = torch.einsum(
-            "bts,bcs->bct", weight, v.reshape(bs * self.n_heads, ch, length)
-        )
+        q = q.reshape(bs * self.n_heads, ch, length)
+        k = k.reshape(bs * self.n_heads, ch, length)
+        v = v.reshape(bs * self.n_heads, ch, length)
+
+        if self.use_cosine_attention:
+            q_float = q.float()
+            k_float = k.float()
+            q_hat = q_float / (q_float.norm(dim=1, keepdim=True) + self.eps)
+            k_hat = k_float / (k_float.norm(dim=1, keepdim=True) + self.eps)
+            logits = torch.einsum("bct,bcs->bts", q_hat, k_hat)
+            logits = logits * math.sqrt(ch)
+            weight = torch.softmax(logits, dim=-1).to(dtype=v.dtype)
+        else:
+            scale = 1 / math.sqrt(math.sqrt(ch))
+            weight = torch.einsum("bct,bcs->bts", q * scale, k * scale)
+            weight = torch.softmax(weight.float(), dim=-1).type(v.dtype)
+        a = torch.einsum("bts,bcs->bct", weight, v)
         return a.reshape(bs, -1, length)
 
     @staticmethod
@@ -477,6 +621,8 @@ class UNetModel(nn.Module):
     with_fourier_features: bool = False
     ignore_time: bool = False
     input_projection: bool = True
+    use_cosine_attention: bool = False
+    use_output_head_weight_norm: bool = False
 
     image_size: int = -1  # not used...
     _target_: str = "lib.models.gd_unet.UNetModel"
@@ -546,6 +692,7 @@ class UNetModel(nn.Module):
                             num_heads=self.num_heads,
                             num_head_channels=self.num_head_channels,
                             use_new_attention_order=self.use_new_attention_order,
+                            use_cosine_attention=self.use_cosine_attention,
                         )
                     )
                 self.input_blocks.append(TimestepEmbedSequential(*layers))
@@ -593,6 +740,7 @@ class UNetModel(nn.Module):
                 num_heads=self.num_heads,
                 num_head_channels=self.num_head_channels,
                 use_new_attention_order=self.use_new_attention_order,
+                use_cosine_attention=self.use_cosine_attention,
             ),
             ResBlock(
                 ch,
@@ -631,6 +779,7 @@ class UNetModel(nn.Module):
                             num_heads=self.num_heads_upsample,
                             num_head_channels=self.num_head_channels,
                             use_new_attention_order=self.use_new_attention_order,
+                            use_cosine_attention=self.use_cosine_attention,
                         )
                     )
                 if level and i == self.num_res_blocks:
@@ -656,11 +805,30 @@ class UNetModel(nn.Module):
                 self.output_blocks.append(TimestepEmbedSequential(*layers))
                 self._feature_size += ch
 
-        self.out = nn.Sequential(
-            normalization(ch),
-            nn.SiLU(),
-            zero_module(conv_nd(self.dims, input_ch, self.out_channels, 3, padding=1)),
-        )
+        self.weight_norm_targets: list[nn.Module] = []
+
+        head_conv = conv_nd(self.dims, input_ch, self.out_channels, 3, padding=1)
+        if self.use_output_head_weight_norm:
+            if not isinstance(head_conv, nn.Conv2d):
+                raise TypeError("Output head weight norm currently supports Conv2d heads.")
+            wn_head = WNOnUseConv2d.from_conv(
+                head_conv,
+                reinit_if_zero=True,
+                std=1e-3,
+            )
+            wn_head.to(head_conv.weight.device, dtype=head_conv.weight.dtype)
+            self.out = nn.Sequential(
+                normalization(ch),
+                nn.SiLU(),
+                wn_head,
+            )
+            self.weight_norm_targets.append(wn_head)
+        else:
+            self.out = nn.Sequential(
+                normalization(ch),
+                nn.SiLU(),
+                zero_module(head_conv),
+            )
 
     def forward(self, x, timesteps, extra):
         """

--- a/examples/image/test_lut_noise_init.py
+++ b/examples/image/test_lut_noise_init.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""
+Test: Verify LUT initialization with noise preserves monotonicity
+
+Checks:
+1. All channels are monotonically increasing (zero or very few inversions)
+2. Channels are decorrelated (correlation < 1.0)
+3. Noise magnitude is small (std ≈ sqrt(init_std^2 + noise_std^2))
+"""
+import sys
+import torch
+sys.path.insert(0, '/223040239/yuping/LLADA/flow_matching')
+
+from flow_matching.path.mixture import LearnableScalarLUT
+
+
+def test_noise_init_monotonicity():
+    """Test that noise doesn't break monotonicity"""
+    print("="*70)
+    print("Test 1: Monotonicity with noise (σ=1e-3)")
+    print("="*70)
+    
+    lut = LearnableScalarLUT(
+        num_channels=3,
+        vocab_size=256,
+        embed_range="pm1",
+        device=None,
+        dtype=torch.float32
+    )
+    
+    weight = lut.weight.data  # [3, 256]
+    
+    # Check monotonicity for each channel
+    print("\n📈 Monotonicity Check:")
+    total_inversions = 0
+    for c, name in enumerate(['R', 'G', 'B']):
+        emb = weight[c]
+        diffs = emb[1:] - emb[:-1]
+        inversions = (diffs < 0).sum().item()
+        total_inversions += inversions
+        
+        status = "✓" if inversions == 0 else f"⚠️ {inversions}"
+        print(f"  {name}: {status} inversions out of 255")
+        
+        if inversions > 0 and inversions <= 5:
+            inv_locs = torch.where(diffs < 0)[0].tolist()
+            print(f"      Locations: {inv_locs}")
+    
+    # Expected: ~0-2 inversions per channel with σ=1e-3
+    assert total_inversions < 10, f"Too many inversions: {total_inversions}"
+    print(f"\n  Total inversions: {total_inversions}/765 ({total_inversions/765:.2%})")
+    print("  ✓ PASS: Monotonicity preserved (< 10 inversions)")
+    
+
+def test_noise_init_decorrelation():
+    """Test that channels are decorrelated"""
+    print("\n" + "="*70)
+    print("Test 2: Channel Decorrelation")
+    print("="*70)
+    
+    # Run multiple times to check variance
+    correlations = []
+    for trial in range(10):
+        lut = LearnableScalarLUT(
+            num_channels=3,
+            vocab_size=256,
+            embed_range="pm1",
+            device=None,
+            dtype=torch.float32
+        )
+        weight = lut.weight.data
+        
+        # Compute R-G, G-B, R-B correlations
+        corr_rg = torch.corrcoef(torch.stack([weight[0], weight[1]]))[0, 1].item()
+        corr_gb = torch.corrcoef(torch.stack([weight[1], weight[2]]))[0, 1].item()
+        corr_rb = torch.corrcoef(torch.stack([weight[0], weight[2]]))[0, 1].item()
+        
+        correlations.append([corr_rg, corr_gb, corr_rb])
+    
+    correlations = torch.tensor(correlations)
+    mean_corr = correlations.mean(dim=0)
+    std_corr = correlations.std(dim=0)
+    
+    print("\n↔️  Correlation Statistics (10 trials):")
+    print(f"  R-G: {mean_corr[0]:.6f} ± {std_corr[0]:.6f}")
+    print(f"  G-B: {mean_corr[1]:.6f} ± {std_corr[1]:.6f}")
+    print(f"  R-B: {mean_corr[2]:.6f} ± {std_corr[2]:.6f}")
+    
+    # Without noise: correlation ≈ 1.0
+    # With σ=1e-3 noise: correlation should be < 1.0 (typically 0.998-0.9995)
+    max_mean_corr = mean_corr.max().item()
+    print(f"\n  Max mean correlation: {max_mean_corr:.6f}")
+    
+    assert max_mean_corr < 1.0, "Channels are perfectly correlated (no decorrelation)"
+    assert max_mean_corr > 0.99, f"Correlation too low ({max_mean_corr:.6f} < 0.99), noise may be too large"
+    
+    print("  ✓ PASS: Channels decorrelated but not too much")
+
+
+def test_noise_magnitude():
+    """Test noise magnitude is as expected"""
+    print("\n" + "="*70)
+    print("Test 3: Noise Magnitude")
+    print("="*70)
+    
+    # Theoretical std without noise (pm1 range, linear)
+    # For linspace(-1, 1, 256): std ≈ 0.577
+    # With added noise σ=1e-3: combined_std ≈ sqrt(0.577^2 + 0.001^2) ≈ 0.577
+    
+    lut = LearnableScalarLUT(
+        num_channels=3,
+        vocab_size=256,
+        embed_range="pm1",
+        device=None,
+        dtype=torch.float32
+    )
+    
+    weight = lut.weight.data
+    
+    print("\n📊 Standard Deviations:")
+    for c, name in enumerate(['R', 'G', 'B']):
+        std = weight[c].std().item()
+        print(f"  {name}: {std:.6f}")
+    
+    mean_std = weight.std(dim=1).mean().item()
+    print(f"\n  Mean std: {mean_std:.6f}")
+    
+    # Expected: ~0.577 (linspace std) + tiny increase from noise
+    # Theoretical: sqrt(0.577^2 + 0.001^2) ≈ 0.5770009 ≈ 0.577
+    # Empirical with random seed variance: allow up to 0.582
+    assert 0.575 < mean_std < 0.582, f"Unexpected std: {mean_std:.6f}"
+    print("  ✓ PASS: Std magnitude as expected (~0.577-0.581)")
+
+
+def test_range_preserved():
+    """Test that range is still approximately pm1"""
+    print("\n" + "="*70)
+    print("Test 4: Range Preservation")
+    print("="*70)
+    
+    lut = LearnableScalarLUT(
+        num_channels=3,
+        vocab_size=256,
+        embed_range="pm1",
+        device=None,
+        dtype=torch.float32
+    )
+    
+    weight = lut.weight.data
+    
+    print("\n📏 Value Ranges:")
+    for c, name in enumerate(['R', 'G', 'B']):
+        min_val = weight[c].min().item()
+        max_val = weight[c].max().item()
+        print(f"  {name}: [{min_val:.6f}, {max_val:.6f}]")
+    
+    # Should be close to [-1, 1] with small noise
+    global_min = weight.min().item()
+    global_max = weight.max().item()
+    
+    print(f"\n  Global range: [{global_min:.6f}, {global_max:.6f}]")
+    
+    # With σ=1e-3, range should extend by ~±3σ at most (99.7%)
+    assert -1.01 < global_min < -0.99, f"Min too far from -1.0: {global_min}"
+    assert 0.99 < global_max < 1.01, f"Max too far from 1.0: {global_max}"
+    
+    print("  ✓ PASS: Range approximately [-1, 1]")
+
+
+if __name__ == "__main__":
+    print("\n" + "🔬 LUT Noise Initialization Tests")
+    print("="*70)
+    print("Verifying that σ=1e-3 noise breaks symmetry without breaking monotonicity\n")
+    
+    test_noise_init_monotonicity()
+    test_noise_init_decorrelation()
+    test_noise_magnitude()
+    test_range_preserved()
+    
+    print("\n" + "="*70)
+    print("✅ ALL TESTS PASSED")
+    print("="*70)
+    print("\nConclusion:")
+    print("  • Noise σ=1e-3 preserves monotonicity (< 10 inversions total)")
+    print("  • Channels are decorrelated (correlation < 1.0)")
+    print("  • Noise magnitude is small and controlled")
+    print("  • Value range remains approximately [-1, 1]")
+    print("\nReady for training with symmetry-breaking initialization! 🚀")

--- a/examples/image/tools/analyze_lut_quantile_hypothesis.py
+++ b/examples/image/tools/analyze_lut_quantile_hypothesis.py
@@ -108,17 +108,6 @@ def load_lut_from_checkpoint(checkpoint_path: str) -> Tuple[torch.Tensor, dict]:
     return lut_weight, metadata
 
 
-def scalarize_embedding(e_raw: torch.Tensor, mode: str = "uniform") -> torch.Tensor:
-    """Backward-compatible shim around :func:`scalarize_embedding`."""
-    warnings.warn(
-        "scalarize_embedding is deprecated; use scalarize_embedding from "
-        "lut_quantile_analysis instead.",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    return scalarize_embedding(e_raw, mode)
-
-
 def estimate_data_histogram(
     data_path: Optional[str] = None,
     vocab_size: int = 256,

--- a/examples/image/tools/analyze_lut_quantile_hypothesis.py
+++ b/examples/image/tools/analyze_lut_quantile_hypothesis.py
@@ -1,4 +1,4 @@
-"""
+﻿"""
 Comprehensive LUT Analysis: Quantile Hypothesis Testing
 
 Implements two key diagnostic probes:
@@ -40,7 +40,22 @@ from scipy.ndimage import gaussian_filter1d
 from sklearn.isotonic import IsotonicRegression
 from sklearn.decomposition import PCA
 
-sys.path.insert(0, str(Path(__file__).parent / "flow_matching"))
+# Allow importing shared LUT quantile tools from examples/image
+_IMAGE_DIR = Path(__file__).resolve().parents[1]
+if str(_IMAGE_DIR) not in sys.path:
+    sys.path.insert(0, str(_IMAGE_DIR))
+
+from lut_quantile_analysis import (  # noqa: E402
+    BaselineResults,
+    analyze_baselines as shared_analyze_baselines,
+    baseline_uniform as shared_baseline_uniform,
+    baseline_probit as shared_baseline_probit,
+    baseline_isotonic as shared_baseline_isotonic,
+    compute_baseline_metrics as shared_compute_baseline_metrics,
+    plot_baseline_comparison,
+    scalarize_embedding,
+    compute_empirical_cdf as shared_compute_empirical_cdf,
+)
 
 
 # ============================================================================
@@ -93,37 +108,15 @@ def load_lut_from_checkpoint(checkpoint_path: str) -> Tuple[torch.Tensor, dict]:
     return lut_weight, metadata
 
 
-def _scalarize_embedding(e_raw: torch.Tensor, mode: str = "uniform") -> torch.Tensor:
-    """Convert [V,D] embedding into a scalar curve [V].
-
-    Modes:
-      - 'norm': L2 norm ||E||
-      - 'norm_normalized': ||E|| / sqrt(D)
-      - 'mean': per-token dimension mean
-      - 'uniform': dot(E, 1/sqrt(D)) (signed projection)
-      - 'pc1': projection to first principal component (signed)
-    """
-    assert e_raw.ndim == 2, "Expected [V,D]"
-    V, D = e_raw.shape
-    if D == 1:
-        return e_raw.squeeze(-1)
-    mode = str(mode).lower()
-    if mode == "norm":
-        return torch.norm(e_raw, p=2, dim=-1)
-    if mode == "norm_normalized":
-        return torch.norm(e_raw, p=2, dim=-1) / torch.sqrt(torch.tensor(float(D), device=e_raw.device, dtype=e_raw.dtype))
-    if mode == "mean":
-        return e_raw.mean(dim=-1)
-    if mode == "uniform":
-        u = torch.ones(D, device=e_raw.device, dtype=e_raw.dtype) / torch.sqrt(torch.tensor(float(D), device=e_raw.device, dtype=e_raw.dtype))
-        return e_raw @ u
-    if mode == "pc1":
-        with torch.no_grad():
-            X = e_raw.double().cpu().numpy()
-            pca = PCA(n_components=1)
-            comp = pca.fit_transform(X)[:, 0]
-            return torch.from_numpy(comp).to(dtype=e_raw.dtype, device=e_raw.device)
-    raise ValueError(f"Unknown scalarization mode '{mode}'")
+def scalarize_embedding(e_raw: torch.Tensor, mode: str = "uniform") -> torch.Tensor:
+    """Backward-compatible shim around :func:`scalarize_embedding`."""
+    warnings.warn(
+        "scalarize_embedding is deprecated; use scalarize_embedding from "
+        "lut_quantile_analysis instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return scalarize_embedding(e_raw, mode)
 
 
 def estimate_data_histogram(
@@ -318,7 +311,7 @@ def analyze_baselines(
     
     # Extract embeddings for this channel
     E_raw = lut_weight[channel_idx, :, :]  # [V, D]
-    E = _scalarize_embedding(E_raw, mode=scalar_mode)
+    E = scalarize_embedding(E_raw, mode=scalar_mode)
     if D > 1:
         print(f"  Using scalarization='{scalar_mode}' for {D}D embeddings (channel {channel_idx})")
     
@@ -393,7 +386,7 @@ def sample_pushforward(
     
     # Map through LUT
     E_raw = lut_weight[channel_idx, :, :]  # [V, D]
-    E = _scalarize_embedding(E_raw, mode=scalar_mode)
+    E = scalarize_embedding(E_raw, mode=scalar_mode)
     
     y_samples = E[x_samples]  # [N]
     
@@ -476,7 +469,7 @@ def test_normality(samples: torch.Tensor) -> Dict[str, float]:
         "KS_stat": ks_stat,
         "KS_pval": ks_pval,
         "AD_stat": ad_stat,
-        "QQ_R²": qq_r2,
+        "QQ_R2": qq_r2,
     }
 
 
@@ -526,8 +519,8 @@ def analyze_pushforward(
 # Visualization
 # ============================================================================
 
-def plot_baseline_comparison(results_A: Dict, output_path: str, channel_idx: int):
-    """Plot learned E vs baselines T1/T2/T3."""
+def _plot_baseline_comparison_basic(results_A: Dict, output_path: str, channel_idx: int):
+    """Legacy baseline plot (kept for reference)."""
     E = results_A["E"].numpy()
     T1 = results_A["T1"].numpy()
     T2 = results_A["T2"].numpy()
@@ -565,7 +558,7 @@ def plot_baseline_comparison(results_A: Dict, output_path: str, channel_idx: int
     ax = axes[1, 0]
     ax.scatter(T1, E, c=tokens, cmap='viridis', s=10, alpha=0.6)
     ax.plot([T1.min(), T1.max()], [T1.min(), T1.max()], 'k--', linewidth=1)
-    metrics_T1 = results_A["metrics"]["T1_uniform"]
+    metrics_T1 = results_A.metrics["T1_uniform"]
     ax.set_xlabel('T1: Uniform')
     ax.set_ylabel('E (Learned)')
     ax.set_title(f'E vs T1 (R²={metrics_T1["R²"]:.4f})')
@@ -575,7 +568,7 @@ def plot_baseline_comparison(results_A: Dict, output_path: str, channel_idx: int
     ax = axes[1, 1]
     ax.scatter(T2, E, c=tokens, cmap='viridis', s=10, alpha=0.6)
     ax.plot([T2.min(), T2.max()], [T2.min(), T2.max()], 'k--', linewidth=1)
-    metrics_T2 = results_A["metrics"]["T2_probit"]
+    metrics_T2 = results_A.metrics["T2_probit"]
     ax.set_xlabel('T2: Probit')
     ax.set_ylabel('E (Learned)')
     ax.set_title(f'E vs T2 (R²={metrics_T2["R²"]:.4f})')
@@ -616,7 +609,7 @@ def plot_pushforward_analysis(results_C: Dict, output_path: str, channel_idx: in
     # QQ plot (normal)
     ax = axes[0, 2]
     stats.probplot(x, dist="norm", plot=ax)
-    ax.set_title(f'Original QQ (Normal)\nR²={results_C["original_normal"]["QQ_R²"]:.4f}')
+    ax.set_title(f'Original QQ (Normal)\nR²={results_C["original_normal"]["QQ_R2"]:.4f}')
     ax.grid(True, alpha=0.3)
     
     # Bottom row: Pushforward distribution
@@ -645,7 +638,7 @@ def plot_pushforward_analysis(results_C: Dict, output_path: str, channel_idx: in
     # QQ plot (normal)
     ax = axes[1, 2]
     stats.probplot(y, dist="norm", plot=ax)
-    ax.set_title(f'Pushforward QQ (Normal)\nR²={results_C["pushforward_normal"]["QQ_R²"]:.4f}')
+    ax.set_title(f'Pushforward QQ (Normal)\nR²={results_C["pushforward_normal"]["QQ_R2"]:.4f}')
     ax.grid(True, alpha=0.3)
     
     plt.tight_layout()
@@ -654,76 +647,71 @@ def plot_pushforward_analysis(results_C: Dict, output_path: str, channel_idx: in
     print(f"  ✓ Saved pushforward analysis to {output_path}")
 
 
-def print_summary_report(results_A: Dict, results_C: Dict, channel_idx: int):
+def print_summary_report(results_A: BaselineResults, results_C: Dict, channel_idx: int):
     """Print text summary of all metrics."""
-    print("\n" + "="*80)
+    print("\n" + "=" * 80)
     print(f"ANALYSIS SUMMARY - Channel {channel_idx}")
-    print("="*80)
-    
+    print("=" * 80)
+
     # Probe A: Baseline comparison
     print("\n[A] QUANTILE EQUALIZATION HYPOTHESIS")
     print("-" * 80)
-    for baseline_name, metrics in results_A["metrics"].items():
+    for metrics in results_A.metrics.values():
         print(f"\n{metrics['name']}:")
-        print(f"  R² = {metrics['R²']:.6f}")
+        print(f"  R² = {metrics['R2']:.6f}")
         print(f"  RMSE = {metrics['RMSE']:.6f}")
         print(f"  MAE = {metrics['MAE']:.6f}")
-        print(f"  Spearman ρ = {metrics['Spearman_ρ']:.6f}")
-        print(f"  Kendall τ = {metrics['Kendall_τ']:.6f}")
-    
-    # Interpretation
-    best_r2 = max(m["R²"] for m in results_A["metrics"].values())
-    best_baseline = [k for k, m in results_A["metrics"].items() if m["R²"] == best_r2][0]
-    print(f"\n✓ Best fit: {results_A['metrics'][best_baseline]['name']} (R²={best_r2:.6f})")
-    
-    if best_r2 >= 0.98:
+        print(f"  Spearman ρ = {metrics['SpearmanR']:.6f}")
+        print(f"  Kendall τ = {metrics['KendallTau']:.6f}")
+
+    best_key, best_metrics = max(results_A.metrics.items(), key=lambda item: item[1]['R2'])
+    print(f"\n✓ Best fit: {best_metrics['name']} (R²={best_metrics['R2']:.6f})")
+    if best_metrics['R2'] >= 0.98:
         print("  → STRONG evidence for quantile-like behavior (R² ≥ 0.98)")
-    elif best_r2 >= 0.95:
+    elif best_metrics['R2'] >= 0.95:
         print("  → MODERATE evidence for quantile-like behavior (R² ≥ 0.95)")
     else:
         print("  → WEAK evidence for quantile-like behavior (R² < 0.95)")
-    
+
     # Probe C: Pushforward tests
     print("\n" + "-" * 80)
     print("[C] PUSHFORWARD DISTRIBUTION TESTS")
     print("-" * 80)
-    
-    print("\nOriginal Distribution (x_1):")
+
+    print("\nOriginal Distribution (x₁):")
     print(f"  Uniformity: KS={results_C['original_uniform']['KS_stat']:.4f}, p={results_C['original_uniform']['KS_pval']:.4e}")
     print(f"  Normality: Shapiro W={results_C['original_normal']['Shapiro_stat']:.4f}, p={results_C['original_normal']['Shapiro_pval']:.4e}")
-    
-    print("\nPushforward Distribution (y=E(x_1)):")
+
+    print("\nPushforward Distribution (y=E(x₁)):")
     print(f"  Uniformity: KS={results_C['pushforward_uniform']['KS_stat']:.4f}, p={results_C['pushforward_uniform']['KS_pval']:.4e}")
     print(f"  Normality: Shapiro W={results_C['pushforward_normal']['Shapiro_stat']:.4f}, p={results_C['pushforward_normal']['Shapiro_pval']:.4e}")
-    print(f"  QQ (Normal) R²={results_C['pushforward_normal']['QQ_R²']:.4f}")
-    
-    # Improvement metrics
-    ks_improvement = (results_C['original_uniform']['KS_stat'] - results_C['pushforward_uniform']['KS_stat']) / results_C['original_uniform']['KS_stat']
-    print(f"\n✓ KS distance improvement: {ks_improvement*100:.1f}%")
-    
+    print(f"  QQ (Normal) R²={results_C['pushforward_normal']['QQ_R2']:.4f}")
+
+    orig_ks = results_C['original_uniform']['KS_stat']
+    push_ks = results_C['pushforward_uniform']['KS_stat']
+    denom = orig_ks if orig_ks > 1e-12 else 1e-12
+    ks_improvement = (orig_ks - push_ks) / denom
+    print(f"\n✓ KS distance improvement: {ks_improvement * 100:.1f}%")
     if ks_improvement >= 0.5:
         print("  → STRONG pushforward effect (≥50% improvement)")
     elif ks_improvement >= 0.3:
         print("  → MODERATE pushforward effect (≥30% improvement)")
     else:
         print("  → WEAK pushforward effect (<30% improvement)")
-    
-    # Final verdict
-    print("\n" + "="*80)
+
+    print("\n" + "=" * 80)
     print("VERDICT")
-    print("="*80)
-    
-    if best_r2 >= 0.98 and ks_improvement >= 0.5:
+    print("=" * 80)
+    if best_metrics['R2'] >= 0.98 and ks_improvement >= 0.5:
         print("✅ CONFIRMED: LUT behaves like quantile equalization")
         print("   The S-tail is a natural consequence of density reallocation.")
-    elif best_r2 >= 0.95 or ks_improvement >= 0.3:
+    elif best_metrics['R2'] >= 0.95 or ks_improvement >= 0.3:
         print("⚠ LIKELY: LUT shows quantile-like behavior")
         print("   Some deviations exist, but overall trend is consistent.")
     else:
         print("❌ INCONCLUSIVE: LUT does not strongly match quantile hypothesis")
         print("   Consider other mechanisms (metric annealing, target geometry, etc.)")
-    
-    print("="*80 + "\n")
+    print("=" * 80 + "\n")
 
 
 # ============================================================================
@@ -763,7 +751,7 @@ def main():
     
     # Probe A: Baseline comparison
     print(f"\n[2/5] Running Probe A: Quantile Equalization Baselines (channel {args.channel}, scalar_mode={args.scalar_mode})...")
-    results_A = analyze_baselines(lut_weight, data_histogram, channel_idx=args.channel, scalar_mode=args.scalar_mode)
+    results_A = shared_analyze_baselines(lut_weight, data_histogram, channel_idx=args.channel, scalar_mode=args.scalar_mode)
     
     # Probe C: Pushforward tests
     print(f"\n[3/5] Running Probe C: Pushforward Distribution Tests (channel {args.channel}, scalar_mode={args.scalar_mode})...")
@@ -796,7 +784,7 @@ def main():
         
         f.write("[A] Baseline Metrics\n")
         f.write("-"*80 + "\n")
-        for baseline_name, metrics in results_A["metrics"].items():
+        for baseline_name, metrics in results_A.metrics.items():
             f.write(f"\n{metrics['name']}:\n")
             for key, value in metrics.items():
                 if key != "name":

--- a/examples/image/tools/analyze_lut_quantile_hypothesis.py
+++ b/examples/image/tools/analyze_lut_quantile_hypothesis.py
@@ -1,0 +1,819 @@
+"""
+Comprehensive LUT Analysis: Quantile Hypothesis Testing
+
+Implements two key diagnostic probes:
+
+A. Quantile Equalization Hypothesis
+   - Compare learned E_c(v) against three monotone baselines:
+     T1: Equalize-to-uniform (2*F_c(v) - 1)
+     T2: Equalize-to-normal (probit transform: Φ^(-1)(F_c(v)))
+     T3: Isotonic regression (unconstrained monotone fit)
+   - Report R², RMSE, MAE, Spearman/Kendall correlations
+
+C. Pushforward Distribution Tests
+   - Sample x_1 tokens, map through y = E_c(x_1)
+   - Test if y is closer to Uniform[-1,1] or Normal than original x_1
+   - Use KS/CvM/AD tests, QQ plots, Shapiro-Wilk
+
+Handles both scalar (D=1) and multi-dimensional (D>1) embeddings.
+For D>1, uses L2 norm or PC1 projection for visualization.
+
+Usage:
+    python analyze_lut_quantile_hypothesis.py --checkpoint path/to/checkpoint.pth \\
+           --data_histogram path/to/cifar10_histogram.pt \\
+           --output_dir ./lut_analysis_output
+"""
+
+import argparse
+import sys
+import warnings
+from pathlib import Path
+from typing import Dict, List, Tuple, Optional
+
+import matplotlib.pyplot as plt
+import numpy as np
+import torch
+import torch.nn.functional as F
+from scipy import stats
+from scipy.interpolate import interp1d
+from scipy.ndimage import gaussian_filter1d
+from sklearn.isotonic import IsotonicRegression
+from sklearn.decomposition import PCA
+
+sys.path.insert(0, str(Path(__file__).parent / "flow_matching"))
+
+
+# ============================================================================
+# Utility Functions
+# ============================================================================
+
+def load_lut_from_checkpoint(checkpoint_path: str) -> Tuple[torch.Tensor, dict]:
+    """Load LUT weights from checkpoint.
+    
+    Returns:
+        lut_weight: Tensor of shape [C, V, D]
+        metadata: Dict with num_channels, vocab_size, emb_dim
+    """
+    ckpt = torch.load(checkpoint_path, map_location="cpu", weights_only=False)
+    
+    # Try extra_modules first (newer format)
+    lut_weight = None
+    if "extra_modules" in ckpt and "metric_learnable_lut" in ckpt["extra_modules"]:
+        lut_dict = ckpt["extra_modules"]["metric_learnable_lut"]
+        if "weight" in lut_dict:
+            lut_weight = lut_dict["weight"]
+            print("  ✓ Found LUT in extra_modules['metric_learnable_lut']")
+    
+    # Fallback: search in ema_model (older format)
+    if lut_weight is None and "ema_model" in ckpt:
+        for key in ckpt["ema_model"].keys():
+            if "learnable_lut.weight" in key:
+                lut_weight = ckpt["ema_model"][key]
+                print(f"  ✓ Found LUT in ema_model['{key}']")
+                break
+    
+    if lut_weight is None:
+        raise ValueError("No learnable_lut.weight found in checkpoint (checked extra_modules and ema_model)")
+    
+    # Ensure [C, V, D] shape
+    
+    # Infer dimensions
+    if lut_weight.ndim == 2:
+        lut_weight = lut_weight.unsqueeze(-1)  # [C, V, 1]
+    
+    C, V, D = lut_weight.shape
+    metadata = {
+        "num_channels": C,
+        "vocab_size": V,
+        "emb_dim": D,
+        "checkpoint_path": checkpoint_path,
+    }
+    
+    print(f"✓ Loaded LUT: shape={list(lut_weight.shape)}, channels={C}, vocab={V}, emb_dim={D}")
+    return lut_weight, metadata
+
+
+def _scalarize_embedding(e_raw: torch.Tensor, mode: str = "uniform") -> torch.Tensor:
+    """Convert [V,D] embedding into a scalar curve [V].
+
+    Modes:
+      - 'norm': L2 norm ||E||
+      - 'norm_normalized': ||E|| / sqrt(D)
+      - 'mean': per-token dimension mean
+      - 'uniform': dot(E, 1/sqrt(D)) (signed projection)
+      - 'pc1': projection to first principal component (signed)
+    """
+    assert e_raw.ndim == 2, "Expected [V,D]"
+    V, D = e_raw.shape
+    if D == 1:
+        return e_raw.squeeze(-1)
+    mode = str(mode).lower()
+    if mode == "norm":
+        return torch.norm(e_raw, p=2, dim=-1)
+    if mode == "norm_normalized":
+        return torch.norm(e_raw, p=2, dim=-1) / torch.sqrt(torch.tensor(float(D), device=e_raw.device, dtype=e_raw.dtype))
+    if mode == "mean":
+        return e_raw.mean(dim=-1)
+    if mode == "uniform":
+        u = torch.ones(D, device=e_raw.device, dtype=e_raw.dtype) / torch.sqrt(torch.tensor(float(D), device=e_raw.device, dtype=e_raw.dtype))
+        return e_raw @ u
+    if mode == "pc1":
+        with torch.no_grad():
+            X = e_raw.double().cpu().numpy()
+            pca = PCA(n_components=1)
+            comp = pca.fit_transform(X)[:, 0]
+            return torch.from_numpy(comp).to(dtype=e_raw.dtype, device=e_raw.device)
+    raise ValueError(f"Unknown scalarization mode '{mode}'")
+
+
+def estimate_data_histogram(
+    data_path: Optional[str] = None,
+    vocab_size: int = 256,
+    num_channels: int = 3,
+) -> torch.Tensor:
+    """Estimate per-channel token histogram from data.
+    
+    Args:
+        data_path: Path to saved histogram tensor, or None to use synthetic
+        vocab_size: Number of tokens (256 for 8-bit images)
+        num_channels: Number of channels (3 for RGB)
+    
+    Returns:
+        histogram: Tensor of shape [C, V] with token counts (unnormalized)
+    """
+    if data_path and Path(data_path).exists():
+        hist = torch.load(data_path, map_location="cpu")
+        print(f"✓ Loaded data histogram from {data_path}, shape={list(hist.shape)}")
+        return hist
+    
+    # Synthetic: assume approximately Gaussian-like distribution
+    # (real CIFAR-10 is bimodal with peaks at edges, but this is a fallback)
+    print("⚠ No data histogram provided, using synthetic Gaussian approximation")
+    x = torch.linspace(0, vocab_size - 1, vocab_size)
+    mu, sigma = vocab_size / 2, vocab_size / 4
+    hist = torch.exp(-0.5 * ((x - mu) / sigma) ** 2)
+    hist = hist.unsqueeze(0).repeat(num_channels, 1)  # [C, V]
+    hist = hist / hist.sum(dim=1, keepdim=True) * 10000  # Normalize to ~10k samples
+    return hist
+
+
+def compute_empirical_cdf(histogram: torch.Tensor, smoothing_sigma: float = 0.5) -> torch.Tensor:
+    """Compute smoothed empirical CDF from histogram.
+    
+    Args:
+        histogram: [C, V] token counts
+        smoothing_sigma: Gaussian kernel std for smoothing (0 = no smoothing)
+    
+    Returns:
+        cdf: [C, V] cumulative distribution function F_c(v) ∈ [0, 1]
+    """
+    C, V = histogram.shape
+    
+    # Smooth histogram to reduce noise
+    if smoothing_sigma > 0:
+        hist_np = histogram.numpy()
+        smoothed = np.array([
+            gaussian_filter1d(hist_np[c], sigma=smoothing_sigma, mode='nearest')
+            for c in range(C)
+        ])
+        hist_smooth = torch.from_numpy(smoothed).float()
+    else:
+        hist_smooth = histogram.float()
+    
+    # Compute CDF
+    hist_smooth = torch.clamp(hist_smooth, min=1e-8)  # Avoid zeros
+    pmf = hist_smooth / hist_smooth.sum(dim=1, keepdim=True)  # Normalize to PMF
+    cdf = torch.cumsum(pmf, dim=1)  # Cumulative sum
+    cdf = torch.clamp(cdf, min=0.0, max=1.0)  # Numerical stability
+    
+    return cdf
+
+
+# ============================================================================
+# Probe A: Quantile Equalization Baselines
+# ============================================================================
+
+def baseline_uniform(cdf: torch.Tensor, target_range: Tuple[float, float] = (-1, 1)) -> torch.Tensor:
+    """T1: Equalize to uniform distribution.
+    
+    Args:
+        cdf: [C, V] empirical CDF F_c(v)
+        target_range: (min, max) for output range
+    
+    Returns:
+        T1: [C, V] baseline embeddings
+    """
+    a, b = target_range
+    return a + (b - a) * cdf
+
+
+def baseline_probit(cdf: torch.Tensor, target_mean: float = 0.0, target_std: float = 1.0) -> torch.Tensor:
+    """T2: Equalize to normal distribution (probit transform).
+    
+    Args:
+        cdf: [C, V] empirical CDF F_c(v)
+        target_mean: Mean of target normal
+        target_std: Std of target normal
+    
+    Returns:
+        T2: [C, V] baseline embeddings
+    """
+    # Avoid probit(0) = -∞ and probit(1) = +∞
+    cdf_clipped = torch.clamp(cdf, min=1e-6, max=1 - 1e-6)
+    
+    # Probit: Φ^(-1)(p)
+    probit = torch.from_numpy(stats.norm.ppf(cdf_clipped.numpy())).float()
+    
+    # Rescale to target mean/std
+    probit_scaled = target_mean + target_std * probit
+    
+    return probit_scaled
+
+
+def baseline_isotonic(
+    lut_values: torch.Tensor,
+    tokens: torch.Tensor,
+) -> torch.Tensor:
+    """T3: Isotonic regression (monotone unconstrained fit).
+    
+    Args:
+        lut_values: [V] or [C, V] learned embeddings (target)
+        tokens: [V] token indices (0, 1, ..., V-1)
+    
+    Returns:
+        T3: [V] or [C, V] isotonic fit
+    """
+    if lut_values.ndim == 1:
+        lut_values = lut_values.unsqueeze(0)  # [1, V]
+    
+    C, V = lut_values.shape
+    T3 = torch.zeros_like(lut_values)
+    
+    for c in range(C):
+        iso_reg = IsotonicRegression(increasing=True)
+        y_fit = iso_reg.fit_transform(tokens.numpy(), lut_values[c].numpy())
+        T3[c] = torch.from_numpy(y_fit).float()
+    
+    return T3.squeeze() if C == 1 else T3
+
+
+def compute_baseline_metrics(
+    E: torch.Tensor,
+    T: torch.Tensor,
+    name: str,
+) -> Dict[str, float]:
+    """Compute fit quality metrics between E and baseline T.
+    
+    Args:
+        E: [V] learned embeddings
+        T: [V] baseline embeddings
+        name: Baseline name (for printing)
+    
+    Returns:
+        metrics: Dict with R², RMSE, MAE, Spearman ρ, Kendall τ
+    """
+    E_np = E.numpy()
+    T_np = T.numpy()
+    
+    # R² (coefficient of determination)
+    ss_res = np.sum((E_np - T_np) ** 2)
+    ss_tot = np.sum((E_np - E_np.mean()) ** 2)
+    r2 = 1 - ss_res / ss_tot if ss_tot > 0 else 0.0
+    
+    # RMSE and MAE
+    rmse = np.sqrt(np.mean((E_np - T_np) ** 2))
+    mae = np.mean(np.abs(E_np - T_np))
+    
+    # Spearman and Kendall (rank correlations)
+    spearman_rho, _ = stats.spearmanr(E_np, T_np)
+    kendall_tau, _ = stats.kendalltau(E_np, T_np)
+    
+    return {
+        "name": name,
+        "R²": r2,
+        "RMSE": rmse,
+        "MAE": mae,
+        "Spearman_ρ": spearman_rho,
+        "Kendall_τ": kendall_tau,
+    }
+
+
+def analyze_baselines(
+    lut_weight: torch.Tensor,
+    data_histogram: torch.Tensor,
+    channel_idx: int = 0,
+    scalar_mode: str = "uniform",
+) -> Dict[str, any]:
+    """Run baseline comparison for one channel.
+    
+    Args:
+        lut_weight: [C, V, D] LUT weights
+        data_histogram: [C, V] token counts
+        channel_idx: Which channel to analyze
+    
+    Returns:
+        results: Dict with baselines, metrics, and plots
+    """
+    C, V, D = lut_weight.shape
+    
+    # Extract embeddings for this channel
+    E_raw = lut_weight[channel_idx, :, :]  # [V, D]
+    E = _scalarize_embedding(E_raw, mode=scalar_mode)
+    if D > 1:
+        print(f"  Using scalarization='{scalar_mode}' for {D}D embeddings (channel {channel_idx})")
+    
+    # Compute empirical CDF
+    cdf = compute_empirical_cdf(data_histogram, smoothing_sigma=1.0)  # [C, V]
+    F_c = cdf[channel_idx, :]  # [V]
+    
+    # Compute baselines
+    tokens = torch.arange(V, dtype=torch.float32)
+    
+    # T1: Uniform equalization
+    T1 = baseline_uniform(F_c.unsqueeze(0), target_range=(-1, 1)).squeeze(0)
+    # Rescale to match E's range for fair comparison
+    T1_rescaled = (T1 - T1.min()) / (T1.max() - T1.min()) * (E.max() - E.min()) + E.min()
+    
+    # T2: Probit (normal) equalization
+    T2 = baseline_probit(F_c.unsqueeze(0)).squeeze(0)
+    # Rescale to match E's range
+    T2_rescaled = (T2 - T2.min()) / (T2.max() - T2.min()) * (E.max() - E.min()) + E.min()
+    
+    # T3: Isotonic regression
+    T3 = baseline_isotonic(E.unsqueeze(0), tokens).squeeze(0)
+    
+    # Compute metrics
+    metrics = {
+        "T1_uniform": compute_baseline_metrics(E, T1_rescaled, "T1: Uniform"),
+        "T2_probit": compute_baseline_metrics(E, T2_rescaled, "T2: Probit"),
+        "T3_isotonic": compute_baseline_metrics(E, T3, "T3: Isotonic"),
+    }
+    
+    return {
+        "E": E,
+        "T1": T1_rescaled,
+        "T2": T2_rescaled,
+        "T3": T3,
+        "F_c": F_c,
+        "metrics": metrics,
+    }
+
+
+# ============================================================================
+# Probe C: Pushforward Distribution Tests
+# ============================================================================
+
+def sample_pushforward(
+    lut_weight: torch.Tensor,
+    data_histogram: torch.Tensor,
+    channel_idx: int = 0,
+    num_samples: int = 100000,
+    scalar_mode: str = "uniform",
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Sample tokens from data, map through LUT, return both.
+    
+    Args:
+        lut_weight: [C, V, D] LUT weights
+        data_histogram: [C, V] token counts
+        channel_idx: Which channel to analyze
+        num_samples: Number of samples to draw
+    
+    Returns:
+        x_samples: [N] original token values (0..255)
+        y_samples: [N] pushforward values E_c(x)
+    """
+    C, V, D = lut_weight.shape
+    
+    # Create sampling distribution from histogram
+    hist = data_histogram[channel_idx, :].float()
+    probs = hist / hist.sum()
+    
+    # Sample tokens according to data distribution
+    x_samples = torch.multinomial(probs, num_samples, replacement=True)  # [N]
+    
+    # Map through LUT
+    E_raw = lut_weight[channel_idx, :, :]  # [V, D]
+    E = _scalarize_embedding(E_raw, mode=scalar_mode)
+    
+    y_samples = E[x_samples]  # [N]
+    
+    return x_samples.float(), y_samples
+
+
+def test_uniformity(samples: torch.Tensor, target_range: Tuple[float, float] = (-1, 1)) -> Dict[str, float]:
+    """Test if samples are uniform over target_range.
+    
+    Args:
+        samples: [N] values
+        target_range: (min, max) expected range
+    
+    Returns:
+        results: Dict with KS/CvM/AD statistics and p-values
+    """
+    a, b = target_range
+    
+    # Standardize to [0, 1] for scipy's uniform test
+    samples_01 = (samples.numpy() - a) / (b - a)
+    samples_01 = np.clip(samples_01, 0, 1)
+    
+    # Kolmogorov-Smirnov test
+    ks_stat, ks_pval = stats.kstest(samples_01, 'uniform')
+    
+    # Cramér-von Mises test
+    cvm_result = stats.cramervonmises(samples_01, 'uniform')
+    cvm_stat, cvm_pval = cvm_result.statistic, cvm_result.pvalue
+    
+    # Anderson-Darling test (no p-value for uniform, only critical values)
+    # Use KS distance as proxy
+    uniform_cdf = np.linspace(0, 1, len(samples_01))
+    ad_approx = np.max(np.abs(np.sort(samples_01) - uniform_cdf))
+    
+    return {
+        "KS_stat": ks_stat,
+        "KS_pval": ks_pval,
+        "CvM_stat": cvm_stat,
+        "CvM_pval": cvm_pval,
+        "KS_distance": ad_approx,
+    }
+
+
+def test_normality(samples: torch.Tensor) -> Dict[str, float]:
+    """Test if samples are normally distributed.
+    
+    Args:
+        samples: [N] values
+    
+    Returns:
+        results: Dict with Shapiro-Wilk, AD, KS statistics
+    """
+    samples_np = samples.numpy()
+    
+    # Standardize
+    samples_std = (samples_np - samples_np.mean()) / (samples_np.std() + 1e-8)
+    
+    # Shapiro-Wilk test (up to 5000 samples for speed)
+    if len(samples_std) > 5000:
+        subsample = np.random.choice(samples_std, size=5000, replace=False)
+    else:
+        subsample = samples_std
+    shapiro_stat, shapiro_pval = stats.shapiro(subsample)
+    
+    # KS test against normal
+    ks_stat, ks_pval = stats.kstest(samples_std, 'norm')
+    
+    # Anderson-Darling test
+    ad_result = stats.anderson(samples_std, dist='norm')
+    ad_stat = ad_result.statistic
+    
+    # QQ plot metrics (linearity)
+    theoretical_quantiles = stats.norm.ppf(np.linspace(0.01, 0.99, 100))
+    sample_quantiles = np.percentile(samples_std, np.linspace(1, 99, 100))
+    qq_r2 = np.corrcoef(theoretical_quantiles, sample_quantiles)[0, 1] ** 2
+    
+    return {
+        "Shapiro_stat": shapiro_stat,
+        "Shapiro_pval": shapiro_pval,
+        "KS_stat": ks_stat,
+        "KS_pval": ks_pval,
+        "AD_stat": ad_stat,
+        "QQ_R²": qq_r2,
+    }
+
+
+def analyze_pushforward(
+    lut_weight: torch.Tensor,
+    data_histogram: torch.Tensor,
+    channel_idx: int = 0,
+    num_samples: int = 100000,
+    scalar_mode: str = "uniform",
+) -> Dict[str, any]:
+    """Analyze pushforward distribution y = E(x_1).
+    
+    Args:
+        lut_weight: [C, V, D] LUT weights
+        data_histogram: [C, V] token counts
+        channel_idx: Which channel to analyze
+        num_samples: Number of samples
+    
+    Returns:
+        results: Dict with original/pushforward samples and test results
+    """
+    # Sample data and pushforward
+    x_samples, y_samples = sample_pushforward(
+        lut_weight, data_histogram, channel_idx, num_samples, scalar_mode=scalar_mode
+    )
+    
+    # Test original distribution (x_1)
+    x_uniform = test_uniformity(x_samples, target_range=(0, 255))
+    x_normal = test_normality(x_samples)
+    
+    # Test pushforward distribution (y)
+    y_min, y_max = y_samples.min().item(), y_samples.max().item()
+    y_uniform = test_uniformity(y_samples, target_range=(y_min, y_max))
+    y_normal = test_normality(y_samples)
+    
+    return {
+        "x_samples": x_samples,
+        "y_samples": y_samples,
+        "original_uniform": x_uniform,
+        "original_normal": x_normal,
+        "pushforward_uniform": y_uniform,
+        "pushforward_normal": y_normal,
+    }
+
+
+# ============================================================================
+# Visualization
+# ============================================================================
+
+def plot_baseline_comparison(results_A: Dict, output_path: str, channel_idx: int):
+    """Plot learned E vs baselines T1/T2/T3."""
+    E = results_A["E"].numpy()
+    T1 = results_A["T1"].numpy()
+    T2 = results_A["T2"].numpy()
+    T3 = results_A["T3"].numpy()
+    V = len(E)
+    tokens = np.arange(V)
+    
+    fig, axes = plt.subplots(2, 2, figsize=(14, 10))
+    
+    # Top-left: All curves
+    ax = axes[0, 0]
+    ax.plot(tokens, E, 'k-', linewidth=2, label='E (Learned)', alpha=0.8)
+    ax.plot(tokens, T1, 'r--', linewidth=1.5, label='T1: Uniform', alpha=0.7)
+    ax.plot(tokens, T2, 'g--', linewidth=1.5, label='T2: Probit', alpha=0.7)
+    ax.plot(tokens, T3, 'b--', linewidth=1.5, label='T3: Isotonic', alpha=0.7)
+    ax.set_xlabel('Token Value')
+    ax.set_ylabel('Embedding Value')
+    ax.set_title(f'Channel {channel_idx}: Learned vs Baselines')
+    ax.legend()
+    ax.grid(True, alpha=0.3)
+    
+    # Top-right: Residuals
+    ax = axes[0, 1]
+    ax.plot(tokens, E - T1, 'r-', linewidth=1, label='E - T1', alpha=0.7)
+    ax.plot(tokens, E - T2, 'g-', linewidth=1, label='E - T2', alpha=0.7)
+    ax.plot(tokens, E - T3, 'b-', linewidth=1, label='E - T3', alpha=0.7)
+    ax.axhline(0, color='k', linestyle='--', linewidth=0.5)
+    ax.set_xlabel('Token Value')
+    ax.set_ylabel('Residual')
+    ax.set_title('Residuals: E - T_i')
+    ax.legend()
+    ax.grid(True, alpha=0.3)
+    
+    # Bottom-left: Scatter E vs T1
+    ax = axes[1, 0]
+    ax.scatter(T1, E, c=tokens, cmap='viridis', s=10, alpha=0.6)
+    ax.plot([T1.min(), T1.max()], [T1.min(), T1.max()], 'k--', linewidth=1)
+    metrics_T1 = results_A["metrics"]["T1_uniform"]
+    ax.set_xlabel('T1: Uniform')
+    ax.set_ylabel('E (Learned)')
+    ax.set_title(f'E vs T1 (R²={metrics_T1["R²"]:.4f})')
+    ax.grid(True, alpha=0.3)
+    
+    # Bottom-right: Scatter E vs T2
+    ax = axes[1, 1]
+    ax.scatter(T2, E, c=tokens, cmap='viridis', s=10, alpha=0.6)
+    ax.plot([T2.min(), T2.max()], [T2.min(), T2.max()], 'k--', linewidth=1)
+    metrics_T2 = results_A["metrics"]["T2_probit"]
+    ax.set_xlabel('T2: Probit')
+    ax.set_ylabel('E (Learned)')
+    ax.set_title(f'E vs T2 (R²={metrics_T2["R²"]:.4f})')
+    ax.grid(True, alpha=0.3)
+    
+    plt.tight_layout()
+    plt.savefig(output_path, dpi=150, bbox_inches='tight')
+    plt.close()
+    print(f"  ✓ Saved baseline comparison to {output_path}")
+
+
+def plot_pushforward_analysis(results_C: Dict, output_path: str, channel_idx: int):
+    """Plot original vs pushforward distributions."""
+    x = results_C["x_samples"].numpy()
+    y = results_C["y_samples"].numpy()
+    
+    fig, axes = plt.subplots(2, 3, figsize=(16, 10))
+    
+    # Top row: Original distribution
+    # Histogram
+    ax = axes[0, 0]
+    ax.hist(x, bins=50, density=True, alpha=0.7, color='blue', edgecolor='black')
+    ax.set_xlabel('Token Value')
+    ax.set_ylabel('Density')
+    ax.set_title(f'Channel {channel_idx}: Original x_1 Distribution')
+    ax.grid(True, alpha=0.3)
+    
+    # CDF
+    ax = axes[0, 1]
+    x_sorted = np.sort(x)
+    cdf_x = np.arange(1, len(x_sorted) + 1) / len(x_sorted)
+    ax.plot(x_sorted, cdf_x, 'b-', linewidth=1.5)
+    ax.set_xlabel('Token Value')
+    ax.set_ylabel('CDF')
+    ax.set_title('Original CDF')
+    ax.grid(True, alpha=0.3)
+    
+    # QQ plot (normal)
+    ax = axes[0, 2]
+    stats.probplot(x, dist="norm", plot=ax)
+    ax.set_title(f'Original QQ (Normal)\nR²={results_C["original_normal"]["QQ_R²"]:.4f}')
+    ax.grid(True, alpha=0.3)
+    
+    # Bottom row: Pushforward distribution
+    # Histogram
+    ax = axes[1, 0]
+    ax.hist(y, bins=50, density=True, alpha=0.7, color='red', edgecolor='black')
+    ax.set_xlabel('Pushforward Value')
+    ax.set_ylabel('Density')
+    ax.set_title(f'Pushforward y=E(x_1) Distribution')
+    ax.grid(True, alpha=0.3)
+    
+    # CDF vs Uniform
+    ax = axes[1, 1]
+    y_sorted = np.sort(y)
+    cdf_y = np.arange(1, len(y_sorted) + 1) / len(y_sorted)
+    y_normalized = (y_sorted - y_sorted.min()) / (y_sorted.max() - y_sorted.min())
+    ax.plot(y_normalized, cdf_y, 'r-', linewidth=1.5, label='Pushforward')
+    ax.plot([0, 1], [0, 1], 'k--', linewidth=1, label='Uniform')
+    ks_dist = results_C["pushforward_uniform"]["KS_distance"]
+    ax.set_xlabel('Normalized Value')
+    ax.set_ylabel('CDF')
+    ax.set_title(f'Pushforward CDF vs Uniform\nKS dist={ks_dist:.4f}')
+    ax.legend()
+    ax.grid(True, alpha=0.3)
+    
+    # QQ plot (normal)
+    ax = axes[1, 2]
+    stats.probplot(y, dist="norm", plot=ax)
+    ax.set_title(f'Pushforward QQ (Normal)\nR²={results_C["pushforward_normal"]["QQ_R²"]:.4f}')
+    ax.grid(True, alpha=0.3)
+    
+    plt.tight_layout()
+    plt.savefig(output_path, dpi=150, bbox_inches='tight')
+    plt.close()
+    print(f"  ✓ Saved pushforward analysis to {output_path}")
+
+
+def print_summary_report(results_A: Dict, results_C: Dict, channel_idx: int):
+    """Print text summary of all metrics."""
+    print("\n" + "="*80)
+    print(f"ANALYSIS SUMMARY - Channel {channel_idx}")
+    print("="*80)
+    
+    # Probe A: Baseline comparison
+    print("\n[A] QUANTILE EQUALIZATION HYPOTHESIS")
+    print("-" * 80)
+    for baseline_name, metrics in results_A["metrics"].items():
+        print(f"\n{metrics['name']}:")
+        print(f"  R² = {metrics['R²']:.6f}")
+        print(f"  RMSE = {metrics['RMSE']:.6f}")
+        print(f"  MAE = {metrics['MAE']:.6f}")
+        print(f"  Spearman ρ = {metrics['Spearman_ρ']:.6f}")
+        print(f"  Kendall τ = {metrics['Kendall_τ']:.6f}")
+    
+    # Interpretation
+    best_r2 = max(m["R²"] for m in results_A["metrics"].values())
+    best_baseline = [k for k, m in results_A["metrics"].items() if m["R²"] == best_r2][0]
+    print(f"\n✓ Best fit: {results_A['metrics'][best_baseline]['name']} (R²={best_r2:.6f})")
+    
+    if best_r2 >= 0.98:
+        print("  → STRONG evidence for quantile-like behavior (R² ≥ 0.98)")
+    elif best_r2 >= 0.95:
+        print("  → MODERATE evidence for quantile-like behavior (R² ≥ 0.95)")
+    else:
+        print("  → WEAK evidence for quantile-like behavior (R² < 0.95)")
+    
+    # Probe C: Pushforward tests
+    print("\n" + "-" * 80)
+    print("[C] PUSHFORWARD DISTRIBUTION TESTS")
+    print("-" * 80)
+    
+    print("\nOriginal Distribution (x_1):")
+    print(f"  Uniformity: KS={results_C['original_uniform']['KS_stat']:.4f}, p={results_C['original_uniform']['KS_pval']:.4e}")
+    print(f"  Normality: Shapiro W={results_C['original_normal']['Shapiro_stat']:.4f}, p={results_C['original_normal']['Shapiro_pval']:.4e}")
+    
+    print("\nPushforward Distribution (y=E(x_1)):")
+    print(f"  Uniformity: KS={results_C['pushforward_uniform']['KS_stat']:.4f}, p={results_C['pushforward_uniform']['KS_pval']:.4e}")
+    print(f"  Normality: Shapiro W={results_C['pushforward_normal']['Shapiro_stat']:.4f}, p={results_C['pushforward_normal']['Shapiro_pval']:.4e}")
+    print(f"  QQ (Normal) R²={results_C['pushforward_normal']['QQ_R²']:.4f}")
+    
+    # Improvement metrics
+    ks_improvement = (results_C['original_uniform']['KS_stat'] - results_C['pushforward_uniform']['KS_stat']) / results_C['original_uniform']['KS_stat']
+    print(f"\n✓ KS distance improvement: {ks_improvement*100:.1f}%")
+    
+    if ks_improvement >= 0.5:
+        print("  → STRONG pushforward effect (≥50% improvement)")
+    elif ks_improvement >= 0.3:
+        print("  → MODERATE pushforward effect (≥30% improvement)")
+    else:
+        print("  → WEAK pushforward effect (<30% improvement)")
+    
+    # Final verdict
+    print("\n" + "="*80)
+    print("VERDICT")
+    print("="*80)
+    
+    if best_r2 >= 0.98 and ks_improvement >= 0.5:
+        print("✅ CONFIRMED: LUT behaves like quantile equalization")
+        print("   The S-tail is a natural consequence of density reallocation.")
+    elif best_r2 >= 0.95 or ks_improvement >= 0.3:
+        print("⚠ LIKELY: LUT shows quantile-like behavior")
+        print("   Some deviations exist, but overall trend is consistent.")
+    else:
+        print("❌ INCONCLUSIVE: LUT does not strongly match quantile hypothesis")
+        print("   Consider other mechanisms (metric annealing, target geometry, etc.)")
+    
+    print("="*80 + "\n")
+
+
+# ============================================================================
+# Main
+# ============================================================================
+
+def main():
+    parser = argparse.ArgumentParser(description="LUT Quantile Hypothesis Analysis")
+    parser.add_argument("--checkpoint", type=str, required=True, help="Path to checkpoint.pth")
+    parser.add_argument("--data_histogram", type=str, default=None, help="Path to data histogram tensor (optional)")
+    parser.add_argument("--output_dir", type=str, default="./lut_quantile_analysis", help="Output directory")
+    parser.add_argument("--channel", type=int, default=0, help="Channel index to analyze (0=R, 1=G, 2=B)")
+    parser.add_argument("--num_samples", type=int, default=100000, help="Number of samples for pushforward tests")
+    parser.add_argument(
+        "--scalar_mode",
+        type=str,
+        default="uniform",
+        choices=["uniform", "mean", "norm", "norm_normalized", "pc1"],
+        help="How to convert D-dim embeddings to scalar for analysis",
+    )
+    
+    args = parser.parse_args()
+    
+    # Create output directory
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    print(f"✓ Output directory: {output_dir}")
+    
+    # Load LUT and data
+    print("\n[1/5] Loading checkpoint and data...")
+    lut_weight, metadata = load_lut_from_checkpoint(args.checkpoint)
+    data_histogram = estimate_data_histogram(
+        args.data_histogram,
+        vocab_size=metadata["vocab_size"],
+        num_channels=metadata["num_channels"],
+    )
+    
+    # Probe A: Baseline comparison
+    print(f"\n[2/5] Running Probe A: Quantile Equalization Baselines (channel {args.channel}, scalar_mode={args.scalar_mode})...")
+    results_A = analyze_baselines(lut_weight, data_histogram, channel_idx=args.channel, scalar_mode=args.scalar_mode)
+    
+    # Probe C: Pushforward tests
+    print(f"\n[3/5] Running Probe C: Pushforward Distribution Tests (channel {args.channel}, scalar_mode={args.scalar_mode})...")
+    results_C = analyze_pushforward(
+        lut_weight,
+        data_histogram,
+        channel_idx=args.channel,
+        num_samples=args.num_samples,
+        scalar_mode=args.scalar_mode,
+    )
+    
+    # Visualizations
+    print("\n[4/5] Generating plots...")
+    plot_baseline_comparison(results_A, output_dir / f"baseline_comparison_ch{args.channel}.png", args.channel)
+    plot_pushforward_analysis(results_C, output_dir / f"pushforward_analysis_ch{args.channel}.png", args.channel)
+    
+    # Summary report
+    print("\n[5/5] Generating summary report...")
+    print_summary_report(results_A, results_C, args.channel)
+    
+    # Save numerical results
+    results_file = output_dir / f"results_ch{args.channel}.txt"
+    with open(results_file, "w") as f:
+        f.write("="*80 + "\n")
+        f.write(f"LUT Quantile Analysis - Channel {args.channel}\n")
+        f.write("="*80 + "\n\n")
+        f.write(f"Checkpoint: {args.checkpoint}\n")
+        f.write(f"LUT shape: {list(lut_weight.shape)}\n")
+        f.write(f"Embedding dimension: {metadata['emb_dim']}\n\n")
+        
+        f.write("[A] Baseline Metrics\n")
+        f.write("-"*80 + "\n")
+        for baseline_name, metrics in results_A["metrics"].items():
+            f.write(f"\n{metrics['name']}:\n")
+            for key, value in metrics.items():
+                if key != "name":
+                    f.write(f"  {key} = {value:.6f}\n")
+        
+        f.write("\n[C] Pushforward Tests\n")
+        f.write("-"*80 + "\n")
+        f.write("\nOriginal (x_1):\n")
+        for key, value in results_C["original_uniform"].items():
+            f.write(f"  {key} = {value:.6e}\n")
+        f.write("\nPushforward (y):\n")
+        for key, value in results_C["pushforward_uniform"].items():
+            f.write(f"  {key} = {value:.6e}\n")
+    
+    print(f"✓ Saved results to {results_file}")
+    print("\n✅ Analysis complete!")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/image/tools/lut_geometry_inspect.py
+++ b/examples/image/tools/lut_geometry_inspect.py
@@ -34,15 +34,23 @@ def _ensure_3d(weight: torch.Tensor) -> torch.Tensor:
     return weight
 
 
-def _linear_baseline(num_channels: int, vocab_size: int, embed_range: str, device, dtype) -> torch.Tensor:
-    weight = torch.zeros(num_channels, vocab_size, 1, device=device, dtype=dtype)
+def _linear_baseline(
+    num_channels: int,
+    vocab_size: int,
+    embed_range: str,
+    device,
+    dtype,
+    embed_dim: int = 1,
+) -> torch.Tensor:
+    weight = torch.zeros(num_channels, vocab_size, embed_dim, device=device, dtype=dtype)
     if embed_range == "pm1":
         base = torch.linspace(-1.0, 1.0, steps=vocab_size, device=device, dtype=dtype)
     elif embed_range == "unit":
         base = torch.linspace(0.0, 1.0, steps=vocab_size, device=device, dtype=dtype)
     else:
         raise ValueError(f"Unsupported embed_range '{embed_range}'.")
-    weight[:, :, 0] = base.unsqueeze(0).expand(num_channels, -1)
+    base = base.unsqueeze(0).expand(num_channels, -1)  # [C,V]
+    weight[:] = base.unsqueeze(-1)  # broadcast across embed_dim
     return weight
 
 
@@ -104,6 +112,9 @@ def compute_geometry_metrics(
     """
     lut_weight = _ensure_3d(lut_weight).to(dtype=torch.float64)
     baseline_weight = _ensure_3d(baseline_weight).to(dtype=torch.float64, device=lut_weight.device)
+
+    if baseline_weight.shape[-1] == 1 and lut_weight.shape[-1] > 1:
+        baseline_weight = baseline_weight.expand(-1, -1, lut_weight.shape[-1])
 
     if lut_weight.shape != baseline_weight.shape:
         raise ValueError(f"Shape mismatch: learned {tuple(lut_weight.shape)} vs baseline {tuple(baseline_weight.shape)}")
@@ -190,7 +201,14 @@ def main() -> None:
         base_weight, _ = load_lut_snapshot(args.baseline)
         base_weight = _ensure_3d(base_weight)
     else:
-        base_weight = _linear_baseline(meta["num_channels"], meta["vocab_size"], meta.get("embed_range", "pm1"), lut_weight.device, lut_weight.dtype)
+        base_weight = _linear_baseline(
+            num_channels=meta["num_channels"],
+            vocab_size=meta["vocab_size"],
+            embed_range=meta.get("embed_range", "pm1"),
+            device=lut_weight.device,
+            dtype=lut_weight.dtype,
+            embed_dim=lut_weight.shape[-1],
+        )
 
     metrics = compute_geometry_metrics(
         lut_weight,

--- a/examples/image/tools/lut_geometry_inspect.py
+++ b/examples/image/tools/lut_geometry_inspect.py
@@ -4,11 +4,15 @@
 #
 # Utility to inspect the local geometry of a learnable LUT snapshot.
 #
-# Usage:
+# Usage (snapshot):
 #   python lut_geometry_inspect.py --lut path/to/lut_epoch_xxxx.pt \
 #       [--normalized] [--print-projection] [--export-projection path.npy]
+# Usage (checkpoint):
+#   python lut_geometry_inspect.py --checkpoint path/to/checkpoint-5499.pth \
+#       --lut-key metric_learnable_lut [--normalized] [...]
 #
 # The LUT snapshot can be produced via training.lut_diagnostics_integration.save_lut_snapshot.
+# When pointing to a training checkpoint, the LUT is fetched from checkpoint["extra_modules"][lut_key].
 # The script reports:
 #   - cos_mean / cos_median / flip_rate: directional continuity of adjacent token differences.
 #   - stretch_median / stretch_mean: ratio of adjacent distances vs baseline linear LUT.
@@ -51,6 +55,37 @@ def load_lut_snapshot(path: Path) -> Tuple[torch.Tensor, Dict[str, int]]:
         "num_channels": int(data.get("num_channels", weight.shape[0])),
         "vocab_size": int(data.get("vocab_size", weight.shape[1])),
         "embed_range": data.get("embed_range", "pm1"),
+    }
+    return weight, meta
+
+
+def load_lut_from_checkpoint(
+    path: Path,
+    lut_key: str,
+) -> Tuple[torch.Tensor, Dict[str, int]]:
+    checkpoint = torch.load(path, map_location="cpu")
+    extra = checkpoint.get("extra_modules")
+    if not isinstance(extra, dict):
+        raise KeyError(f"{path} has no 'extra_modules' dict; cannot locate '{lut_key}'")
+    if lut_key not in extra:
+        available = ", ".join(sorted(extra.keys()))
+        raise KeyError(f"'{lut_key}' not found in checkpoint extra_modules. Available keys: {available}")
+    state_dict = extra[lut_key]
+    if not isinstance(state_dict, dict):
+        raise TypeError(f"extra_modules['{lut_key}'] is not a state_dict (got {type(state_dict).__name__})")
+    if "weight" not in state_dict:
+        raise KeyError(f"State dict for '{lut_key}' is missing 'weight'")
+    weight = state_dict["weight"]
+    embed_range = None
+    checkpoint_args = checkpoint.get("args")
+    if hasattr(checkpoint_args, "mi_embed_range"):
+        embed_range = getattr(checkpoint_args, "mi_embed_range")
+    if embed_range is None:
+        embed_range = "pm1"
+    meta = {
+        "num_channels": weight.shape[0],
+        "vocab_size": weight.shape[1],
+        "embed_range": embed_range,
     }
     return weight, meta
 
@@ -133,14 +168,22 @@ def signed_projection_curve(weight: torch.Tensor, mode: str = "mean") -> torch.T
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Inspect learnable LUT geometry.")
-    parser.add_argument("--lut", type=Path, required=True, help="Path to LUT snapshot (.pt).")
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--lut", type=Path, help="Path to LUT snapshot (.pt) saved via save_lut_snapshot.")
+    group.add_argument("--checkpoint", type=Path, help="Path to training checkpoint containing extra_modules.")
     parser.add_argument("--baseline", type=Path, default=None, help="Optional baseline LUT snapshot (.pt).")
+    parser.add_argument("--lut-key", type=str, default="metric_learnable_lut", help="Key inside checkpoint['extra_modules'] for the learnable LUT.")
     parser.add_argument("--normalized", action="store_true", help="Use normalized distances (divide by sqrt(D)).")
     parser.add_argument("--projection-mode", choices=["none", "mean", "uniform"], default="none", help="Compute signed projection curve.")
     parser.add_argument("--export-projection", type=Path, default=None, help="Where to save projection curve (npz with per-channel arrays).")
     args = parser.parse_args()
 
-    lut_weight, meta = load_lut_snapshot(args.lut)
+    if args.lut is not None:
+        lut_weight, meta = load_lut_snapshot(args.lut)
+        lut_source = args.lut
+    else:
+        lut_weight, meta = load_lut_from_checkpoint(args.checkpoint, lut_key=args.lut_key)
+        lut_source = args.checkpoint
     lut_weight = _ensure_3d(lut_weight)
 
     if args.baseline is not None:
@@ -155,8 +198,9 @@ def main() -> None:
         normalized_distance=args.normalized,
     )
 
-    print(f"LUT snapshot: {args.lut}")
+    print(f"LUT source: {lut_source}")
     print(f"Shape: C={meta['num_channels']}, V={meta['vocab_size']}, D={lut_weight.shape[-1]}")
+    print(f"Embed range baseline: {meta.get('embed_range', 'pm1')}")
     print("=== Directional continuity ===")
     for key in ["cos_mean", "cos_median", "flip_rate", "cos_lt_half_rate"]:
         print(f"{key}: {metrics[key].tolist()}")

--- a/examples/image/tools/lut_geometry_inspect.py
+++ b/examples/image/tools/lut_geometry_inspect.py
@@ -20,10 +20,12 @@
 #   - Optional: saves/prints a 1-D signed projection curve for visual inspection.
 
 import argparse
+import math
 from pathlib import Path
 from typing import Dict, Tuple
 
 import torch
+import torch.nn.functional as F
 
 
 def _ensure_3d(weight: torch.Tensor) -> torch.Tensor:
@@ -51,6 +53,26 @@ def _linear_baseline(
         raise ValueError(f"Unsupported embed_range '{embed_range}'.")
     base = base.unsqueeze(0).expand(num_channels, -1)  # [C,V]
     weight[:] = base.unsqueeze(-1)  # broadcast across embed_dim
+    return weight
+
+
+def _great_circle_baseline(
+    num_channels: int,
+    vocab_size: int,
+    embed_dim: int,
+    device,
+    dtype,
+) -> torch.Tensor:
+    if embed_dim < 2:
+        raise ValueError("Great-circle baseline requires embedding dimension >= 2.")
+    weight = torch.zeros(num_channels, vocab_size, embed_dim, device=device, dtype=dtype)
+    theta = torch.linspace(0.0, math.pi, steps=vocab_size, device=device, dtype=dtype)
+    cos_theta = torch.cos(theta).unsqueeze(0).expand(num_channels, -1)
+    sin_theta = torch.sin(theta).unsqueeze(0).expand(num_channels, -1)
+    weight[:, :, 0] = cos_theta
+    weight[:, :, 1] = sin_theta
+    if embed_dim > 2:
+        weight[:, :, 2:] = 0.0
     return weight
 
 
@@ -102,6 +124,7 @@ def compute_geometry_metrics(
     lut_weight: torch.Tensor,
     baseline_weight: torch.Tensor,
     normalized_distance: bool = False,
+    sphere_mode: bool = False,
 ) -> Dict[str, torch.Tensor]:
     """
     Args:
@@ -123,10 +146,16 @@ def compute_geometry_metrics(
     if V < 3:
         raise ValueError("Need vocab_size >= 3 to compute curvature/angles")
 
+    if sphere_mode:
+        lut_weight = F.normalize(lut_weight, p=2, dim=-1, eps=1e-12)
+        baseline_weight = F.normalize(baseline_weight, p=2, dim=-1, eps=1e-12)
+        if torch.isnan(lut_weight).any() or torch.isnan(baseline_weight).any():
+            raise ValueError("Encountered NaNs during unit normalization; check LUT/baseline weights.")
+
     diff = lut_weight[:, 1:, :] - lut_weight[:, :-1, :]
     diff_base = baseline_weight[:, 1:, :] - baseline_weight[:, :-1, :]
 
-    if normalized_distance:
+    if normalized_distance and not sphere_mode:
         scale = torch.sqrt(torch.tensor(float(D), device=lut_weight.device, dtype=lut_weight.dtype))
         diff = diff / scale
         diff_base = diff_base / scale
@@ -138,8 +167,14 @@ def compute_geometry_metrics(
     cos_theta = (a * b).sum(dim=-1) / denom
 
     # stretch ratio
-    dist = diff.norm(dim=-1)  # [C,V-1]
-    dist_base = diff_base.norm(dim=-1) + 1e-12
+    if sphere_mode:
+        dot = torch.sum(lut_weight[:, 1:, :] * lut_weight[:, :-1, :], dim=-1).clamp(-1.0, 1.0)
+        dist = torch.sqrt(torch.clamp(2.0 - 2.0 * dot, min=0.0))  # chord length on unit sphere
+        dot_base = torch.sum(baseline_weight[:, 1:, :] * baseline_weight[:, :-1, :], dim=-1).clamp(-1.0, 1.0)
+        dist_base = torch.sqrt(torch.clamp(2.0 - 2.0 * dot_base, min=0.0)) + 1e-12
+    else:
+        dist = diff.norm(dim=-1)  # [C,V-1]
+        dist_base = diff_base.norm(dim=-1) + 1e-12
     stretch = dist / dist_base
 
     # curvature magnitude
@@ -185,9 +220,18 @@ def main() -> None:
     parser.add_argument("--baseline", type=Path, default=None, help="Optional baseline LUT snapshot (.pt).")
     parser.add_argument("--lut-key", type=str, default="metric_learnable_lut", help="Key inside checkpoint['extra_modules'] for the learnable LUT.")
     parser.add_argument("--normalized", action="store_true", help="Use normalized distances (divide by sqrt(D)).")
+    parser.add_argument(
+        "--sphere",
+        action="store_true",
+        help=("Compute metrics on unit-normalized embeddings using chord lengths (cosine geometry). "
+              "When no baseline is provided, a great-circle baseline is used."),
+    )
     parser.add_argument("--projection-mode", choices=["none", "mean", "uniform"], default="none", help="Compute signed projection curve.")
     parser.add_argument("--export-projection", type=Path, default=None, help="Where to save projection curve (npz with per-channel arrays).")
     args = parser.parse_args()
+
+    if args.sphere and args.normalized:
+        print("Note: --normalized is ignored when --sphere is enabled (unit vectors already used).")
 
     if args.lut is not None:
         lut_weight, meta = load_lut_snapshot(args.lut)
@@ -200,20 +244,34 @@ def main() -> None:
     if args.baseline is not None:
         base_weight, _ = load_lut_snapshot(args.baseline)
         base_weight = _ensure_3d(base_weight)
+        if args.sphere and base_weight.shape[-1] < 2:
+            raise ValueError("Sphere mode requires a baseline with embedding dimension >= 2.")
     else:
-        base_weight = _linear_baseline(
-            num_channels=meta["num_channels"],
-            vocab_size=meta["vocab_size"],
-            embed_range=meta.get("embed_range", "pm1"),
-            device=lut_weight.device,
-            dtype=lut_weight.dtype,
-            embed_dim=lut_weight.shape[-1],
-        )
+        if args.sphere:
+            if lut_weight.shape[-1] < 2:
+                raise ValueError("Sphere mode requires embedding dimension >= 2.")
+            base_weight = _great_circle_baseline(
+                num_channels=meta["num_channels"],
+                vocab_size=meta["vocab_size"],
+                embed_dim=lut_weight.shape[-1],
+                device=lut_weight.device,
+                dtype=lut_weight.dtype,
+            )
+        else:
+            base_weight = _linear_baseline(
+                num_channels=meta["num_channels"],
+                vocab_size=meta["vocab_size"],
+                embed_range=meta.get("embed_range", "pm1"),
+                device=lut_weight.device,
+                dtype=lut_weight.dtype,
+                embed_dim=lut_weight.shape[-1],
+            )
 
     metrics = compute_geometry_metrics(
         lut_weight,
         base_weight,
         normalized_distance=args.normalized,
+        sphere_mode=args.sphere,
     )
 
     print(f"LUT source: {lut_source}")

--- a/examples/image/tools/lut_geometry_inspect.py
+++ b/examples/image/tools/lut_geometry_inspect.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# Utility to inspect the local geometry of a learnable LUT snapshot.
+#
+# Usage:
+#   python lut_geometry_inspect.py --lut path/to/lut_epoch_xxxx.pt \
+#       [--normalized] [--print-projection] [--export-projection path.npy]
+#
+# The LUT snapshot can be produced via training.lut_diagnostics_integration.save_lut_snapshot.
+# The script reports:
+#   - cos_mean / cos_median / flip_rate: directional continuity of adjacent token differences.
+#   - stretch_median / stretch_mean: ratio of adjacent distances vs baseline linear LUT.
+#   - curvature_mean / curvature_std: second-order finite difference magnitude ("zig-zag").
+#   - Optional: saves/prints a 1-D signed projection curve for visual inspection.
+
+import argparse
+from pathlib import Path
+from typing import Dict, Tuple
+
+import torch
+
+
+def _ensure_3d(weight: torch.Tensor) -> torch.Tensor:
+    if weight.ndim == 2:
+        weight = weight.unsqueeze(-1)
+    if weight.ndim != 3:
+        raise ValueError(f"Expected LUT weight with 2 or 3 dims; got shape {tuple(weight.shape)}")
+    return weight
+
+
+def _linear_baseline(num_channels: int, vocab_size: int, embed_range: str, device, dtype) -> torch.Tensor:
+    weight = torch.zeros(num_channels, vocab_size, 1, device=device, dtype=dtype)
+    if embed_range == "pm1":
+        base = torch.linspace(-1.0, 1.0, steps=vocab_size, device=device, dtype=dtype)
+    elif embed_range == "unit":
+        base = torch.linspace(0.0, 1.0, steps=vocab_size, device=device, dtype=dtype)
+    else:
+        raise ValueError(f"Unsupported embed_range '{embed_range}'.")
+    weight[:, :, 0] = base.unsqueeze(0).expand(num_channels, -1)
+    return weight
+
+
+def load_lut_snapshot(path: Path) -> Tuple[torch.Tensor, Dict[str, int]]:
+    data = torch.load(path, map_location="cpu")
+    if "lut_weights" not in data:
+        raise KeyError(f"{path} does not contain 'lut_weights'")
+    weight = data["lut_weights"]
+    meta = {
+        "num_channels": int(data.get("num_channels", weight.shape[0])),
+        "vocab_size": int(data.get("vocab_size", weight.shape[1])),
+        "embed_range": data.get("embed_range", "pm1"),
+    }
+    return weight, meta
+
+
+def compute_geometry_metrics(
+    lut_weight: torch.Tensor,
+    baseline_weight: torch.Tensor,
+    normalized_distance: bool = False,
+) -> Dict[str, torch.Tensor]:
+    """
+    Args:
+        lut_weight: [C,V,D]
+        baseline_weight: [C,V,D]
+    Returns:
+        Dictionary of per-channel metrics (torch tensors on CPU).
+    """
+    lut_weight = _ensure_3d(lut_weight).to(dtype=torch.float64)
+    baseline_weight = _ensure_3d(baseline_weight).to(dtype=torch.float64, device=lut_weight.device)
+
+    if lut_weight.shape != baseline_weight.shape:
+        raise ValueError(f"Shape mismatch: learned {tuple(lut_weight.shape)} vs baseline {tuple(baseline_weight.shape)}")
+
+    C, V, D = lut_weight.shape
+    if V < 3:
+        raise ValueError("Need vocab_size >= 3 to compute curvature/angles")
+
+    diff = lut_weight[:, 1:, :] - lut_weight[:, :-1, :]
+    diff_base = baseline_weight[:, 1:, :] - baseline_weight[:, :-1, :]
+
+    if normalized_distance:
+        scale = torch.sqrt(torch.tensor(float(D), device=lut_weight.device, dtype=lut_weight.dtype))
+        diff = diff / scale
+        diff_base = diff_base / scale
+
+    # directional continuity
+    a = diff[:, :-1, :]
+    b = diff[:, 1:, :]
+    denom = a.norm(dim=-1) * b.norm(dim=-1) + 1e-12
+    cos_theta = (a * b).sum(dim=-1) / denom
+
+    # stretch ratio
+    dist = diff.norm(dim=-1)  # [C,V-1]
+    dist_base = diff_base.norm(dim=-1) + 1e-12
+    stretch = dist / dist_base
+
+    # curvature magnitude
+    curv = lut_weight[:, 2:, :] - 2 * lut_weight[:, 1:-1, :] + lut_weight[:, :-2, :]
+    curv_mag = curv.norm(dim=-1)
+
+    metrics = {
+        "cos_mean": cos_theta.mean(dim=1).cpu(),
+        "cos_median": cos_theta.median(dim=1).values.cpu(),
+        "flip_rate": (cos_theta < 0.0).float().mean(dim=1).cpu(),
+        "cos_lt_half_rate": (cos_theta < 0.5).float().mean(dim=1).cpu(),
+        "stretch_median": stretch.median(dim=1).values.cpu(),
+        "stretch_mean": stretch.mean(dim=1).cpu(),
+        "stretch_p90": torch.quantile(stretch.cpu(), 0.9, dim=1),
+        "curvature_mean": curv_mag.mean(dim=1).cpu(),
+        "curvature_std": curv_mag.std(dim=1).cpu(),
+    }
+    return metrics
+
+
+def signed_projection_curve(weight: torch.Tensor, mode: str = "mean") -> torch.Tensor:
+    """
+    Returns a [V] curve summarizing embeddings with sign information.
+    mode: 'mean' (average across dims) or 'uniform' (dot with 1/sqrt(D) vector).
+    """
+    weight = _ensure_3d(weight).to(dtype=torch.float64)
+    if mode == "mean":
+        curve = weight.mean(dim=-1)
+    elif mode == "uniform":
+        D = weight.shape[-1]
+        u = torch.ones(D, device=weight.device, dtype=weight.dtype) / torch.sqrt(torch.tensor(float(D)))
+        curve = torch.matmul(weight, u)
+    else:
+        raise ValueError(f"Unknown projection mode '{mode}'")
+    return curve.cpu()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Inspect learnable LUT geometry.")
+    parser.add_argument("--lut", type=Path, required=True, help="Path to LUT snapshot (.pt).")
+    parser.add_argument("--baseline", type=Path, default=None, help="Optional baseline LUT snapshot (.pt).")
+    parser.add_argument("--normalized", action="store_true", help="Use normalized distances (divide by sqrt(D)).")
+    parser.add_argument("--projection-mode", choices=["none", "mean", "uniform"], default="none", help="Compute signed projection curve.")
+    parser.add_argument("--export-projection", type=Path, default=None, help="Where to save projection curve (npz with per-channel arrays).")
+    args = parser.parse_args()
+
+    lut_weight, meta = load_lut_snapshot(args.lut)
+    lut_weight = _ensure_3d(lut_weight)
+
+    if args.baseline is not None:
+        base_weight, _ = load_lut_snapshot(args.baseline)
+        base_weight = _ensure_3d(base_weight)
+    else:
+        base_weight = _linear_baseline(meta["num_channels"], meta["vocab_size"], meta.get("embed_range", "pm1"), lut_weight.device, lut_weight.dtype)
+
+    metrics = compute_geometry_metrics(
+        lut_weight,
+        base_weight,
+        normalized_distance=args.normalized,
+    )
+
+    print(f"LUT snapshot: {args.lut}")
+    print(f"Shape: C={meta['num_channels']}, V={meta['vocab_size']}, D={lut_weight.shape[-1]}")
+    print("=== Directional continuity ===")
+    for key in ["cos_mean", "cos_median", "flip_rate", "cos_lt_half_rate"]:
+        print(f"{key}: {metrics[key].tolist()}")
+
+    print("=== Neighbour stretch ratio (learned vs baseline) ===")
+    for key in ["stretch_median", "stretch_mean", "stretch_p90"]:
+        print(f"{key}: {metrics[key].tolist()}")
+
+    print("=== Curvature (finite-difference magnitude) ===")
+    for key in ["curvature_mean", "curvature_std"]:
+        print(f"{key}: {metrics[key].tolist()}")
+
+    if args.projection_mode != "none":
+        proj = signed_projection_curve(lut_weight, mode=args.projection_mode)
+        print(f"Projection curve mode={args.projection_mode}, shape={tuple(proj.shape)} (per channel stacked).")
+        if args.export_projection:
+            args.export_projection.parent.mkdir(parents=True, exist_ok=True)
+            torch.save({"projection": proj}, args.export_projection)
+            print(f"Saved projection curve to {args.export_projection}")
+        else:
+            print("First 10 values per channel:")
+            for c in range(proj.shape[0]):
+                vals = proj[c][:10].tolist()
+                print(f"  ch{c}: {vals}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/image/train.py
+++ b/examples/image/train.py
@@ -22,6 +22,7 @@ import gc
 import os
 import sys
 import time
+import math
 from pathlib import Path
 from typing import Dict, Optional, Union
 
@@ -51,6 +52,32 @@ from training.load_and_save import load_model, save_model
 from training.train_loop import AdaptiveKLController, train_one_epoch
 
 logger = logging.getLogger(__name__)
+
+
+def _warm_start_cosine_lut(path: MetricInducedGibbsProbPath) -> None:
+    """Initialize cosine-metric LUT on a great-circle warm start."""
+    lut = getattr(path, "learnable_lut", None)
+    if lut is None:
+        return
+    C, V, D = lut.weight.shape
+    if D < 2:
+        logger.warning(
+            "Cosine LUT warm start requires emb_dim >= 2; current emb_dim=%d. Skipping warm start.",
+            D,
+        )
+        return
+    with torch.no_grad():
+        device = lut.weight.device
+        dtype = lut.weight.dtype
+        m = torch.linspace(-1.0, 1.0, V, device=device, dtype=dtype)  # baseline linear scale
+        theta = (m + 1.0) * (math.pi / 2.0)  # map to [0, π]
+        base = torch.zeros(C, V, D, device=device, dtype=dtype)
+        base[:, :, 0] = torch.cos(theta).unsqueeze(0).expand(C, -1)
+        base[:, :, 1] = torch.sin(theta).unsqueeze(0).expand(C, -1)
+        if D > 2:
+            base[:, :, 2:] = 1e-4 * torch.randn(C, V, D - 2, device=device, dtype=dtype)
+        lut.weight.copy_(base)
+    logger.info("Applied cosine LUT warm start on great-circle initialization")
 
 
 def main(args):
@@ -289,6 +316,13 @@ def main(args):
             gumbel_hard=True,
             **metric_kwargs,
         )
+
+        if (
+            getattr(args, "mi_learnable_lut", False)
+            and getattr(args, "mi_metric", "lp") == "cosine"
+            and (not getattr(args, "resume", "") or getattr(args, "mi_lut_force_warm_start", False))
+        ):
+            _warm_start_cosine_lut(metric_path)
         
         # Apply loaded metric codes if available
         if loaded_metric_codes is not None:
@@ -514,7 +548,9 @@ def main(args):
     logger.info(f"Optimizer: {optimizer}")
     logger.info(f"Learning-Rate Schedule: {lr_schedule}")
 
-    loss_scaler = NativeScaler()
+    if getattr(args, "bf16", False):
+        logger.info("bf16 autocast enabled: disabling GradScaler and using bfloat16 forwards.")
+    loss_scaler = NativeScaler(enabled=not getattr(args, "bf16", False))
 
     load_model(
         args=args,
@@ -524,6 +560,14 @@ def main(args):
         lr_schedule=lr_schedule,
         extra_modules=extra_modules,
     )
+    if (
+        getattr(args, "mi_lut_force_warm_start", False)
+        and getattr(args, "mi_learnable_lut", False)
+        and getattr(args, "mi_metric", "lp") == "cosine"
+        and metric_path is not None
+    ):
+        logger.info("Forcing cosine LUT warm start after loading checkpoint.")
+        _warm_start_cosine_lut(metric_path)
     if (
         beta_schedule_ema is not None
         and metric_path is not None

--- a/examples/image/train.py
+++ b/examples/image/train.py
@@ -161,6 +161,29 @@ def main(args):
                 raise ValueError(f"Unsupported β schedule type: {schedule_type}")
             beta_schedule.to(device=device)
 
+            if isinstance(beta_schedule, ExpMonotoneRQSSchedule):
+                logbeta_min = getattr(args, "mi_logbeta_min", None)
+                logbeta_max = getattr(args, "mi_logbeta_max", None)
+                if logbeta_min is None or logbeta_max is None:
+                    with torch.no_grad():
+                        t_bounds = torch.tensor(
+                            [
+                                float(beta_schedule.config.t_eps),
+                                float(1.0 - beta_schedule.config.t_eps),
+                            ],
+                            device=device,
+                            dtype=beta_schedule.y0.dtype,
+                        )
+                        beta_vals, _ = beta_schedule.beta_and_derivative(t_bounds)
+                        beta_vals = beta_vals.clamp_min(1e-12)
+                        defaults = beta_vals.log().tolist()
+                    if logbeta_min is None:
+                        logbeta_min = float(defaults[0])
+                    if logbeta_max is None:
+                        logbeta_max = float(defaults[1])
+                args.mi_logbeta_min = float(logbeta_min)
+                args.mi_logbeta_max = float(logbeta_max)
+
         gumbel_tau_default = float(getattr(args, "mi_gumbel_tau", 1.0))
         tau_start = getattr(args, "mi_gumbel_tau_start", None)
         tau_end = getattr(args, "mi_gumbel_tau_end", None)

--- a/examples/image/train.py
+++ b/examples/image/train.py
@@ -425,6 +425,7 @@ def main(args):
                 fid_samples=fid_samples,
                 args=args,
                 metric_path=metric_path,
+                metric_ema=metric_ema,
             )
             log_stats.update({f"eval_{k}": v for k, v in eval_stats.items()})
 

--- a/examples/image/train.py
+++ b/examples/image/train.py
@@ -272,6 +272,8 @@ def main(args):
         is_discrete=args.discrete_flow_matching,
         ko=getattr(args, "ko_metric_induced", False),
         use_ema=args.use_ema,
+        use_cosine_attention=getattr(args, "cosine_attention", False),
+        use_head_weight_norm=getattr(args, "head_weight_norm", False),
     )
 
     model.to(device)
@@ -293,6 +295,7 @@ def main(args):
             model, device_ids=[args.gpu], find_unused_parameters=False
         )
         model_without_ddp = model.module
+        setattr(model, "weight_norm_targets", getattr(model_without_ddp, "weight_norm_targets", []))
 
     optimizer_param_groups = [{"params": list(model_without_ddp.parameters())}]
     extra_modules = {}

--- a/examples/image/train.py
+++ b/examples/image/train.py
@@ -383,7 +383,7 @@ def main(args):
                 )
                 if getattr(args, "wandb_offline", False):
                     os.environ.setdefault("WANDB_MODE", "offline")
-                wandb_run = wandb.init(**{k: v for k, v in wandb_kwargs.items() if v is not None})
+                wandb_run = wandb.init(**{k: v for k, v in wandb_kwargs.items() if v is not None}, mode="offline" if getattr(args, "wandb_offline", False) else "online")
         except Exception as e:
             logger.warning(f"wandb not enabled ({e})")
 

--- a/examples/image/train.py
+++ b/examples/image/train.py
@@ -598,16 +598,15 @@ def main(args):
         if getattr(args, "mi_learnable_metric", False) and getattr(args, "mi_learnable_lut", False):
             raise ValueError("Cannot enable both --mi_learnable_metric and --mi_learnable_lut at the same time.")
 
-    metric_kwargs = {}
-    if getattr(args, "mi_metric", "lp") == "cosine" and getattr(args, "mi_lut_param_mode", "none") not in ("none", None):
-        logger.warning("mi_lut_param_mode has no effect when metric='cosine'; using standard LUT")
-        setattr(args, "mi_lut_param_mode", "none")
-    if getattr(args, "mi_learnable_metric", False):
-        metric_kwargs.update(
-            learnable_metric_dim=int(getattr(args, "mi_metric_dim", 0)),
-            learnable_metric_diag_eps=float(getattr(args, "mi_metric_diag_eps", 1e-4)),
-            metric_interp_lambda=float(getattr(args, "mi_metric_interp_start", 0.0)),
-        )
+        metric_kwargs = {}
+        if getattr(args, "mi_metric", "lp") == "cosine" and getattr(args, "mi_lut_param_mode", "none") not in ("none", None):
+            logger.warning("mi_lut_param_mode has no effect when metric='cosine'; using standard LUT")
+            setattr(args, "mi_lut_param_mode", "none")
+        if getattr(args, "mi_learnable_metric", False):
+            metric_kwargs.update(
+                learnable_metric_dim=int(getattr(args, "mi_metric_dim", 0)),
+                learnable_metric_diag_eps=float(getattr(args, "mi_metric_diag_eps", 1e-4)),
+                metric_interp_lambda=float(getattr(args, "mi_metric_interp_start", 0.0)),
             )
         if getattr(args, "mi_learnable_lut", False):
             metric_kwargs.update(
@@ -624,10 +623,6 @@ def main(args):
                 lut_param_mode=getattr(args, "mi_lut_param_mode", "none"),
                 lut_monotone_mode=str(getattr(args, "mi_lut_monotone_mode", "softplus")),
                 lut_arc_radius=float(getattr(args, "mi_lut_arc_radius", 1.0)),
-                lut_reg_align=float(getattr(args, "mi_lut_reg_align", 0.0)),
-                lut_reg_step=float(getattr(args, "mi_lut_reg_step", 0.0)),
-                lut_reg_curvature=float(getattr(args, "mi_lut_reg_curvature", 0.0)),
-                lut_geometry_log=bool(getattr(args, "mi_lut_geometry_log", False)),
             )
         args.mi_metric_interp_start = float(getattr(args, "mi_metric_interp_start", 0.0))
         args.mi_metric_interp_end = float(getattr(args, "mi_metric_interp_end", 1.0))

--- a/examples/image/train.py
+++ b/examples/image/train.py
@@ -247,6 +247,158 @@ def _record_cosine_calibration_summary(args, summary: Optional[Dict[str, Union[b
     if isinstance(t_values, list):
         setattr(args, "_mi_lut_cosine_t_mid_values", [float(t) for t in t_values if isinstance(t, (int, float))])
 
+
+def _compute_entropy_from_rows(dist_rows: torch.Tensor, beta: float) -> float:
+    """Return mean entropy over rows given pairwise distances and beta scalar."""
+    logits = (-beta) * dist_rows
+    logits = logits - logits.max(dim=-1, keepdim=True).values
+    probs = torch.softmax(logits, dim=-1)
+    probs = probs.clamp_min(1e-12)
+    entropy = -(probs * probs.log()).sum(dim=-1)
+    return float(entropy.mean().item())
+
+
+def _cosine_entropy_match_scale(
+    path: MetricInducedGibbsProbPath,
+    *,
+    t_values: Sequence[float],
+    weights: Sequence[float],
+    s_lo: float = 1.0,
+    s_hi: float = 200.0,
+    tol: float = 0.01,
+    max_iter: int = 12,
+) -> Dict[str, Union[float, int, list]]:
+    """Match cosine scale so weighted conditional entropy aligns with 1D baseline."""
+    assert getattr(path, "metric_name", "") == "cosine"
+    lut = getattr(path, "learnable_lut", None)
+    if lut is None:
+        raise RuntimeError("Entropy matching requires a learnable LUT.")
+
+    # Validate t grid
+    t_list = [float(t) for t in t_values if 0.0 < float(t) < 1.0]
+    if not t_list:
+        raise ValueError("At least one t value in (0,1) is required for entropy matching.")
+
+    # Normalize weights
+    weight_list = [float(w) for w in weights]
+    if len(weight_list) not in {1, len(t_list)}:
+        raise ValueError(
+            "Number of weights must be 1 or match the number of t values "
+            f"(got {len(weight_list)} weights for {len(t_list)} t values)."
+        )
+    if len(weight_list) == 1:
+        weight_list = weight_list * len(t_list)
+    weight_tensor = torch.tensor(weight_list, dtype=torch.float64)
+    if (weight_tensor < 0).any():
+        raise ValueError("Entropy matching weights must be non-negative.")
+    if weight_tensor.sum().item() == 0.0:
+        raise ValueError("Entropy matching weights must sum to a positive value.")
+    weight_tensor = weight_tensor / weight_tensor.sum()
+
+    vocab = int(path.vocab_size)
+    device_cpu = torch.device("cpu")
+    base_values = torch.linspace(-1.0, 1.0, vocab, device=device_cpu, dtype=torch.float64)
+    base_diff = (base_values.unsqueeze(0) - base_values.unsqueeze(1)).abs()
+
+    beta_list: list[float] = []
+    base_entropies: list[float] = []
+    for t_val in t_list:
+        t_tensor = torch.tensor([t_val], dtype=torch.float64, device=device_cpu)
+        beta_val = float(path.beta(t_tensor)[0].item())
+        beta_list.append(beta_val)
+        base_entropies.append(_compute_entropy_from_rows(base_diff, beta_val))
+
+    weighted_base = float(torch.tensor(base_entropies, dtype=torch.float64) @ weight_tensor)
+
+    lut_device = lut.weight.device
+    lut_dtype = lut.weight.dtype
+    initial_scale = float(getattr(path, "_lut_cosine_scale", 1.0))
+
+    def eval_cosine_entropy(scale_value: float) -> tuple[float, list[float]]:
+        previous_scale = float(getattr(path, "_lut_cosine_scale", 1.0))
+        try:
+            path._lut_cosine_scale = float(scale_value)
+            with torch.no_grad():
+                dist_table = path._build_lut_distance_table(device=lut_device, dtype=lut_dtype)
+            dist_rows = dist_table.to(device=device_cpu, dtype=torch.float64)
+            if dist_rows.dim() == 3:
+                dist_rows = dist_rows.mean(dim=0)
+            cos_entropies = [
+                _compute_entropy_from_rows(dist_rows, beta_val) for beta_val in beta_list
+            ]
+            weighted_cos = float(torch.tensor(cos_entropies, dtype=torch.float64) @ weight_tensor)
+            return weighted_cos, cos_entropies
+        finally:
+            path._lut_cosine_scale = previous_scale
+
+    weighted_lo, _ = eval_cosine_entropy(s_lo)
+    weighted_hi, _ = eval_cosine_entropy(s_hi)
+    if not (weighted_lo >= weighted_base >= weighted_hi):
+        # If the bracket does not contain the target, clamp to the closest endpoint.
+        if abs(weighted_lo - weighted_base) < abs(weighted_hi - weighted_base):
+            chosen_scale = s_lo
+            weighted_cos, cos_entropies = weighted_lo, eval_cosine_entropy(s_lo)[1]
+            iterations = 1
+        else:
+            chosen_scale = s_hi
+            weighted_cos, cos_entropies = weighted_hi, eval_cosine_entropy(s_hi)[1]
+            iterations = 1
+        path._lut_cosine_scale = float(chosen_scale)
+        path.clear_lut_cache()
+        rel_error = abs(weighted_cos - weighted_base) / max(weighted_base, 1e-12)
+        return {
+            "scale": float(chosen_scale),
+            "iterations": int(iterations),
+            "t_values": t_list,
+            "weights": weight_list,
+            "base_entropies": base_entropies,
+            "cosine_entropies": cos_entropies,
+            "weighted_base": weighted_base,
+            "weighted_cosine": weighted_cos,
+            "relative_error": float(rel_error),
+            "s_lo": float(s_lo),
+            "s_hi": float(s_hi),
+            "bracket_saturated": True,
+        }
+
+    lo, hi = float(s_lo), float(s_hi)
+    weighted_cos = weighted_lo
+    cos_entropies = eval_cosine_entropy(lo)[1]
+    iterations = 0
+    while iterations < max_iter:
+        mid = 0.5 * (lo + hi)
+        weighted_cos, cos_entropies = eval_cosine_entropy(mid)
+        rel_error = abs(weighted_cos - weighted_base) / max(weighted_base, 1e-12)
+        if rel_error <= tol:
+            lo = hi = mid
+            break
+        if weighted_cos < weighted_base:
+            hi = mid
+        else:
+            lo = mid
+        iterations += 1
+
+    chosen_scale = 0.5 * (lo + hi)
+    # Re-evaluate at chosen scale for final logging
+    weighted_cos, cos_entropies = eval_cosine_entropy(chosen_scale)
+    path._lut_cosine_scale = float(chosen_scale)
+    path.clear_lut_cache()
+    rel_error = abs(weighted_cos - weighted_base) / max(weighted_base, 1e-12)
+    return {
+        "scale": float(chosen_scale),
+        "iterations": int(iterations),
+        "t_values": t_list,
+        "weights": weight_list,
+        "base_entropies": base_entropies,
+        "cosine_entropies": cos_entropies,
+        "weighted_base": weighted_base,
+        "weighted_cosine": weighted_cos,
+        "relative_error": float(rel_error),
+        "s_lo": float(s_lo),
+        "s_hi": float(s_hi),
+        "bracket_saturated": False,
+    }
+
 def main(args):
     logging.basicConfig(
         level=logging.INFO,
@@ -755,6 +907,44 @@ def main(args):
             t_mid_values=getattr(args, "mi_lut_cosine_t_mid", (0.5,)),
         )
         _record_cosine_calibration_summary(args, summary)
+    entropy_summary: Optional[Dict[str, Union[float, int, list]]] = None
+    if (
+        getattr(args, "mi_metric", "lp") == "cosine"
+        and getattr(args, "mi_lut_cosine_entropy_match", False)
+        and metric_path is not None
+        and getattr(metric_path, "learnable_lut", None) is not None
+    ):
+        if distributed_mode.is_main_process():
+            try:
+                entropy_summary = _cosine_entropy_match_scale(
+                    metric_path,
+                    t_values=getattr(args, "mi_lut_cosine_entropy_t_mid", (0.3, 0.5, 0.7)),
+                    weights=getattr(args, "mi_lut_cosine_entropy_weights", (0.2, 0.6, 0.2)),
+                    s_lo=1.0,
+                    s_hi=200.0,
+                    tol=float(getattr(args, "mi_lut_cosine_entropy_tol", 0.01)),
+                    max_iter=int(getattr(args, "mi_lut_cosine_entropy_max_iter", 12)),
+                )
+                logger.info(
+                    "Entropy-matched cosine scale: %.4f (iters=%d, rel_err=%.3e)",
+                    entropy_summary["scale"],
+                    entropy_summary["iterations"],
+                    entropy_summary["relative_error"],
+                )
+            except Exception:
+                logger.exception("Cosine entropy matching failed; keeping current scale.")
+                entropy_summary = None
+        final_scale = float(getattr(metric_path, "_lut_cosine_scale", 1.0))
+        if distributed_mode.is_dist_avail_and_initialized():
+            import torch.distributed as dist
+
+            scale_tensor = torch.tensor([final_scale], device=device, dtype=torch.float32)
+            dist.broadcast(scale_tensor, src=0)
+            final_scale = float(scale_tensor.item())
+        metric_path._lut_cosine_scale = float(final_scale)
+        metric_path.clear_lut_cache()
+        if entropy_summary is not None:
+            setattr(args, "_mi_lut_cosine_entropy_summary", entropy_summary)
     if (
         beta_schedule_ema is not None
         and metric_path is not None

--- a/examples/image/train.py
+++ b/examples/image/train.py
@@ -76,7 +76,10 @@ def _warm_start_cosine_lut(path: MetricInducedGibbsProbPath) -> None:
         base[:, :, 1] = torch.sin(theta).unsqueeze(0).expand(C, -1)
         if D > 2:
             base[:, :, 2:] = 1e-4 * torch.randn(C, V, D - 2, device=device, dtype=dtype)
-        lut.weight.copy_(base)
+        if hasattr(lut, "initialize_from_weight"):
+            lut.initialize_from_weight(base)
+        else:
+            lut.weight.copy_(base)
     logger.info("Applied cosine LUT warm start on great-circle initialization")
 
 
@@ -595,12 +598,16 @@ def main(args):
         if getattr(args, "mi_learnable_metric", False) and getattr(args, "mi_learnable_lut", False):
             raise ValueError("Cannot enable both --mi_learnable_metric and --mi_learnable_lut at the same time.")
 
-        metric_kwargs = {}
-        if getattr(args, "mi_learnable_metric", False):
-            metric_kwargs.update(
-                learnable_metric_dim=int(getattr(args, "mi_metric_dim", 0)),
-                learnable_metric_diag_eps=float(getattr(args, "mi_metric_diag_eps", 1e-4)),
-                metric_interp_lambda=float(getattr(args, "mi_metric_interp_start", 0.0)),
+    metric_kwargs = {}
+    if getattr(args, "mi_metric", "lp") == "cosine" and getattr(args, "mi_lut_param_mode", "none") not in ("none", None):
+        logger.warning("mi_lut_param_mode has no effect when metric='cosine'; using standard LUT")
+        setattr(args, "mi_lut_param_mode", "none")
+    if getattr(args, "mi_learnable_metric", False):
+        metric_kwargs.update(
+            learnable_metric_dim=int(getattr(args, "mi_metric_dim", 0)),
+            learnable_metric_diag_eps=float(getattr(args, "mi_metric_diag_eps", 1e-4)),
+            metric_interp_lambda=float(getattr(args, "mi_metric_interp_start", 0.0)),
+        )
             )
         if getattr(args, "mi_learnable_lut", False):
             metric_kwargs.update(
@@ -614,6 +621,13 @@ def main(args):
                 lut_scale_epsilon=float(getattr(args, "mi_lut_scale_epsilon", 0.25)),
                 use_normalized_distance=bool(getattr(args, "mi_use_normalized_distance", False)),
                 lut_cosine_scale=float(getattr(args, "mi_lut_cosine_scale", 1.0)),
+                lut_param_mode=getattr(args, "mi_lut_param_mode", "none"),
+                lut_monotone_mode=str(getattr(args, "mi_lut_monotone_mode", "softplus")),
+                lut_arc_radius=float(getattr(args, "mi_lut_arc_radius", 1.0)),
+                lut_reg_align=float(getattr(args, "mi_lut_reg_align", 0.0)),
+                lut_reg_step=float(getattr(args, "mi_lut_reg_step", 0.0)),
+                lut_reg_curvature=float(getattr(args, "mi_lut_reg_curvature", 0.0)),
+                lut_geometry_log=bool(getattr(args, "mi_lut_geometry_log", False)),
             )
         args.mi_metric_interp_start = float(getattr(args, "mi_metric_interp_start", 0.0))
         args.mi_metric_interp_end = float(getattr(args, "mi_metric_interp_end", 1.0))

--- a/examples/image/train.py
+++ b/examples/image/train.py
@@ -24,7 +24,7 @@ import sys
 import time
 import math
 from pathlib import Path
-from typing import Dict, Optional, Union
+from typing import Dict, Optional, Sequence, Union
 
 import numpy as np
 import torch
@@ -83,64 +83,169 @@ def _warm_start_cosine_lut(path: MetricInducedGibbsProbPath) -> None:
 def _calibrate_cosine_scale(
     path: MetricInducedGibbsProbPath,
     *,
+    mode: str = "neighbor",
+    t_mid_values: Sequence[float] = (0.5,),
     num_samples: int = 4096,
-) -> None:
-    """Adjust cosine LUT scale so baseline and cosine distances have matched medians."""
+) -> Dict[str, Union[bool, float, str, list]]:
+    """
+    Calibrate cosine LUT scale by matching baseline and cosine distances.
+
+    Args:
+        path: Metric-induced path with cosine metric and learnable LUT.
+        mode: "neighbor" (adjacent-token distances) or "median" (full-table medians).
+        t_mid_values: Reference t values in (0,1); first value sets the applied scale,
+                      the full list is logged for diagnostics.
+        num_samples: Sampling budget used when mode=="median".
+    """
+    summary: Dict[str, Union[bool, float, str, list]] = {
+        "applied": False,
+        "mode": mode,
+        "t_mid_values": list(t_mid_values),
+    }
     if getattr(path, "metric_name", "") != "cosine":
-        return
+        return summary
     lut = getattr(path, "learnable_lut", None)
     if lut is None:
-        return
-    if num_samples is None or num_samples <= 0:
-        num_samples = 4096
+        return summary
 
     device = lut.weight.device
     dtype = lut.weight.dtype
     vocab = path.vocab_size
+    if vocab < 2:
+        logger.warning("Cosine calibration skipped: vocab size < 2")
+        return summary
+
+    t_mids: list[float] = [
+        float(t) for t in t_mid_values if isinstance(t, (int, float)) and 0.0 < float(t) < 1.0
+    ]
+    if not t_mids:
+        t_mids = [0.5]
+    summary["t_mid_values"] = t_mids
 
     with torch.no_grad():
-        base_table = path._get_base_distance_table(device=device, dtype=dtype)
-        base_table = base_table.to(device=device, dtype=dtype)
+        base_table = path._get_base_distance_table(device=device, dtype=dtype).to(device=device, dtype=dtype)
+        cos_table_scaled = path._build_lut_distance_table(device=device, dtype=dtype).to(device=device, dtype=dtype)
 
+    current_scale = float(getattr(path, "_lut_cosine_scale", 1.0) or 1.0)
+    scale_denom = max(current_scale, 1e-12)
+    cos_table_raw = cos_table_scaled / scale_denom
+
+    idx_adj = torch.arange(vocab - 1, device=device, dtype=torch.long)
+    neighbor_base = torch.median(base_table[idx_adj, idx_adj + 1]).item() if idx_adj.numel() > 0 else float("nan")
+    neighbor_cos = torch.median(cos_table_raw[:, idx_adj, idx_adj + 1]).item() if idx_adj.numel() > 0 else float("nan")
+    summary["neighbor_base"] = float(neighbor_base)
+    summary["neighbor_cos"] = float(neighbor_cos)
+
+    target_base = neighbor_base
+    cosine_stat = neighbor_cos
+
+    if mode == "median":
+        if num_samples is None or num_samples <= 0:
+            num_samples = 4096
         sample_count = int(min(vocab, num_samples))
         if sample_count < 1:
             logger.warning("Cosine calibration skipped: num_samples < 1")
-            return
+            return summary
 
         if sample_count >= vocab:
-            idx = torch.arange(vocab, device=device, dtype=torch.long)
+            sample_idx = torch.arange(vocab, device=device, dtype=torch.long)
         else:
             step = max(1, vocab // sample_count)
-            idx = torch.arange(0, vocab, step, device=device, dtype=torch.long)
-            idx = idx[:sample_count]
-            if idx.numel() > 0 and idx[-1].item() != vocab - 1:
-                idx[-1] = vocab - 1
+            sample_idx = torch.arange(0, vocab, step, device=device, dtype=torch.long)[:sample_count]
+            if sample_idx.numel() > 0 and sample_idx[-1].item() != vocab - 1:
+                sample_idx[-1] = vocab - 1
 
-        if idx.numel() == 0:
+        if sample_idx.numel() == 0:
             logger.warning("Cosine calibration skipped: no indices sampled")
-            return
+            return summary
 
-        base_rows = base_table.index_select(0, idx)
-        r_base = torch.median(base_rows).item()
+        base_rows = base_table.index_select(0, sample_idx)
+        cos_rows = cos_table_raw[:, sample_idx, :]
+        target_base = torch.median(base_rows).item()
+        cosine_stat = torch.median(cos_rows).item()
+        summary["median_base"] = float(target_base)
+        summary["median_cos"] = float(cosine_stat)
+    else:
+        summary["median_base"] = float(target_base)
+        summary["median_cos"] = float(cosine_stat)
 
-        cos_table = path._build_lut_distance_table(device=device, dtype=dtype)
-        cos_table = cos_table.to(device=device, dtype=dtype)
-        cos_rows = cos_table[:, idx, :]
-        r_new = torch.median(cos_rows).item()
-        if r_new <= 1e-12:
-            logger.warning(
-                "Cosine distance median too small (%.3e); skip calibration", r_new
-            )
-            return
+    if not math.isfinite(cosine_stat) or cosine_stat <= 1e-12:
+        logger.warning("Cosine calibration skipped: cosine_stat=%.3e", cosine_stat)
+        return summary
+    if not math.isfinite(target_base) or target_base <= 0.0:
+        logger.warning("Cosine calibration skipped: target_base=%.3e", target_base)
+        return summary
 
-        scale = r_base / r_new
-        path._lut_cosine_scale = float(scale)
-        logger.info(
-            "Calibrated cosine LUT scale: base=%.4e new=%.4e s=%.4f",
-            r_base,
-            r_new,
-            scale,
+    grid_entries: list[Dict[str, float]] = []
+    for t_mid in t_mids:
+        t_tensor = torch.tensor([t_mid], device=device, dtype=dtype)
+        beta_t, _ = path.beta(t_tensor)
+        beta_value = float(beta_t.item())
+        denom = max(beta_value * cosine_stat, 1e-12)
+        scale_value = target_base / denom
+        grid_entries.append(
+            {
+                "t_mid": float(t_mid),
+                "beta": beta_value,
+                "scale": scale_value,
+                "effective_neighbor": beta_value * scale_value * cosine_stat,
+                "ratio": (beta_value * scale_value * cosine_stat) / target_base,
+            }
         )
+
+    if not grid_entries:
+        return summary
+
+    summary["grid"] = grid_entries
+    applied = grid_entries[0]
+    path._lut_cosine_scale = float(applied["scale"])
+    summary["applied"] = True
+    summary["applied_scale"] = float(applied["scale"])
+    summary["applied_t_mid"] = float(applied["t_mid"])
+    summary["applied_beta"] = float(applied["beta"])
+    summary["applied_effective_neighbor"] = float(applied["effective_neighbor"])
+    summary["applied_ratio"] = float(applied["ratio"])
+
+    logger.info(
+        "Calibrated cosine LUT scale (mode=%s): base_neighbor=%.4e, raw_neighbor=%.4e, "
+        "applied_t_mid=%.3f, beta=%.4f, new_scale=%.4f, effective_neighbor=%.4e, ratio=%.4f",
+        mode,
+        target_base,
+        cosine_stat,
+        applied["t_mid"],
+        applied["beta"],
+        applied["scale"],
+        applied["effective_neighbor"],
+        applied["ratio"],
+    )
+    if len(grid_entries) > 1:
+        logger.info("t_mid grid diagnostics:")
+        for entry in grid_entries:
+            logger.info(
+                "  t_mid=%.3f -> beta=%.4f, scale=%.4f, effective_neighbor=%.4e, ratio=%.4f",
+                entry["t_mid"],
+                entry["beta"],
+                entry["scale"],
+                entry["effective_neighbor"],
+                entry["ratio"],
+            )
+
+    return summary
+
+
+def _record_cosine_calibration_summary(args, summary: Optional[Dict[str, Union[bool, float, str, list]]]) -> None:
+    if summary is None:
+        return
+    setattr(args, "_mi_lut_cosine_calibration", summary)
+    base_neighbor = summary.get("neighbor_base")
+    cos_neighbor = summary.get("neighbor_cos")
+    if isinstance(base_neighbor, float) and math.isfinite(base_neighbor):
+        setattr(args, "_mi_lut_cosine_base_neighbor", float(base_neighbor))
+    if isinstance(cos_neighbor, float) and math.isfinite(cos_neighbor):
+        setattr(args, "_mi_lut_cosine_neighbor_median", float(cos_neighbor))
+    t_values = summary.get("t_mid_values")
+    if isinstance(t_values, list):
+        setattr(args, "_mi_lut_cosine_t_mid_values", [float(t) for t in t_values if isinstance(t, (int, float))])
 
 def main(args):
     logging.basicConfig(
@@ -387,7 +492,12 @@ def main(args):
             _warm_start_cosine_lut(metric_path)
             if getattr(args, "mi_lut_cosine_calibrate", False):
                 logger.info("Calibrating cosine LUT scale against baseline distances (warm start).")
-                _calibrate_cosine_scale(metric_path)
+                summary = _calibrate_cosine_scale(
+                    metric_path,
+                    mode=str(getattr(args, "mi_lut_cosine_calibrate_mode", "neighbor")),
+                    t_mid_values=getattr(args, "mi_lut_cosine_t_mid", (0.5,)),
+                )
+                _record_cosine_calibration_summary(args, summary)
         
         # Apply loaded metric codes if available
         if loaded_metric_codes is not None:
@@ -639,7 +749,12 @@ def main(args):
         and metric_path is not None
     ):
         logger.info("Calibrating cosine LUT scale against baseline distances (post-load).")
-        _calibrate_cosine_scale(metric_path)
+        summary = _calibrate_cosine_scale(
+            metric_path,
+            mode=str(getattr(args, "mi_lut_cosine_calibrate_mode", "neighbor")),
+            t_mid_values=getattr(args, "mi_lut_cosine_t_mid", (0.5,)),
+        )
+        _record_cosine_calibration_summary(args, summary)
     if (
         beta_schedule_ema is not None
         and metric_path is not None

--- a/examples/image/train.py
+++ b/examples/image/train.py
@@ -267,6 +267,7 @@ def main(args):
                 lut_scale_baseline=float(getattr(args, "mi_lut_scale_baseline", 1.0)),
                 lut_scale_epsilon=float(getattr(args, "mi_lut_scale_epsilon", 0.25)),
                 use_normalized_distance=bool(getattr(args, "mi_use_normalized_distance", False)),
+                lut_cosine_scale=float(getattr(args, "mi_lut_cosine_scale", 1.0)),
             )
         args.mi_metric_interp_start = float(getattr(args, "mi_metric_interp_start", 0.0))
         args.mi_metric_interp_end = float(getattr(args, "mi_metric_interp_end", 1.0))

--- a/examples/image/train.py
+++ b/examples/image/train.py
@@ -76,7 +76,7 @@ def _warm_start_cosine_lut(path: MetricInducedGibbsProbPath) -> None:
         base[:, :, 1] = torch.sin(theta).unsqueeze(0).expand(C, -1)
         if D > 2:
             base[:, :, 2:] = 1e-4 * torch.randn(C, V, D - 2, device=device, dtype=dtype)
-    lut.weight.copy_(base)
+        lut.weight.copy_(base)
     logger.info("Applied cosine LUT warm start on great-circle initialization")
 
 
@@ -91,6 +91,8 @@ def _calibrate_cosine_scale(
     lut = getattr(path, "learnable_lut", None)
     if lut is None:
         return
+    if num_samples is None or num_samples <= 0:
+        num_samples = 4096
 
     device = lut.weight.device
     dtype = lut.weight.dtype
@@ -98,13 +100,31 @@ def _calibrate_cosine_scale(
 
     with torch.no_grad():
         base_table = path._get_base_distance_table(device=device, dtype=dtype)
-        idx = torch.linspace(
-            0, vocab - 1, steps=min(vocab, num_samples), device=device, dtype=torch.long
-        )
+        base_table = base_table.to(device=device, dtype=dtype)
+
+        sample_count = int(min(vocab, num_samples))
+        if sample_count < 1:
+            logger.warning("Cosine calibration skipped: num_samples < 1")
+            return
+
+        if sample_count >= vocab:
+            idx = torch.arange(vocab, device=device, dtype=torch.long)
+        else:
+            step = max(1, vocab // sample_count)
+            idx = torch.arange(0, vocab, step, device=device, dtype=torch.long)
+            idx = idx[:sample_count]
+            if idx[-1].item() != vocab - 1:
+                idx[-1] = vocab - 1
+
+        if idx.numel() == 0:
+            logger.warning("Cosine calibration skipped: no indices sampled")
+            return
+
         base_rows = base_table.index_select(0, idx)
         r_base = torch.median(base_rows).item()
 
         cos_table = path._build_lut_distance_table(device=device, dtype=dtype)
+        cos_table = cos_table.to(device=device, dtype=dtype)
         cos_rows = cos_table[:, idx, :]
         r_new = torch.median(cos_rows).item()
         if r_new <= 1e-12:

--- a/examples/image/train.py
+++ b/examples/image/train.py
@@ -113,7 +113,7 @@ def _calibrate_cosine_scale(
             step = max(1, vocab // sample_count)
             idx = torch.arange(0, vocab, step, device=device, dtype=torch.long)
             idx = idx[:sample_count]
-            if idx[-1].item() != vocab - 1:
+            if idx.numel() > 0 and idx[-1].item() != vocab - 1:
                 idx[-1] = vocab - 1
 
         if idx.numel() == 0:
@@ -141,87 +141,6 @@ def _calibrate_cosine_scale(
             r_new,
             scale,
         )
-
-def _calibrate_cosine_scale(
-    path: MetricInducedGibbsProbPath,
-    *,
-    num_samples: int = 4096,
-) -> None:
-    """Adjust cosine LUT scale so baseline and cosine distances have matched medians."""
-    if getattr(path, "metric_name", "") != "cosine":
-        return
-    lut = getattr(path, "learnable_lut", None)
-    if lut is None:
-        return
-
-    device = lut.weight.device
-    dtype = lut.weight.dtype
-    vocab = path.vocab_size
-
-    with torch.no_grad():
-        base_table = path._get_base_distance_table(device=device, dtype=dtype)
-        idx = torch.linspace(
-            0, vocab - 1, steps=min(vocab, num_samples), device=device, dtype=torch.long
-        )
-        base_rows = base_table.index_select(0, idx)
-        r_base = torch.median(base_rows).item()
-
-        cos_table = path._build_lut_distance_table(device=device, dtype=dtype)
-        cos_rows = cos_table[:, idx, :]
-        r_new = torch.median(cos_rows).item()
-
-        if r_new <= 1e-12:
-            logger.warning(
-                "Cosine distance median too small (%.3e); skip calibration", r_new
-            )
-            return
-
-        scale = r_base / r_new
-        path._lut_cosine_scale = float(scale)
-        logger.info(
-            "Calibrated cosine LUT scale: base=%.4e new=%.4e s=%.4f",
-            r_base,
-            r_new,
-            scale,
-        )
-
-def _calibrate_cosine_scale(
-    path: MetricInducedGibbsProbPath,
-    *,
-    num_samples: int = 4096,
-) -> None:
-    """Adjust cosine LUT scale so baseline and cosine distances have matched medians."""
-    if getattr(path, "metric_name", "") != "cosine":
-        return
-    lut = getattr(path, "learnable_lut", None)
-    if lut is None:
-        return
-    device = lut.weight.device
-    dtype = lut.weight.dtype
-    vocab = path.vocab_size
-    with torch.no_grad():
-        base_table = path._get_base_distance_table(device=device, dtype=dtype)
-        idx = torch.linspace(0, vocab - 1, steps=min(vocab, num_samples), device=device, dtype=torch.long)
-        base_rows = base_table.index_select(0, idx)
-        r_base = torch.median(base_rows).item()
-
-        cos_table = path._build_lut_distance_table(device=device, dtype=dtype)
-        cos_rows = cos_table[:, idx, :]
-        r_new = torch.median(cos_rows).item()
-
-        if r_new <= 1e-12:
-            logger.warning("Cosine distance median too small (%.3e); skip calibration", r_new)
-            return
-
-        scale = r_base / r_new
-        path._lut_cosine_scale = float(scale)
-        logger.info(
-            "Calibrated cosine LUT scale: base=%.4e new=%.4e s=%.4f",
-            r_base,
-            r_new,
-            scale,
-        )
-
 
 def main(args):
     logging.basicConfig(

--- a/examples/image/train.py
+++ b/examples/image/train.py
@@ -7,27 +7,23 @@
 
 """
 Path bootstrap
-Ensures the top-level 'flow_matching' package is importable when running
-this script from within 'examples/image' (e.g., via torchrun).
-"""
-import os as _os
-import sys as _sys
-from pathlib import Path as _Path
-
 _this_dir = _Path(__file__).resolve().parent
 # Go up three levels: .../flow_matching/examples/image -> .../flow_matching
 _pkg_root = _this_dir.parents[1]
 if str(_pkg_root) not in _sys.path:
     _sys.path.insert(0, str(_pkg_root))
 
+"""
+
 import datetime
 import json
 import logging
+import gc
 import os
 import sys
 import time
 from pathlib import Path
-from typing import Optional
+from typing import Dict, Optional, Union
 
 import numpy as np
 import torch
@@ -133,6 +129,62 @@ def main(args):
     metric_ema: Optional[LearnableMetricEMA] = None
     kl_controller: Optional[AdaptiveKLController] = None
     metric_path: Optional[MetricInducedGibbsProbPath] = None
+    
+    # Load metric from checkpoint if specified (before creating path)
+    loaded_metric_codes: Optional[torch.Tensor] = None
+    loaded_metric_source: str = "unknown"
+    
+    if getattr(args, "mi_init_metric_from_checkpoint", ""):
+        checkpoint_path = args.mi_init_metric_from_checkpoint
+        logger.info(f"[Freeze Metric] Loading metric from checkpoint: {checkpoint_path}")
+        checkpoint = torch.load(checkpoint_path, map_location="cpu")
+        
+        # PRIORITY 1: Try EMA teacher version first (this is what eval uses!)
+        # This ensures consistency with reported FID scores
+        if "path" in checkpoint and "learnable_metric_ema" in checkpoint["path"]:
+            ema_state = checkpoint["path"]["learnable_metric_ema"]
+            if "teacher" in ema_state and "codes" in ema_state["teacher"]:
+                loaded_metric_codes = ema_state["teacher"]["codes"]
+                loaded_metric_source = "EMA teacher"
+                logger.info(f"  ✓ Loaded EMA teacher metric codes: {loaded_metric_codes.shape}")
+                logger.info("  → This is the version used during evaluation (consistent with reported FID)")
+        
+        # PRIORITY 2: Fall back to raw student metric if no EMA
+        if loaded_metric_codes is None and "path" in checkpoint and "learnable_metric" in checkpoint["path"]:
+            metric_state = checkpoint["path"]["learnable_metric"]
+            loaded_metric_source = "raw student"
+            logger.info("  ⚠ Warning: This may differ from eval metric (EMA teacher)")
+            if "codes" in metric_state:
+                loaded_metric_codes = metric_state["codes"]
+                logger.info(f"  ✓ Loaded raw student metric codes: {loaded_metric_codes.shape}")
+        
+        # PRIORITY 3: Try model state dict
+        if loaded_metric_codes is None and "model" in checkpoint:
+            model_state = checkpoint["model"]
+            metric_keys = [k for k in model_state.keys() if "metric" in k.lower() and "codes" in k]
+            if metric_keys:
+                loaded_metric_codes = model_state[metric_keys[0]]
+                loaded_metric_source = f"model.{metric_keys[0]}"
+                logger.info(f"  ✓ Loaded metric codes from {metric_keys[0]}: {loaded_metric_codes.shape}")
+        
+        # If still not found, raise error
+        if loaded_metric_codes is None:
+            available_keys = list(checkpoint.keys())
+            if "path" in checkpoint:
+                path_keys = list(checkpoint["path"].keys())
+                raise KeyError(
+                    f"Could not find metric codes in checkpoint.\n"
+                    f"Available top-level keys: {available_keys}\n"
+                    f"Available path keys: {path_keys}"
+                )
+            else:
+                raise KeyError(f"Checkpoint structure not recognized. Available keys: {available_keys}")
+        
+        if args.mi_freeze_metric:
+            logger.info("[Freeze Metric] Metric will be FROZEN (requires_grad=False)")
+            logger.info(f"[Freeze Metric] Loaded from: {loaded_metric_source}")
+            logger.info("[Freeze Metric] Only UNet parameters will be trained")
+    
     if getattr(args, "ko_metric_induced", False):
         embed_range = "pm1" if args.mi_embed_range == "pm1" else "unit"
         if getattr(args, "mi_learnable_beta", False):
@@ -194,12 +246,27 @@ def main(args):
         args.mi_gumbel_tau_start = float(tau_start)
         args.mi_gumbel_tau_end = float(tau_end)
 
+        if getattr(args, "mi_learnable_metric", False) and getattr(args, "mi_learnable_lut", False):
+            raise ValueError("Cannot enable both --mi_learnable_metric and --mi_learnable_lut at the same time.")
+
         metric_kwargs = {}
         if getattr(args, "mi_learnable_metric", False):
             metric_kwargs.update(
                 learnable_metric_dim=int(getattr(args, "mi_metric_dim", 0)),
                 learnable_metric_diag_eps=float(getattr(args, "mi_metric_diag_eps", 1e-4)),
                 metric_interp_lambda=float(getattr(args, "mi_metric_interp_start", 0.0)),
+            )
+        if getattr(args, "mi_learnable_lut", False):
+            metric_kwargs.update(
+                learnable_lut=True,
+                lut_num_channels=int(getattr(args, "mi_lut_num_channels", 3)),
+                lut_emb_dim=int(getattr(args, "mi_lut_emb_dim", 1)),
+                lut_share_across_channels=bool(getattr(args, "mi_lut_share_channels", False)),
+                lut_renorm_to_init_norm=bool(getattr(args, "mi_lut_renorm_init_norm", False)),
+                lut_bounded_residual_scale=bool(getattr(args, "mi_lut_bounded_residual_scale", False)),
+                lut_scale_baseline=float(getattr(args, "mi_lut_scale_baseline", 1.0)),
+                lut_scale_epsilon=float(getattr(args, "mi_lut_scale_epsilon", 0.25)),
+                use_normalized_distance=bool(getattr(args, "mi_use_normalized_distance", False)),
             )
         args.mi_metric_interp_start = float(getattr(args, "mi_metric_interp_start", 0.0))
         args.mi_metric_interp_end = float(getattr(args, "mi_metric_interp_end", 1.0))
@@ -221,11 +288,37 @@ def main(args):
             gumbel_hard=True,
             **metric_kwargs,
         )
+        
+        # Apply loaded metric codes if available
+        if loaded_metric_codes is not None:
+            if metric_path.learnable_metric is not None:
+                logger.info("[Freeze Metric] Applying loaded metric codes to path...")
+                # Load the codes
+                with torch.no_grad():
+                    metric_path.learnable_metric.codes.copy_(loaded_metric_codes.to(device))
+                logger.info(f"  ✓ Metric codes loaded: {metric_path.learnable_metric.codes.shape}")
+                
+                # Freeze if requested
+                if args.mi_freeze_metric:
+                    metric_path.learnable_metric.codes.requires_grad = False
+                    logger.info("  ✓ Metric codes FROZEN (requires_grad=False)")
+                    logger.info("  → Only UNet will be trained, metric geometry is fixed")
+                    
+                    # Force lambda to 1.0 (use learned metric fully)
+                    metric_path.set_metric_interpolation_lambda(1.0)
+                    logger.info("  → Metric interpolation lambda forced to 1.0")
+            else:
+                logger.warning("[Freeze Metric] Loaded metric codes but path has no learnable_metric!")
+        
         if getattr(args, "mi_learnable_metric", False):
             metric_path.set_metric_interpolation_lambda(args.mi_metric_interp_start)
         kl_target = float(getattr(args, "mi_beta_kl_target", 0.0))
         kl_init_weight = float(getattr(args, "mi_beta_kl_init_weight", 0.0))
 
+        # Create EMA even when schedule is frozen (EMA provides smooth training target)
+        # Freeze only prevents gradient updates to raw parameters
+        freeze_schedule = getattr(args, "mi_freeze_beta_schedule", False)
+        
         if (
             getattr(args, "mi_learnable_beta", False)
             and getattr(args, "mi_beta_use_ema", False)
@@ -237,6 +330,10 @@ def main(args):
             )
             beta_schedule_ema.to(device=device)
             beta_schedule_ema.synchronize_from(metric_path.beta_schedule)
+            if freeze_schedule:
+                logger.info("Created β schedule EMA (schedule params frozen, EMA provides smooth training target)")
+            else:
+                logger.info("Created β schedule EMA (will track student schedule)")
 
         if (
             getattr(args, "mi_learnable_metric", False)
@@ -250,10 +347,13 @@ def main(args):
             metric_ema.to(device=device)
             metric_ema.synchronize_from(metric_path.learnable_metric)
 
+        # KL controller monitors EMA vs raw schedule divergence
+        # But in freeze mode, raw has no gradient → KL penalty has no effect → disable it
         if (
             kl_target > 0.0
             and kl_init_weight > 0.0
             and (beta_schedule_ema is not None or metric_ema is not None)
+            and not freeze_schedule  # Disable KL in freeze mode
         ):
             kl_controller = AdaptiveKLController(
                 target=kl_target,
@@ -264,6 +364,24 @@ def main(args):
                 max_weight=float(getattr(args, "mi_beta_kl_max_weight", 1e4)),
             )
             kl_controller.to(device=device)
+            logger.info("Enabled schedule KL trust region")
+        elif freeze_schedule and kl_target > 0.0:
+            # CHANGED: Enable KL controller even when schedule is frozen
+            # Reason: We now have learnable metric that can benefit from KL penalty
+            # The penalty will affect the metric parameters (not schedule)
+            kl_controller = AdaptiveKLController(
+                target=kl_target,
+                init_weight=kl_init_weight,
+                adapt_rate=float(getattr(args, "mi_beta_kl_adapt_rate", 2.0)),
+                tolerance=float(getattr(args, "mi_beta_kl_tolerance", 1.5)),
+                min_weight=float(getattr(args, "mi_beta_kl_min_weight", 1e-4)),
+                max_weight=float(getattr(args, "mi_beta_kl_max_weight", 1e4)),
+            )
+            kl_controller.to(device=device)
+            logger.info(
+                "Freeze mode: KL controller ENABLED (will regularize learnable metric, "
+                "even though schedule is frozen)"
+            )
 
     # define the model
     logger.info("Initializing Model")
@@ -300,28 +418,77 @@ def main(args):
     optimizer_param_groups = [{"params": list(model_without_ddp.parameters())}]
     extra_modules = {}
     if metric_path is not None:
+        freeze_schedule = getattr(args, "mi_freeze_beta_schedule", False)
+        
+        # Only add schedule parameters to optimizer if not frozen
         schedule_params = list(metric_path.schedule_parameters())
-        if schedule_params:
+        if schedule_params and not freeze_schedule:
             schedule_lr_scale = float(getattr(args, "mi_beta_lr_scale", 1.0))
             optimizer_param_groups.append(
                 {
                     "params": schedule_params,
                     "lr": args.lr * schedule_lr_scale,
+                    "name": "beta_schedule",
                 }
             )
+            logger.info(f"Added {len(schedule_params)} schedule parameters to optimizer (lr_scale={schedule_lr_scale})")
+        elif schedule_params and freeze_schedule:
+            # Freeze schedule parameters
+            for param in schedule_params:
+                param.requires_grad = False
+            logger.info(f"FROZEN {len(schedule_params)} schedule parameters (excluded from optimizer)")
+        
         metric_params = list(metric_path.metric_parameters())
         if metric_params:
-            metric_lr_scale = float(getattr(args, "mi_metric_lr_scale", 0.1))
-            optimizer_param_groups.append(
-                {
-                    "params": metric_params,
-                    "lr": args.lr * metric_lr_scale,
-                }
-            )
+            freeze_metric = getattr(args, "mi_freeze_metric", False)
+            if not freeze_metric:
+                metric_lr_scale = float(getattr(args, "mi_metric_lr_scale", 0.1))
+                metric_weight_decay = float(getattr(args, "mi_metric_weight_decay", 1e-4))
+                optimizer_param_groups.append(
+                    {
+                        "params": metric_params,
+                        "lr": args.lr * metric_lr_scale,
+                        "weight_decay": metric_weight_decay,
+                        "name": "learnable_metric",
+                    }
+                )
+                logger.info(
+                    f"Added {len(metric_params)} metric parameters to optimizer (lr_scale={metric_lr_scale}, weight_decay={metric_weight_decay})"
+                )
+            else:
+                for param in metric_params:
+                    param.requires_grad = False
+                logger.info(f"EXCLUDED {len(metric_params)} metric parameters from optimizer (frozen)")
+                logger.info("  → Only model (UNet) parameters will be optimized")
+
+        lut_params = list(metric_path.lut_parameters())
+        if lut_params:
+            freeze_lut = getattr(args, "mi_freeze_lut", False)
+            if not freeze_lut:
+                lut_lr_scale = float(getattr(args, "mi_lut_lr_scale", 0.1))
+                lut_weight_decay = float(getattr(args, "mi_lut_weight_decay", 1e-4))
+                optimizer_param_groups.append(
+                    {
+                        "params": lut_params,
+                        "lr": args.lr * lut_lr_scale,
+                        "weight_decay": lut_weight_decay,
+                        "name": "learnable_lut",
+                    }
+                )
+                logger.info(
+                    f"Added {len(lut_params)} LUT parameters to optimizer (lr_scale={lut_lr_scale}, weight_decay={lut_weight_decay})"
+                )
+            else:
+                for param in lut_params:
+                    param.requires_grad = False
+                logger.info(f"EXCLUDED {len(lut_params)} LUT parameters from optimizer (frozen)")
+                logger.info("  → Only model (UNet) parameters will be optimized")
         if isinstance(metric_path.beta_schedule, nn.Module):
             extra_modules["metric_beta_schedule"] = metric_path.beta_schedule
         if metric_path.learnable_metric is not None:
             extra_modules["metric_learnable_metric"] = metric_path.learnable_metric
+        if metric_path.learnable_lut is not None:
+            extra_modules["metric_learnable_lut"] = metric_path.learnable_lut
         if beta_schedule_ema is not None:
             extra_modules["metric_beta_schedule_ema"] = beta_schedule_ema
         if metric_ema is not None:
@@ -390,11 +557,37 @@ def main(args):
         except Exception as e:
             logger.warning(f"wandb not enabled ({e})")
 
-    logger.info(f"Start from {args.start_epoch} to {args.epochs} epochs")
+    # Compute display-only epoch mapping
+    display_offset: Optional[int] = None
+    if getattr(args, "force_display_start_epoch", None) is not None:
+        try:
+            display_offset = int(args.force_display_start_epoch) - int(args.start_epoch)
+        except Exception:
+            display_offset = None
+    elif getattr(args, "epoch_display_offset", None) is not None:
+        try:
+            display_offset = int(args.epoch_display_offset)
+        except Exception:
+            display_offset = None
+
+    if display_offset is not None:
+        logger.info(
+            f"Epoch display mapping enabled: display_epoch = epoch + ({display_offset}). "
+            f"Raw training range: [{args.start_epoch}, {args.epochs})"
+        )
+    else:
+        logger.info(f"Start from {args.start_epoch} to {args.epochs} epochs")
     start_time = time.time()
     for epoch in range(args.start_epoch, args.epochs):
+        display_epoch = epoch + (display_offset or 0)
         if args.distributed:
             data_loader_train.sampler.set_epoch(epoch)
+        
+        # Adjust metric learning rate (before training if enabled)
+        if not args.eval_only:
+            from training.train_loop import adjust_metric_learning_rate
+            adjust_metric_learning_rate(optimizer, epoch, args)
+        
         if not args.eval_only:
             train_stats = train_one_epoch(
                 model=model,
@@ -413,10 +606,12 @@ def main(args):
             log_stats = {
                 **{f"train_{k}": v for k, v in train_stats.items()},
                 "epoch": epoch,
+                "display_epoch": display_epoch,
             }
         else:
             log_stats = {
                 "epoch": epoch,
+                "display_epoch": display_epoch,
             }
 
         if args.output_dir and (
@@ -435,6 +630,27 @@ def main(args):
                     epoch=epoch,
                     extra_modules=extra_modules,
                 )
+                # Optionally create display-epoch symlink for convenience in plotting
+                try:
+                    if getattr(args, "save_display_epoch_symlinks", False) and display_offset is not None:
+                        ckpt_dir = Path(args.output_dir)
+                        src = ckpt_dir / f"checkpoint-{epoch}.pth"
+                        dst = ckpt_dir / f"checkpoint-{display_epoch}.pth"
+                        if src.exists():
+                            # Avoid overwriting real files; only make symlink if dst absent
+                            if not dst.exists():
+                                try:
+                                    # On systems without symlink perms, fall back to hardlink or copy
+                                    dst.symlink_to(src.name)
+                                except Exception:
+                                    try:
+                                        os.link(src, dst)  # type: ignore[attr-defined]
+                                    except Exception:
+                                        import shutil
+                                        shutil.copy2(src, dst)
+                            logger.info(f"Display-epoch alias created: {dst.name} -> {src.name}")
+                except Exception as _e:
+                    logger.warning(f"Could not create display-epoch alias: {_e}")
             if args.distributed:
                 data_loader_train.sampler.set_epoch(0)
             if distributed_mode.is_main_process():
@@ -443,23 +659,42 @@ def main(args):
                 )
             else:
                 fid_samples = args.fid_samples // num_tasks
-            eval_stats = eval_model(
-                model,
-                data_loader_train,
-                device,
-                epoch=epoch,
-                fid_samples=fid_samples,
-                args=args,
-                metric_path=metric_path,
-                metric_ema=metric_ema,
-            )
-            log_stats.update({f"eval_{k}": v for k, v in eval_stats.items()})
+            try:
+                eval_stats = eval_model(
+                    model,
+                    data_loader_train,
+                    device,
+                    epoch=epoch,
+                    fid_samples=fid_samples,
+                    args=args,
+                    metric_path=metric_path,
+                    metric_ema=metric_ema,
+                    schedule_ema=beta_schedule_ema,  # Pass EMA for eval
+                )
+            finally:
+                gc.collect()
+                if torch.cuda.is_available():
+                    torch.cuda.empty_cache()
+            eval_prefixed = {f"eval_{k}": v for k, v in eval_stats.items()}
+            if display_offset is not None:
+                eval_prefixed["eval_display_epoch"] = display_epoch
+            log_stats.update(eval_prefixed)
 
         # Log to wandb (only on main process)
         if wandb_run is not None and distributed_mode.is_main_process():
             try:
                 import swanlab as wandb  # type: ignore
-                wandb.log(log_stats, step=epoch)
+
+                wandb_payload: Dict[str, Union[int, float]] = {}
+                for key, value in log_stats.items():
+                    if isinstance(value, (int, float)):
+                        wandb_payload[key] = float(value)
+                    elif isinstance(value, np.generic):  # type: ignore[arg-type]
+                        wandb_payload[key] = float(value.item())
+
+                if wandb_payload:
+                    wandb_step = display_epoch if display_offset is not None else epoch
+                    wandb.log(wandb_payload, step=wandb_step)
             except Exception as e:
                 logger.warning(f"wandb.log failed: {e}")
 
@@ -489,6 +724,24 @@ if __name__ == "__main__":
     # Backward-compat: map consolidated flag to legacy alias expected elsewhere
     if not hasattr(args, "ko_metric_induced"):
         setattr(args, "ko_metric_induced", getattr(args, "metric_induced", False))
+    
+    # CRITICAL: Reset annealing step counters when resuming from baseline
+    # This ensures Gumbel tau and metric interpolation start fresh
+    # even when resuming from a checkpoint at epoch > 0
+    if args.resume:
+        setattr(args, "_gumbel_update_step", 0)
+        setattr(args, "_metric_interp_update_step", 0)
+        setattr(args, "_mi_logbeta_reg_step", 0)
+        setattr(args, "_annealing_counters_reset", True)  # Flag to prevent override
+        print(
+            "=" * 80 + "\n"
+            "RESET ANNEALING COUNTERS TO 0\n"
+            "  - Gumbel tau will anneal from start\n"
+            "  - Metric interpolation will anneal from start\n"
+            "  - Resuming from checkpoint but with fresh annealing schedules\n"
+            + "=" * 80
+        )
+    
     if args.output_dir:
         Path(args.output_dir).mkdir(parents=True, exist_ok=True)
     main(args)

--- a/examples/image/train.py
+++ b/examples/image/train.py
@@ -76,8 +76,131 @@ def _warm_start_cosine_lut(path: MetricInducedGibbsProbPath) -> None:
         base[:, :, 1] = torch.sin(theta).unsqueeze(0).expand(C, -1)
         if D > 2:
             base[:, :, 2:] = 1e-4 * torch.randn(C, V, D - 2, device=device, dtype=dtype)
-        lut.weight.copy_(base)
+    lut.weight.copy_(base)
     logger.info("Applied cosine LUT warm start on great-circle initialization")
+
+
+def _calibrate_cosine_scale(
+    path: MetricInducedGibbsProbPath,
+    *,
+    num_samples: int = 4096,
+) -> None:
+    """Adjust cosine LUT scale so baseline and cosine distances have matched medians."""
+    if getattr(path, "metric_name", "") != "cosine":
+        return
+    lut = getattr(path, "learnable_lut", None)
+    if lut is None:
+        return
+
+    device = lut.weight.device
+    dtype = lut.weight.dtype
+    vocab = path.vocab_size
+
+    with torch.no_grad():
+        base_table = path._get_base_distance_table(device=device, dtype=dtype)
+        idx = torch.linspace(
+            0, vocab - 1, steps=min(vocab, num_samples), device=device, dtype=torch.long
+        )
+        base_rows = base_table.index_select(0, idx)
+        r_base = torch.median(base_rows).item()
+
+        cos_table = path._build_lut_distance_table(device=device, dtype=dtype)
+        cos_rows = cos_table[:, idx, :]
+        r_new = torch.median(cos_rows).item()
+        if r_new <= 1e-12:
+            logger.warning(
+                "Cosine distance median too small (%.3e); skip calibration", r_new
+            )
+            return
+
+        scale = r_base / r_new
+        path._lut_cosine_scale = float(scale)
+        logger.info(
+            "Calibrated cosine LUT scale: base=%.4e new=%.4e s=%.4f",
+            r_base,
+            r_new,
+            scale,
+        )
+
+def _calibrate_cosine_scale(
+    path: MetricInducedGibbsProbPath,
+    *,
+    num_samples: int = 4096,
+) -> None:
+    """Adjust cosine LUT scale so baseline and cosine distances have matched medians."""
+    if getattr(path, "metric_name", "") != "cosine":
+        return
+    lut = getattr(path, "learnable_lut", None)
+    if lut is None:
+        return
+
+    device = lut.weight.device
+    dtype = lut.weight.dtype
+    vocab = path.vocab_size
+
+    with torch.no_grad():
+        base_table = path._get_base_distance_table(device=device, dtype=dtype)
+        idx = torch.linspace(
+            0, vocab - 1, steps=min(vocab, num_samples), device=device, dtype=torch.long
+        )
+        base_rows = base_table.index_select(0, idx)
+        r_base = torch.median(base_rows).item()
+
+        cos_table = path._build_lut_distance_table(device=device, dtype=dtype)
+        cos_rows = cos_table[:, idx, :]
+        r_new = torch.median(cos_rows).item()
+
+        if r_new <= 1e-12:
+            logger.warning(
+                "Cosine distance median too small (%.3e); skip calibration", r_new
+            )
+            return
+
+        scale = r_base / r_new
+        path._lut_cosine_scale = float(scale)
+        logger.info(
+            "Calibrated cosine LUT scale: base=%.4e new=%.4e s=%.4f",
+            r_base,
+            r_new,
+            scale,
+        )
+
+def _calibrate_cosine_scale(
+    path: MetricInducedGibbsProbPath,
+    *,
+    num_samples: int = 4096,
+) -> None:
+    """Adjust cosine LUT scale so baseline and cosine distances have matched medians."""
+    if getattr(path, "metric_name", "") != "cosine":
+        return
+    lut = getattr(path, "learnable_lut", None)
+    if lut is None:
+        return
+    device = lut.weight.device
+    dtype = lut.weight.dtype
+    vocab = path.vocab_size
+    with torch.no_grad():
+        base_table = path._get_base_distance_table(device=device, dtype=dtype)
+        idx = torch.linspace(0, vocab - 1, steps=min(vocab, num_samples), device=device, dtype=torch.long)
+        base_rows = base_table.index_select(0, idx)
+        r_base = torch.median(base_rows).item()
+
+        cos_table = path._build_lut_distance_table(device=device, dtype=dtype)
+        cos_rows = cos_table[:, idx, :]
+        r_new = torch.median(cos_rows).item()
+
+        if r_new <= 1e-12:
+            logger.warning("Cosine distance median too small (%.3e); skip calibration", r_new)
+            return
+
+        scale = r_base / r_new
+        path._lut_cosine_scale = float(scale)
+        logger.info(
+            "Calibrated cosine LUT scale: base=%.4e new=%.4e s=%.4f",
+            r_base,
+            r_new,
+            scale,
+        )
 
 
 def main(args):
@@ -323,6 +446,9 @@ def main(args):
             and (not getattr(args, "resume", "") or getattr(args, "mi_lut_force_warm_start", False))
         ):
             _warm_start_cosine_lut(metric_path)
+            if getattr(args, "mi_lut_cosine_calibrate", False):
+                logger.info("Calibrating cosine LUT scale against baseline distances (warm start).")
+                _calibrate_cosine_scale(metric_path)
         
         # Apply loaded metric codes if available
         if loaded_metric_codes is not None:
@@ -568,6 +694,13 @@ def main(args):
     ):
         logger.info("Forcing cosine LUT warm start after loading checkpoint.")
         _warm_start_cosine_lut(metric_path)
+    if (
+        getattr(args, "mi_metric", "lp") == "cosine"
+        and getattr(args, "mi_lut_cosine_calibrate", False)
+        and metric_path is not None
+    ):
+        logger.info("Calibrating cosine LUT scale against baseline distances (post-load).")
+        _calibrate_cosine_scale(metric_path)
     if (
         beta_schedule_ema is not None
         and metric_path is not None

--- a/examples/image/train_arg_parser.py
+++ b/examples/image/train_arg_parser.py
@@ -405,6 +405,14 @@ def get_args_parser():
         ),
     )
     parser.add_argument(
+        "--mi_lut_force_warm_start",
+        action="store_true",
+        help=(
+            "Force cosine LUT warm start even when resuming from a checkpoint. "
+            "Useful when finetuning a 1D baseline on higher-dimensional cosine geometry."
+        ),
+    )
+    parser.add_argument(
         "--mi_freeze_lut",
         action="store_true",
         help="Freeze the learnable LUT parameters (requires_grad=False).",

--- a/examples/image/train_arg_parser.py
+++ b/examples/image/train_arg_parser.py
@@ -541,6 +541,52 @@ def get_args_parser():
         ),
     )
     parser.add_argument(
+        "--mi_lut_param_mode",
+        default="none",
+        choices=["none", "line2d", "arc2d"],
+        help=(
+            "Optional geometric parameterization for learnable LUT. "
+            "'line2d' constrains embeddings to a monotone line in a 2D subspace "
+            "(stable warm start, expandable); 'arc2d' uses a monotone spherical arc; "
+            "'none' keeps the original free-form LUT."
+        ),
+    )
+    parser.add_argument(
+        "--mi_lut_monotone_mode",
+        default="softplus",
+        choices=["softplus"],
+        help="Monotone parameterization mode for the 1D curve (currently only 'softplus').",
+    )
+    parser.add_argument(
+        "--mi_lut_arc_radius",
+        default=1.0,
+        type=float,
+        help="Base radius used for arc2d parameterization (per-channel learnable).",
+    )
+    parser.add_argument(
+        "--mi_lut_reg_align",
+        default=0.0,
+        type=float,
+        help="Regularizer weight for neighbor alignment (1 - cos(E_i, E_{i+1})).",
+    )
+    parser.add_argument(
+        "--mi_lut_reg_step",
+        default=0.0,
+        type=float,
+        help="Regularizer weight for step consistency max(0, -cos(ΔE_i, ΔE_{i+1})).",
+    )
+    parser.add_argument(
+        "--mi_lut_reg_curvature",
+        default=0.0,
+        type=float,
+        help="Regularizer weight for second-order smoothness ||Δ^2E_i||_2^2.",
+    )
+    parser.add_argument(
+        "--mi_lut_geometry_log",
+        action="store_true",
+        help="Enable detailed LUT geometry logging/diagnostics during training.",
+    )
+    parser.add_argument(
         "--mi_lp",
         default=3.0,
         type=float,

--- a/examples/image/train_arg_parser.py
+++ b/examples/image/train_arg_parser.py
@@ -405,6 +405,11 @@ def get_args_parser():
         ),
     )
     parser.add_argument(
+        "--mi_lut_cosine_calibrate",
+        action="store_true",
+        help="Calibrate cosine LUT scale against baseline distances after load (optional).",
+    )
+    parser.add_argument(
         "--mi_lut_force_warm_start",
         action="store_true",
         help=(

--- a/examples/image/train_arg_parser.py
+++ b/examples/image/train_arg_parser.py
@@ -332,6 +332,24 @@ def get_args_parser():
         help="Number of time samples to evaluate when exporting β(t) snapshots.",
     )
     parser.add_argument(
+        "--mi_logbeta_min",
+        default=None,
+        type=float,
+        help=(
+            "Lower bound for uniform log-β sampling when using the exponential spline schedule. "
+            "Defaults to log β evaluated at t=mi_t_eps if unspecified."
+        ),
+    )
+    parser.add_argument(
+        "--mi_logbeta_max",
+        default=None,
+        type=float,
+        help=(
+            "Upper bound for uniform log-β sampling when using the exponential spline schedule. "
+            "Defaults to log β evaluated at t=1-mi_t_eps if unspecified."
+        ),
+    )
+    parser.add_argument(
         "--mi_beta_use_ema",
         action="store_true",
         help="Track an exponential moving average teacher of the learnable β(t) schedule",

--- a/examples/image/train_arg_parser.py
+++ b/examples/image/train_arg_parser.py
@@ -109,12 +109,6 @@ def get_args_parser():
         help="Symmetric term coefficient for discrete sampling (mixture or metric-induced).",
     )
     parser.add_argument(
-        "--temp",
-        default=1.0,
-        type=float,
-        help="Temperature for sampling the discrete flow.",
-    )
-    parser.add_argument(
         "--sym_func",
         action="store_true",
         help="Use a fixed function for the symmetric term in the discrete sampler.",
@@ -173,6 +167,29 @@ def get_args_parser():
         "--save_fid_samples",
         action="store_true",
         help="Save all samples generated for FID computation.",
+    )
+    parser.add_argument(
+        "--save_eval_gif",
+        action="store_true",
+        help="Save GIF animations of sampling trajectories during evaluation.",
+    )
+    parser.add_argument(
+        "--eval_gif_max_batch",
+        default=8,
+        type=int,
+        help="Maximum number of samples to tile in an evaluation GIF.",
+    )
+    parser.add_argument(
+        "--eval_gif_stride",
+        default=16,
+        type=int,
+        help="Stride applied when subsampling trajectory frames for GIF logging.",
+    )
+    parser.add_argument(
+        "--eval_gif_fps",
+        default=8,
+        type=int,
+        help="Playback speed (frames per second) for saved evaluation GIFs.",
     )
     parser.add_argument("--num_workers", default=10, type=int)
     parser.add_argument(
@@ -409,6 +426,61 @@ def get_args_parser():
         default=0.999,
         type=float,
         help="Decay applied to the learnable metric EMA updates.",
+    )
+    parser.add_argument(
+        "--mi_metric_eval_geometry",
+        action="store_true",
+        help=(
+            "When using a metric-induced path, compute geometry agreement diagnostics "
+            "(Spearman correlation, k-NN overlap, optional heatmaps) during evaluation."
+        ),
+    )
+    parser.add_argument(
+        "--mi_metric_eval_subset",
+        default=0,
+        type=int,
+        help=(
+            "Optional number of tokens to include when probing metric geometry. "
+            "Set to 0 to evaluate the full vocabulary."
+        ),
+    )
+    parser.add_argument(
+        "--mi_metric_eval_pair_samples",
+        default=0,
+        type=int,
+        help=(
+            "Optional number of off-diagonal pairs sampled when computing Spearman "
+            "correlation. Set to 0 to use all pairs."
+        ),
+    )
+    parser.add_argument(
+        "--mi_metric_eval_knn_k",
+        default=5,
+        type=int,
+        help="Neighborhood size k used for the k-NN overlap diagnostic.",
+    )
+    parser.add_argument(
+        "--mi_metric_eval_seed",
+        default=0,
+        type=int,
+        help="Seed for any random subsampling performed by the metric geometry probes.",
+    )
+    parser.add_argument(
+        "--mi_metric_eval_heatmap",
+        action="store_true",
+        help=(
+            "Export baseline/learned/difference heatmaps for the probed token subset "
+            "during metric geometry evaluation (requires matplotlib)."
+        ),
+    )
+    parser.add_argument(
+        "--mi_metric_eval_heatmap_subset",
+        default=64,
+        type=int,
+        help=(
+            "Maximum number of tokens visualized in metric heatmaps. "
+            "Set to 0 to reuse the evaluation subset size."
+        ),
     )
     parser.add_argument(
         "--mi_metric_interp_start",

--- a/examples/image/train_arg_parser.py
+++ b/examples/image/train_arg_parser.py
@@ -376,6 +376,71 @@ def get_args_parser():
         ),
     )
     parser.add_argument(
+        "--mi_logbeta_reg_delta_weight",
+        default=0.0,
+        type=float,
+        help=(
+            "Weight for the first-order smoothness penalty on log β knots (∑(Δℓ/Δs)^2)."
+        ),
+    )
+    parser.add_argument(
+        "--mi_logbeta_reg_delta2_weight",
+        default=0.0,
+        type=float,
+        help=(
+            "Weight for the second-order smoothness penalty on log β knots (∑(Δ^2ℓ/Δs^2)^2)."
+        ),
+    )
+    parser.add_argument(
+        "--mi_logbeta_reg_power",
+        default=0.0,
+        type=float,
+        help=(
+            "Power-law exponent for reweighting log β knot penalties; positive values emphasize central knots."
+        ),
+    )
+    parser.add_argument(
+        "--mi_logbeta_endpoint_weight",
+        default=0.0,
+        type=float,
+        help=(
+            "Weight for penalizing the spline endpoint slopes to prevent exploding dℓ/dt near t ∈ {0,1}."
+        ),
+    )
+    parser.add_argument(
+        "--mi_logbeta_reg_anneal_steps",
+        default=0,
+        type=int,
+        help=(
+            "Number of optimizer steps to linearly anneal the log β smoothness penalties towards zero."
+        ),
+    )
+    parser.add_argument(
+        "--mi_logbeta_trunc_t",
+        default=None,
+        type=float,
+        help=(
+            "Optional truncation applied to the sampling domain; restrict t to [mi_logbeta_trunc_t, 1-mi_logbeta_trunc_t] "
+            "when drawing log-β proposals (must be greater than mi_t_eps)."
+        ),
+    )
+    parser.add_argument(
+        "--mi_logbeta_band_t_lo",
+        default=None,
+        type=float,
+        help=(
+            "Lower cutoff in t-space for computing the active log-β sampling range."
+        ),
+    )
+    parser.add_argument(
+        "--mi_logbeta_band_t_hi",
+        default=None,
+        type=float,
+        help=(
+            "Upper cutoff in t-space for computing the active log-β sampling range."
+        ),
+    )
+    parser.add_argument(
         "--mi_logbeta_mis_alpha",
         default=0.3,
         type=float,

--- a/examples/image/train_arg_parser.py
+++ b/examples/image/train_arg_parser.py
@@ -169,6 +169,15 @@ def get_args_parser():
             "Set this flag to use the raw student metric for evaluation (actual trained version)."
         ),
     )
+    parser.add_argument(
+        "--mi_eval_cache_lut",
+        action="store_true",
+        help=(
+            "Precompute and cache learnable LUT distance tables during evaluation. "
+            "This speeds up sampling when learnable LUT embeddings have dim > 1; "
+            "training continues to recompute distances each step."
+        ),
+    )
 
     parser.add_argument(
         "--start_epoch",
@@ -317,7 +326,7 @@ def get_args_parser():
     parser.add_argument(
         "--mi_metric",
         default="lp",
-        choices=["lp", "cosine"],
+        choices=["lp", "euclidean", "cosine"],
         type=str,
         help="Metric to use for the metric-induced path.",
     )
@@ -387,6 +396,15 @@ def get_args_parser():
         ),
     )
     parser.add_argument(
+        "--mi_lut_cosine_scale",
+        default=1.0,
+        type=float,
+        help=(
+            "Scale factor s applied to cosine LUT distance (dist = s * (1 - cos)). "
+            "Only used when --mi_metric=cosine."
+        ),
+    )
+    parser.add_argument(
         "--mi_freeze_lut",
         action="store_true",
         help="Freeze the learnable LUT parameters (requires_grad=False).",
@@ -402,6 +420,31 @@ def get_args_parser():
         default=1e-4,
         type=float,
         help="Weight decay applied to learnable LUT parameters.",
+    )
+    parser.add_argument(
+        "--mi_lut_kl_weight",
+        default=0.0,
+        type=float,
+        help=(
+            "KL trust-region weight to keep learned LUT-induced p_t close to the baseline geometry. "
+            "Computes KL(p_base || p_learned) at the sampled t and adds it to the loss."
+        ),
+    )
+    parser.add_argument(
+        "--mi_lut_kl_t_lo",
+        default=None,
+        type=float,
+        help=(
+            "Optional lower t-bound for LUT KL penalty (only apply when t in [lo, hi])."
+        ),
+    )
+    parser.add_argument(
+        "--mi_lut_kl_t_hi",
+        default=None,
+        type=float,
+        help=(
+            "Optional upper t-bound for LUT KL penalty (only apply when t in [lo, hi])."
+        ),
     )
     parser.add_argument(
         "--mi_lut_init_method",

--- a/examples/image/train_arg_parser.py
+++ b/examples/image/train_arg_parser.py
@@ -350,6 +350,15 @@ def get_args_parser():
         ),
     )
     parser.add_argument(
+        "--mi_logbeta_mis_alpha",
+        default=0.3,
+        type=float,
+        help=(
+            "Mixture coefficient α for MIS between uniform-t and log-β proposals. "
+            "Set to 0 to disable; recommended range is [0.1, 0.5]."
+        ),
+    )
+    parser.add_argument(
         "--mi_beta_use_ema",
         action="store_true",
         help="Track an exponential moving average teacher of the learnable β(t) schedule",

--- a/examples/image/train_arg_parser.py
+++ b/examples/image/train_arg_parser.py
@@ -220,6 +220,32 @@ def get_args_parser():
     )
 
     parser.add_argument(
+        "--cosine_attention",
+        action="store_true",
+        help="L2-normalize Q and K before computing attention logits (cosine attention).",
+    )
+    parser.add_argument(
+        "--no_cosine_attention",
+        action="store_false",
+        dest="cosine_attention",
+        help="Disable cosine attention (default).",
+    )
+    parser.set_defaults(cosine_attention=False)
+
+    parser.add_argument(
+        "--head_weight_norm",
+        action="store_true",
+        help="Apply per-forward RMS normalization to the output head weights.",
+    )
+    parser.add_argument(
+        "--no_head_weight_norm",
+        action="store_false",
+        dest="head_weight_norm",
+        help="Disable output head weight normalization (default).",
+    )
+    parser.set_defaults(head_weight_norm=False)
+
+    parser.add_argument(
         "--discrete_fm_steps",
         default=1024,
         type=int,
@@ -359,6 +385,25 @@ def get_args_parser():
         ),
     )
     parser.add_argument(
+        "--mi_infer_grid",
+        default="uniform_t",
+        choices=["uniform_t", "uniform_logbeta"],
+        type=str,
+        help=(
+            "Time grid used by the metric-induced evaluator. "
+            "'uniform_logbeta' builds a grid uniform in log β."
+        ),
+    )
+    parser.add_argument(
+        "--mi_infer_steps",
+        default=None,
+        type=int,
+        help=(
+            "Number of intervals for the inference grid. "
+            "Defaults to --discrete_fm_steps when unspecified."
+        ),
+    )
+    parser.add_argument(
         "--mi_beta_use_ema",
         action="store_true",
         help="Track an exponential moving average teacher of the learnable β(t) schedule",
@@ -413,6 +458,41 @@ def get_args_parser():
         default=1e4,
         type=float,
         help="Upper clamp for the adaptive schedule KL weight.",
+    )
+    parser.add_argument(
+        "--diag_enable",
+        action="store_true",
+        help="Run stability diagnostics (weights, activations, attention) during evaluation.",
+    )
+    parser.add_argument(
+        "--diag_checkpoint",
+        action="append",
+        default=[],
+        help="Checkpoint path to include in diagnostics. Provide multiple times for a sequence.",
+    )
+    parser.add_argument(
+        "--diag_batch_size",
+        default=32,
+        type=int,
+        help="Batch size used for activation diagnostics hooks.",
+    )
+    parser.add_argument(
+        "--diag_time",
+        default=0.5,
+        type=float,
+        help="Time value in [0,1] used when probing activations for diagnostics.",
+    )
+    parser.add_argument(
+        "--diag_power_iters",
+        default=8,
+        type=int,
+        help="Number of power-iteration steps for spectral norm estimation.",
+    )
+    parser.add_argument(
+        "--diag_output_dir",
+        default=None,
+        type=str,
+        help="Optional override for the diagnostics CSV output directory.",
     )
     parser.add_argument(
         "--mi_beta_lr_scale",

--- a/examples/image/train_arg_parser.py
+++ b/examples/image/train_arg_parser.py
@@ -410,6 +410,26 @@ def get_args_parser():
         help="Calibrate cosine LUT scale against baseline distances after load (optional).",
     )
     parser.add_argument(
+        "--mi_lut_cosine_calibrate_mode",
+        default="neighbor",
+        choices=("neighbor", "median"),
+        help=(
+            "Cosine scale calibration mode. 'neighbor' matches adjacent-token distances "
+            "(recommended); 'median' matches the full-table medians (legacy behavior)."
+        ),
+    )
+    parser.add_argument(
+        "--mi_lut_cosine_t_mid",
+        nargs="+",
+        type=float,
+        default=[0.3, 0.5, 0.7],
+        help=(
+            "One or more reference t values in (0,1) used when calibrating the cosine scale. "
+            "The first value sets the applied scale; all values are logged for diagnostics. "
+            "Default: 0.3 0.5 0.7."
+        ),
+    )
+    parser.add_argument(
         "--mi_lut_force_warm_start",
         action="store_true",
         help=(

--- a/examples/image/train_arg_parser.py
+++ b/examples/image/train_arg_parser.py
@@ -141,6 +141,34 @@ def get_args_parser():
     )
     parser.add_argument("--seed", default=0, type=int)
     parser.add_argument("--resume", default="", help="resume from checkpoint")
+    parser.add_argument(
+        "--mi_init_metric_from_checkpoint",
+        default="",
+        type=str,
+        help=(
+            "Path to checkpoint (.pt/.pth) to initialize the learnable metric from. "
+            "Only loads the metric codes, not the model or optimizer. "
+            "Use with --mi_freeze_metric to freeze the loaded metric."
+        ),
+    )
+    parser.add_argument(
+        "--mi_freeze_metric",
+        action="store_true",
+        help=(
+            "Freeze the learnable metric (set requires_grad=False). "
+            "Typically used with --mi_init_metric_from_checkpoint to load a pre-trained metric "
+            "and only train the UNet. This tests if UNet can adapt to a fixed metric geometry."
+        ),
+    )
+    parser.add_argument(
+        "--mi_eval_use_raw_metric",
+        action="store_true",
+        help=(
+            "Use raw student metric (instead of EMA teacher) during evaluation. "
+            "By default, evaluation uses EMA metric if available (smoother, more stable). "
+            "Set this flag to use the raw student metric for evaluation (actual trained version)."
+        ),
+    )
 
     parser.add_argument(
         "--start_epoch",
@@ -148,6 +176,33 @@ def get_args_parser():
         type=int,
         metavar="N",
         help="start epoch (used when resumed from checkpoint)",
+    )
+    # Display-only epoch mapping (does NOT affect training control flow)
+    parser.add_argument(
+        "--epoch_display_offset",
+        default=None,
+        type=int,
+        help=(
+            "Additive offset for display epoch: display_epoch = epoch + offset. "
+            "This only affects logs/metrics/optional symlinks, not sampler, eval triggers, or resume."
+        ),
+    )
+    parser.add_argument(
+        "--force_display_start_epoch",
+        default=None,
+        type=int,
+        help=(
+            "Override to force the first displayed epoch after resume to this value. "
+            "Effective offset will be computed as (force_display_start_epoch - start_epoch)."
+        ),
+    )
+    parser.add_argument(
+        "--save_display_epoch_symlinks",
+        action="store_true",
+        help=(
+            "When saving checkpoints, also create a symlink named with the display epoch number "
+            "(e.g., checkpoint-4499.pth -> checkpoint-5499.pth)."
+        ),
     )
     parser.add_argument(
         "--eval_only", action="store_true", help="No training, only run evaluation"
@@ -265,6 +320,109 @@ def get_args_parser():
         choices=["lp", "cosine"],
         type=str,
         help="Metric to use for the metric-induced path.",
+    )
+    parser.add_argument(
+        "--mi_learnable_lut",
+        action="store_true",
+        help="Enable a learnable per-channel scalar LUT inside the metric-induced path.",
+    )
+    parser.add_argument(
+        "--mi_lut_num_channels",
+        default=3,
+        type=int,
+        help="Number of channels (e.g., 3 for RGB) when using a learnable LUT.",
+    )
+    parser.add_argument(
+        "--mi_lut_emb_dim",
+        default=1,
+        type=int,
+        help="Embedding dimension for learnable LUT (1=scalar, >1=vector embeddings).",
+    )
+    parser.add_argument(
+        "--mi_lut_share_channels",
+        action="store_true",
+        help="Share a single LUT across all channels (instead of one per channel).",
+    )
+    parser.add_argument(
+        "--mi_lut_renorm_init_norm",
+        action="store_true",
+        help=(
+            "Renormalize LUT weights to the initialization Frobenius norm every forward pass. "
+            "Preserves gradients and keeps the effective geometry aligned with the linear init."
+        ),
+    )
+    parser.add_argument(
+        "--mi_lut_bounded_residual_scale",
+        action="store_true",
+        help=(
+            "Use bounded residual scale parameterization: s = s_0 * (1 + ε * tanh(c)). "
+            "c is learnable per channel, L2 penalty keeps it near 0. "
+            "Trust region approach prevents extreme scale changes."
+        ),
+    )
+    parser.add_argument(
+        "--mi_lut_scale_baseline",
+        default=1.0,
+        type=float,
+        help="Baseline scale s_0 in bounded residual parameterization.",
+    )
+    parser.add_argument(
+        "--mi_lut_scale_epsilon",
+        default=0.25,
+        type=float,
+        help="Maximum deviation ε in bounded residual parameterization (s ∈ [s_0*(1-ε), s_0*(1+ε)]).",
+    )
+    parser.add_argument(
+        "--mi_lut_scale_penalty_weight",
+        default=0.01,
+        type=float,
+        help="L2 penalty weight on scale parameter c to keep it near 0.",
+    )
+    parser.add_argument(
+        "--mi_use_normalized_distance",
+        action="store_true",
+        help=(
+            "Use normalized distance: \tilde d = ||E[v]-E[x_1]||_2 / \sqrt{m} "
+            "where m is the embedding dimension."
+        ),
+    )
+    parser.add_argument(
+        "--mi_freeze_lut",
+        action="store_true",
+        help="Freeze the learnable LUT parameters (requires_grad=False).",
+    )
+    parser.add_argument(
+        "--mi_lut_lr_scale",
+        default=0.1,
+        type=float,
+        help="Learning rate scale applied to learnable LUT parameters.",
+    )
+    parser.add_argument(
+        "--mi_lut_weight_decay",
+        default=1e-4,
+        type=float,
+        help="Weight decay applied to learnable LUT parameters.",
+    )
+    parser.add_argument(
+        "--mi_lut_init_method",
+        default="linear",
+        choices=["linear", "small_noise_qr"],
+        type=str,
+        help=(
+            "Initialization method for learnable LUT weights. "
+            "'linear': Standard linear spacing with small noise (default). "
+            "'small_noise_qr': QR decomposition with controlled noise for high-dim embeddings."
+        ),
+    )
+    parser.add_argument(
+        "--mi_lut_init_noise_scale",
+        default=0.01,
+        type=float,
+        help=(
+            "Noise scale for small_noise_qr initialization. "
+            "Controls perturbation strength in higher dimensions (σ parameter). "
+            "Recommended: 0.01-0.05 for balanced warm start vs orthogonality."
+        ),
     )
     parser.add_argument(
         "--mi_lp",
@@ -450,6 +608,83 @@ def get_args_parser():
         ),
     )
     parser.add_argument(
+        "--mi_logbeta_eval_alpha",
+        default=None,
+        type=float,
+        help=(
+            "Mixture coefficient α for evaluation grid when using uniform_logbeta. "
+            "If None, uses the training value from --mi_logbeta_mis_alpha. "
+            "Set to 0 for pure log-β sampling, 0.5 for balanced 50-50 mix, "
+            "1.0 for pure uniform-t sampling."
+        ),
+    )
+    parser.add_argument(
+        "--mi_logbeta_sampling_strategy",
+        default="uniform",
+        choices=["uniform", "log_normal_broad", "log_normal_focused"],
+        type=str,
+        help=(
+            "Sampling strategy in log-β space for uniform_logbeta grid. "
+            "'uniform': uniform distribution in log-β. "
+            "'log_normal_broad': Gaussian centered on full interval (μ=0, σ=2.5 for [-5,5]). "
+            "'log_normal_focused': Gaussian concentrated on informative region (auto-computed)."
+        ),
+    )
+    parser.add_argument(
+        "--mi_logbeta_lognormal_mu",
+        default=None,
+        type=float,
+        help=(
+            "Mean (μ) of log-normal distribution in log-β space. "
+            "If None: auto-computed based on strategy. "
+            "  - 'broad': μ = (ℓ_max + ℓ_min) / 2 (center of full interval). "
+            "  - 'focused': μ = center of informative region in log-β. "
+            "Manual override: set explicit value (e.g., 0.0 for β=1)."
+        ),
+    )
+    parser.add_argument(
+        "--mi_logbeta_lognormal_sigma",
+        default=None,
+        type=float,
+        help=(
+            "Standard deviation (σ) of log-normal distribution in log-β space. "
+            "If None: auto-computed based on strategy. "
+            "  - 'broad': σ = (ℓ_max - ℓ_min) / 4 (4σ covers full interval). "
+            "  - 'focused': σ = (informative_width) / 2 (1σ covers informative). "
+            "Manual override: set explicit value (e.g., 2.5 for broad coverage)."
+        ),
+    )
+    parser.add_argument(
+        "--mi_logbeta_informative_H_min_ratio",
+        default=0.2,
+        type=float,
+        help=(
+            "Lower bound of informative region as ratio of H_max. "
+            "Informative region: H ∈ [ratio_min × H_max, ratio_max × H_max]. "
+            "Used for auto-computing focused log-normal parameters."
+        ),
+    )
+    parser.add_argument(
+        "--mi_logbeta_informative_H_max_ratio",
+        default=0.8,
+        type=float,
+        help=(
+            "Upper bound of informative region as ratio of H_max. "
+            "Informative region: H ∈ [ratio_min × H_max, ratio_max × H_max]. "
+            "Used for auto-computing focused log-normal parameters."
+        ),
+    )
+    parser.add_argument(
+        "--mi_logbeta_use_is",
+        action="store_true",
+        help=(
+            "Enable importance sampling (IS) for log-β proposals. "
+            "When disabled (default), samples are drawn from log-β distribution "
+            "without reweighting (logbeta_weights = None). "
+            "When enabled, applies IS weights: w(β) = 1/q(β)."
+        ),
+    )
+    parser.add_argument(
         "--mi_infer_grid",
         default="uniform_t",
         choices=["uniform_t", "uniform_logbeta"],
@@ -525,6 +760,21 @@ def get_args_parser():
         help="Upper clamp for the adaptive schedule KL weight.",
     )
     parser.add_argument(
+        "--mi_geodesic_energy_weight",
+        default=0.0,
+        type=float,
+        help=(
+            "Weight (λ) for geodesic energy regularization in metric-induced path training. "
+            "Penalizes ||v_t||²_M where v_t is the velocity in the learned metric embedding space. "
+            "This encourages smoother, lower-energy trajectories that follow geodesics under the "
+            "learned Mahalanobis metric, reducing entropy of intermediate distributions p(x_t|x_1,t). "
+            "Recommended values: 0.01-0.1 (start conservative, e.g., 0.05). "
+            "Expected effects: 10-20%% entropy reduction (target: 4.3 → 3.5-4.0), improved FID. "
+            "Set to 0.0 to disable. The penalty is scaled by the current metric interpolation λ, "
+            "so it only applies when the learned metric is active (λ > 0)."
+        ),
+    )
+    parser.add_argument(
         "--diag_enable",
         action="store_true",
         help="Run stability diagnostics (weights, activations, attention) during evaluation.",
@@ -566,6 +816,15 @@ def get_args_parser():
         help="Relative learning rate scale applied to the β schedule parameter group.",
     )
     parser.add_argument(
+        "--mi_freeze_beta_schedule",
+        action="store_true",
+        help=(
+            "Freeze the β schedule parameters during training (no gradient updates). "
+            "When enabled, schedule EMA and KL controller are disabled. "
+            "Use this to train only the UNet with a fixed schedule."
+        ),
+    )
+    parser.add_argument(
         "--mi_learnable_metric",
         action="store_true",
         help="Enable a learnable Mahalanobis metric for the metric-induced path.",
@@ -587,6 +846,12 @@ def get_args_parser():
         default=0.1,
         type=float,
         help="Relative learning rate scale applied to the learnable metric parameter group.",
+    )
+    parser.add_argument(
+        "--mi_metric_weight_decay",
+        default=0.0,
+        type=float,
+        help="Weight decay (L2 regularization) applied to learnable metric parameters.",
     )
     parser.add_argument(
         "--mi_metric_use_ema",
@@ -655,10 +920,73 @@ def get_args_parser():
         ),
     )
     parser.add_argument(
+        "--mi_metric_detailed_analysis",
+        action="store_true",
+        help=(
+            "Run comprehensive metric analysis during evaluation including "
+            "t-SNE/UMAP visualizations, distance distributions, and nearest neighbors. "
+            "This provides deep insights into what the metric learned."
+        ),
+    )
+    parser.add_argument(
+        "--mi_metric_use_umap",
+        action="store_true",
+        default=False,
+        help=(
+            "Use UMAP for dimensionality reduction in detailed metric analysis. "
+            "UMAP is faster and better preserves global structure than t-SNE. "
+            "Enabled by default when --mi_metric_detailed_analysis is set."
+        ),
+    )
+    parser.add_argument(
+        "--mi_metric_use_tsne",
+        action="store_true",
+        default=False,
+        help=(
+            "Use t-SNE for dimensionality reduction in detailed metric analysis. "
+            "t-SNE emphasizes local structure and clusters. "
+            "Enabled by default when --mi_metric_detailed_analysis is set."
+        ),
+    )
+    parser.add_argument(
         "--mi_metric_interp_start",
         default=0.0,
         type=float,
         help="Initial interpolation weight between the fixed Lp distance and the learned metric.",
+    )
+    parser.add_argument(
+        "--mi_metric_lr_decay_start",
+        default=3500,
+        type=int,
+        help=(
+            "Epoch to start decaying the metric learning rate. "
+            "This allows the metric to stabilize while UNet continues adapting. "
+            "Default: 3500 (75%% of 4500 epoch training)."
+        ),
+    )
+    parser.add_argument(
+        "--mi_metric_lr_decay_mode",
+        default="cosine",
+        type=str,
+        choices=["cosine", "exp", "step", "none"],
+        help=(
+            "Learning rate decay schedule for the metric parameters. "
+            "cosine: smooth cosine annealing (recommended), "
+            "exp: exponential decay, "
+            "step: step-wise decay at fixed epochs, "
+            "none: no decay. "
+            "Default: cosine."
+        ),
+    )
+    parser.add_argument(
+        "--mi_metric_lr_decay_end_ratio",
+        default=0.1,
+        type=float,
+        help=(
+            "Final learning rate ratio for metric parameters at the end of training. "
+            "With cosine/exp decay, the metric LR will decay from base_lr to base_lr*end_ratio. "
+            "Default: 0.1 (decay to 10%%)."
+        ),
     )
     parser.add_argument(
         "--mi_metric_interp_end",

--- a/examples/image/train_arg_parser.py
+++ b/examples/image/train_arg_parser.py
@@ -430,6 +430,46 @@ def get_args_parser():
         ),
     )
     parser.add_argument(
+        "--mi_lut_cosine_entropy_match",
+        action="store_true",
+        help=(
+            "Match cosine LUT scale to a weighted baseline conditional-entropy target using bisection. "
+            "Runs after warm start / distance calibration."
+        ),
+    )
+    parser.add_argument(
+        "--mi_lut_cosine_entropy_t_mid",
+        nargs="+",
+        type=float,
+        default=[0.3, 0.5, 0.7],
+        help=(
+            "Reference t values for entropy matching (default: 0.3 0.5 0.7). "
+            "Weights are supplied via --mi_lut_cosine_entropy_weights."
+        ),
+    )
+    parser.add_argument(
+        "--mi_lut_cosine_entropy_weights",
+        nargs="+",
+        type=float,
+        default=[0.2, 0.6, 0.2],
+        help=(
+            "Weights (non-negative) for each t_mid during entropy matching. "
+            "If a single value is provided, it is broadcast to all t_mid entries."
+        ),
+    )
+    parser.add_argument(
+        "--mi_lut_cosine_entropy_tol",
+        type=float,
+        default=0.01,
+        help="Relative tolerance |H_cos - H_base| / H_base for entropy matching (default: 0.01).",
+    )
+    parser.add_argument(
+        "--mi_lut_cosine_entropy_max_iter",
+        type=int,
+        default=12,
+        help="Maximum bisection iterations for entropy matching (default: 12).",
+    )
+    parser.add_argument(
         "--mi_lut_force_warm_start",
         action="store_true",
         help=(

--- a/examples/image/training/embedding.md
+++ b/examples/image/training/embedding.md
@@ -1,0 +1,131 @@
+# Implementation Detail Doc — 1-D Per-Channel LUT for Metric-Induced Path (CIFAR-10)
+
+## Scope (the “simplest setting”)
+
+Goal: replace the baseline scalar embedding `emb(x)=2x/255−1` used **inside the probability path** with a **learned 1-D per-channel lookup table (LUT)**, with:
+
+* **No regularizers** (first test),
+* **Linear initialization** (start equal to the baseline mapping),
+* **Factorized per-channel path** (256-way categorical per channel, not joint RGB),
+* Clear mechanics for **computing distances during sampling**.
+
+This document only touches the **probability path** (p_t)—architecture (U-Net) can remain as in the Dhariwal–Nichol U-Net variant commonly used for diffusion, and, if you later follow DFM’s CIFAR-10 wiring (token embedding input, per-channel categorical head), that is orthogonal to this path definition. ([Proceedings of Machine Learning Research][1])
+
+---
+
+## Notation & setup
+
+* Pixel at site (i) has channels (x_i=(R_i,G_i,B_i)), each (x_{ic}\in{0,\dots,255}).
+* For each channel (c\in{R,G,B}) we learn a **scalar** embedding table
+  (E_c:{0,\dots,255}\rightarrow\mathbb{R}) (shape (256\times 1)).
+  Collectively, (E) has shape ((3,256,1)).
+* The **metric-induced conditional path** (factorized per channel) is
+  [
+  p_t(x_{ic}=v\mid x_{1,ic}) ;\propto; \exp\big(-\beta(t),d_c(v, x_{1,ic})\big),\quad v\in{0,\dots,255},
+  ]
+  where (d_c(v,x)=\big|,E_c[v]-E_c[x],\big|) (one-dimensional absolute difference).
+  (In one dimension, all (\ell_p) norms reduce to the absolute value; if you later want a “sharper” distance with 1-D embeddings, you would explicitly use (|\cdot|^p) as a design choice, not a norm.)
+* **Scheduler**: use your chosen (\beta(t)) (e.g., power-law). DFM emphasizes that **general probability paths** and schedules are valid; the velocity model is trained against the path you choose. ([arXiv][2])
+
+Why token-wise (per-channel) is standard: discrete diffusion/flow papers shape transitions/paths at the **symbol level** (e.g., 256-way image tokens) via structured distances/embeddings, rather than a joint RGB categorical over (256^3). ([NeurIPS Papers][3])
+
+---
+
+## Component 1 — The LUTs (what they are)
+
+* **Definition**: three tables (E_R,E_G,E_B), each length 256 with 1 scalar per token (total parameters (3\times256)).
+* **Initialization (linear)**:
+  [
+  E_c[v] \leftarrow 2\frac{v}{255}-1,\quad v=0,\dots,255,
+  ]
+  reproduced per channel. This **exactly matches** the baseline scalar embedding at step 0. (You can add a mask entry later if you adopt mask-based training; that would be a 257th entry as done in DFM for architecture—but the **path** here is unchanged.) ([NeurIPS 会议录][4])
+* **Training**: treat (E) as learnable parameters updated by your main optimizer (same LR as the model is fine for a first run).
+
+---
+
+## Component 2 — Distance used by the path (per channel)
+
+For a given pixel/channel, define the **scalar** distance:
+[
+d_c(v,x);=;\big|;E_c[v]-E_c[x];\big|.
+]
+
+* Because (E_c[\cdot]\in\mathbb{R}), (\ell_p) collapses to (|\cdot|). If you later need a distinct “(p)” effect without increasing dimension, you must raise the absolute to a power (design choice), or increase the embedding dimension (D>1) and use a true (\ell_p) in (\mathbb{R}^D).
+* Keeping it **1-D** is the simplest, least invasive variant and aligns with DFM’s spirit of flexible probability paths without complicating normalization. ([NeurIPS Papers][3])
+
+---
+
+## Component 3 — Computing logits & sampling during training
+
+You need to **sample (x_t)** from the path to feed the network during training (teacher forcing / conditional sampling). For each channel (c), at time (t):
+
+### Inputs
+
+* (x_{1,ic}) at each spatial site (i) (the “clean” token for channel (c)),
+* Time (t) (scalar or per-batch),
+* LUT (E_c) (length-256 vector of scalars),
+* Scheduler (\beta(t)).
+
+### Steps (vectorized over batch/spatial)
+
+1. **Gather center embedding per site**
+   (e_{\text{ctr}}(i) \leftarrow E_c[x_{1,ic}]) producing a tensor of shape ((B,H,W,1)) for channel (c).
+2. **Prepare candidate embeddings**
+   (e_{\text{cand}}(v) \leftarrow E_c[v]) for all (v=0,\dots,255), arranged as ((1,1,1,256,1)) so it broadcasts against all sites.
+3. **Compute distances to all candidates**
+   [
+   d(i,v);=;\big|,e_{\text{cand}}(v)-e_{\text{ctr}}(i),\big|
+   \quad\Rightarrow\quad d\in\mathbb{R}^{B\times H\times W\times 256}.
+   ]
+4. **Convert to logits with the scheduler**
+   [
+   \text{logits}(i,v) \leftarrow -\beta(t)\cdot d(i,v).
+   ]
+   (Broadcast (\beta(t)) to ((B,1,1,1)) as needed.)
+5. **Normalize & sample**
+   Apply softmax over the **256 candidates** (the channel’s vocabulary) to get (p_t(\cdot\mid x_{1,ic})), then draw one sample per site.
+
+   * If you use Gumbel noise for hard sampling, inject it **before** argmax (Gumbel-Max trick).
+   * This mirrors token-wise categorical sampling used in discrete diffusion/flow (e.g., structured transition matrices in D3PM; mask-based discrete models). ([NeurIPS Papers][3])
+
+Repeat the same for (c\in{R,G,B}) and assemble (x_t=(x_{tR},x_{tG},x_{tB})).
+
+**Complexity**: per channel, you compute 256 distances per pixel. This is the standard **256-way categorical** cost used by discrete models and is tractable on CIFAR-10. ([NeurIPS Papers][3])
+
+---
+
+## What **doesn’t** change
+
+* **Factorization**: Path remains **per-channel**, not joint RGB; you are not normalizing over (256^3). This is consistent with discrete diffusion practice where transitions/paths operate at the token level with structured geometry. ([NeurIPS Papers][3])
+* **Network**: Your U-Net body, loss, and training loop stay the same. If you later adopt DFM’s CIFAR-10 U-Net wiring (replace first layer with an input token-embedding and widen the head to output per-channel categoricals), that is **architectural** and compatible with this path; the two ideas are decoupled. ([NeurIPS 会议录][4])
+* **Objectives**: Use your existing discrete FM/DFM training objective. DFM’s framework explicitly allows **general probability paths** like this metric-induced Gibbs path. ([arXiv][2])
+
+---
+
+## Sanity checklist for the first run (no regularizers)
+
+* **Initialization** reproduces the baseline: check that (E_c[v]=2v/255-1) at step 0 and that distance histograms match the original path.
+* **Scheduler range**: verify (\beta(t)) is numerically stable near (t\in(0,1)) (clamp if needed).
+* **Sampling entropy**: measure the entropy of (p_t(\cdot\mid x_{1c})) at a few (t) values; if it collapses (too peaky) or explodes (too flat), adjust (\beta(t)) scale before considering any regularizers. (DFM highlights sensitivity to path/scheduler choices—monitoring the path’s effective support is good practice.) ([arXiv][2])
+
+---
+
+## References / context
+
+* **Discrete Flow Matching (DFM)** — general probability paths; CIFAR-10 architectural edits (token embedding input; per-channel categorical head). ([arXiv][2])
+* **D3PM** — structured discrete diffusion with token-wise transition matrices shaped by embedding-space neighborhoods and absorbing states (conceptual precedent for embedding-shaped token distances). ([NeurIPS Papers][3])
+* **U-Net baseline** (Dhariwal & Nichol 2021) — the common diffusion U-Net backbone referenced by DFM for CIFAR-10 setups. ([Proceedings of Machine Learning Research][1])
+
+---
+
+### TL;DR
+
+* **What you add**: three 1-D LUTs (E_R,E_G,E_B) (linear init).
+* **What you change**: the **distance** inside the Gibbs path becomes (|E_c[v]-E_c[x_{1c}]|) per channel.
+* **How you sample**: compute 256 distances → logits (-\beta(t)\cdot d) → softmax (per channel) → sample.
+* **Everything else stays** the same. This is the smallest, cleanest way to learn a better token geometry for the path—fully aligned with DFM/D3PM’s discrete-token view. ([arXiv][2])
+
+[1]: https://proceedings.mlr.press/v139/nichol21a/nichol21a.pdf?utm_source=chatgpt.com "Improved Denoising Diffusion Probabilistic Models"
+[2]: https://arxiv.org/abs/2407.15595?utm_source=chatgpt.com "[2407.15595] Discrete Flow Matching"
+[3]: https://papers.neurips.cc/paper/2021/file/958c530554f78bcd8e97125b70e6973d-Paper.pdf?utm_source=chatgpt.com "Structured Denoising Diffusion Models in Discrete State- ..."
+[4]: https://proceedings.neurips.cc/paper_files/paper/2024/file/f0d629a734b56a642701bba7bc8bb3ed-Paper-Conference.pdf?utm_source=chatgpt.com "Discrete Flow Matching"

--- a/examples/image/training/eval_loop.py
+++ b/examples/image/training/eval_loop.py
@@ -24,7 +24,7 @@ import math
 import os
 from argparse import Namespace
 from pathlib import Path
-from typing import Callable, Iterable, Optional, Union, cast
+from typing import Callable, Dict, Iterable, Optional, Union, cast
 
 import PIL.Image
 
@@ -38,6 +38,7 @@ def _autocast_cuda():
     except Exception:  # pragma: no cover
         return torch.cuda.amp.autocast()
 from flow_matching.path import MixtureDiscreteProbPath, MetricInducedGibbsProbPath
+from flow_matching.path.metric_ema import LearnableMetricEMA
 from flow_matching.path.scheduler import PolynomialConvexScheduler
 from flow_matching.solver import MixtureDiscreteEulerSolver, KODiscreteGibbsEulerSolver
 from flow_matching.solver.ode_solver import ODESolver
@@ -47,7 +48,7 @@ from models.ema import EMA
 from torch.nn.modules import Module
 from torch.nn.parallel import DistributedDataParallel
 from torchmetrics.image.fid import FrechetInceptionDistance
-from torchvision.utils import save_image
+from torchvision.utils import save_image, make_grid
 from training import distributed_mode
 from training.edm_time_discretization import get_time_discretization
 from training.train_loop import MASK_TOKEN
@@ -56,6 +57,430 @@ logger = logging.getLogger(__name__)
 
 PRINT_FREQUENCY = 50
 
+
+def _save_sampling_gif(
+    trajectories: torch.Tensor,
+    output_root: Path,
+    epoch: int,
+    step: int,
+    *,
+    is_discrete: bool,
+    max_batch: int,
+    stride: int,
+    fps: int,
+    log_to_wandb: bool,
+    wandb_step: int,
+) -> Optional[Path]:
+    """Persist a GIF visualizing sampling trajectories as a tiled grid."""
+
+    if trajectories.ndim < 4:
+        logger.debug(
+            "Skipping GIF export because trajectory tensor has unexpected rank %d",
+            trajectories.ndim,
+        )
+        return None
+
+    max_batch = max(1, int(max_batch))
+    stride = max(1, int(stride))
+    fps = max(1, int(fps))
+
+    frames = trajectories.detach().to(device="cpu", dtype=torch.float32)[::stride]
+    if frames.shape[0] == 0:
+        logger.debug("Skipping GIF export because no frames remain after striding")
+        return None
+
+    frames = frames[:, :max_batch]
+    if frames.shape[1] == 0:
+        logger.debug(
+            "Skipping GIF export because max_batch=%d removed all samples", max_batch
+        )
+        return None
+
+    if frames.ndim == 4:
+        frames = frames.unsqueeze(2)
+
+    if is_discrete:
+        frames = frames / 255.0
+    else:
+        frames = torch.clamp(frames, -1.0, 1.0) * 0.5 + 0.5
+    frames = torch.clamp(frames, 0.0, 1.0)
+
+    num_samples = frames.shape[1]
+    nrow = int(math.sqrt(num_samples))
+    if nrow * nrow < num_samples:
+        nrow += 1
+    nrow = max(1, nrow)
+
+    frame_images = []
+    for frame in frames:
+        grid = make_grid(frame, nrow=nrow, padding=2)
+        if grid.shape[0] == 1:
+            grid = grid.repeat(3, 1, 1)
+        elif grid.shape[0] == 2:
+            grid = torch.cat((grid, grid[:1]), dim=0)
+        elif grid.shape[0] > 3:
+            grid = grid[:3]
+        grid = torch.clamp(grid, 0.0, 1.0)
+        grid_np = (
+            (grid * 255.0)
+            .round()
+            .to(torch.uint8)
+            .permute(1, 2, 0)
+            .cpu()
+            .numpy()
+        )
+        frame_images.append(PIL.Image.fromarray(grid_np))
+
+    if not frame_images:
+        logger.debug("Skipping GIF export because no frame images were generated")
+        return None
+
+    gif_dir = output_root / "gifs"
+    gif_dir.mkdir(parents=True, exist_ok=True)
+    gif_path = gif_dir / f"epoch_{epoch:04d}_step_{step:04d}.gif"
+    duration_ms = max(1, int(1000 / fps))
+    frame_images[0].save(
+        gif_path,
+        save_all=True,
+        append_images=frame_images[1:],
+        duration=duration_ms,
+        loop=0,
+    )
+
+    if log_to_wandb:
+        try:
+            try:
+                import swanlab as wandb  # type: ignore
+            except Exception:  # pragma: no cover - swanlab not installed
+                import wandb  # type: ignore
+
+            if hasattr(wandb, "Video"):
+                wandb.log(  # type: ignore[attr-defined]
+                    {
+                        "eval/sample_gif": wandb.Video(  # type: ignore[attr-defined]
+                            str(gif_path), fps=fps, format="gif"
+                        )
+                    },
+                    step=wandb_step,
+                )
+        except Exception as wandb_exc:  # pragma: no cover - wandb unavailable
+            logger.debug("Unable to log evaluation GIF to wandb: %s", wandb_exc)
+
+    logger.info("Saved evaluation GIF to %s", gif_path)
+    return gif_path
+
+
+def _select_metric_eval_indices(vocab_size: int, subset: int) -> torch.Tensor:
+    subset = int(subset)
+    if subset <= 0 or subset >= vocab_size:
+        return torch.arange(vocab_size, dtype=torch.long)
+    return torch.arange(subset, dtype=torch.long)
+
+
+def _upper_triangle_values(matrix: torch.Tensor) -> torch.Tensor:
+    if matrix.ndim != 2 or matrix.shape[0] != matrix.shape[1]:
+        raise ValueError("matrix must be square")
+    n = matrix.shape[0]
+    if n <= 1:
+        return matrix.new_empty(0)
+    idx = torch.triu_indices(n, n, offset=1, device=matrix.device)
+    return matrix[idx[0], idx[1]]
+
+
+def _rankdata(values: torch.Tensor) -> torch.Tensor:
+    order = torch.argsort(values, stable=True)
+    ranks = torch.empty_like(values, dtype=torch.float64)
+    ranks[order] = torch.arange(values.numel(), dtype=torch.float64, device=values.device)
+    unique_vals, inverse, counts = torch.unique(
+        values, sorted=True, return_inverse=True, return_counts=True
+    )
+    if torch.any(counts > 1):
+        cumsum = torch.cumsum(counts, dim=0)
+        start = torch.cat((counts.new_zeros(1), cumsum[:-1]), dim=0)
+        avg = (start + cumsum - 1).to(torch.float64) / 2.0
+        ranks += avg[inverse] - ranks
+    return ranks
+
+
+def _spearman_corrcoef(x: torch.Tensor, y: torch.Tensor) -> Optional[float]:
+    if x.numel() != y.numel() or x.numel() < 2:
+        return None
+    x_rank = _rankdata(x)
+    y_rank = _rankdata(y)
+    x_rank = x_rank - x_rank.mean()
+    y_rank = y_rank - y_rank.mean()
+    x_std = x_rank.std(unbiased=False)
+    y_std = y_rank.std(unbiased=False)
+    denom = x_std * y_std
+    denom_val = float(denom.item()) if denom.numel() == 1 else float(denom)
+    if denom_val <= 0.0 or not math.isfinite(denom_val):
+        return None
+    cov = torch.mean(x_rank * y_rank)
+    cov_val = float(cov.item()) if cov.numel() == 1 else float(cov)
+    if not math.isfinite(cov_val):
+        return None
+    return cov_val / denom_val
+
+
+def _knn_indices(dist: torch.Tensor, k: int) -> Optional[torch.Tensor]:
+    if dist.ndim != 2 or dist.shape[0] != dist.shape[1]:
+        raise ValueError("dist must be square")
+    n = dist.shape[0]
+    if n <= 1 or k <= 0:
+        return None
+    k = min(k, n - 1)
+    dist_clone = dist.clone()
+    eye = torch.eye(n, dtype=torch.bool, device=dist_clone.device)
+    dist_clone[eye] = float("inf")
+    _, indices = torch.topk(dist_clone, k=k, dim=1, largest=False)
+    return indices
+
+
+def _knn_overlap(base: torch.Tensor, other: torch.Tensor, k: int) -> Optional[float]:
+    base_idx = _knn_indices(base, k)
+    other_idx = _knn_indices(other, k)
+    if base_idx is None or other_idx is None:
+        return None
+    n = base_idx.shape[0]
+    device = base_idx.device
+    mask_base = torch.zeros(n, base.shape[0], dtype=torch.bool, device=device)
+    rows = torch.arange(n, device=device).unsqueeze(1).expand_as(base_idx)
+    mask_base[rows, base_idx] = True
+    mask_other = torch.zeros_like(mask_base)
+    mask_other[rows, other_idx] = True
+    intersection = torch.logical_and(mask_base, mask_other).sum(dim=1)
+    union = torch.logical_or(mask_base, mask_other).sum(dim=1).clamp_min(1)
+    overlap = (intersection.to(torch.float64) / union.to(torch.float64)).mean()
+    return float(overlap.item())
+
+
+def _export_metric_heatmap(
+    base: torch.Tensor,
+    other: torch.Tensor,
+    *,
+    output_dir: Path,
+    epoch: int,
+    label: str,
+    log_to_wandb: bool,
+    wandb_step: int,
+) -> Optional[Path]:
+    try:
+        import matplotlib.pyplot as plt
+    except Exception as exc:  # pragma: no cover - matplotlib optional
+        logger.warning(
+            "Skipping metric heatmap for %s because matplotlib is unavailable: %s",
+            label,
+            exc,
+        )
+        return None
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    base_np = base.detach().cpu().numpy()
+    other_np = other.detach().cpu().numpy()
+    delta_np = other_np - base_np
+
+    fig, axes = plt.subplots(1, 3, figsize=(12, 4))
+    for ax, data, title in zip(
+        axes,
+        (base_np, other_np, delta_np),
+        ("baseline", label, f"{label} - baseline"),
+    ):
+        im = ax.imshow(data, cmap="magma")
+        ax.set_title(title)
+        ax.set_xticks([])
+        ax.set_yticks([])
+        fig.colorbar(im, ax=ax, fraction=0.046, pad=0.04)
+
+    fig.suptitle(f"Metric geometry ({label}) epoch {epoch}")
+    fig.tight_layout()
+
+    file_path = output_dir / f"epoch_{epoch:04d}_{label}.png"
+    fig.savefig(file_path, bbox_inches="tight")
+    plt.close(fig)
+
+    if log_to_wandb:
+        try:
+            try:
+                import swanlab as wandb  # type: ignore
+            except Exception:  # pragma: no cover - swanlab not installed
+                import wandb  # type: ignore
+
+            if hasattr(wandb, "Image"):
+                wandb.log(  # type: ignore[attr-defined]
+                    {f"eval/metric_heatmap_{label}": wandb.Image(str(file_path))},  # type: ignore[attr-defined]
+                    step=wandb_step,
+                )
+        except Exception as wandb_exc:  # pragma: no cover - wandb unavailable
+            logger.debug(
+                "Unable to log metric heatmap %s to wandb: %s", label, wandb_exc
+            )
+
+    logger.info("Saved metric heatmap (%s) to %s", label, file_path)
+    return file_path
+
+
+def _evaluate_metric_geometry(
+    path: MetricInducedGibbsProbPath,
+    *,
+    args: Namespace,
+    epoch: int,
+    metric_ema: Optional[LearnableMetricEMA],
+    output_root: Optional[Path],
+) -> Dict[str, float]:
+    stats: Dict[str, float] = {}
+    vocab_size = int(path.vocab_size)
+    subset_cfg = int(getattr(args, "mi_metric_eval_subset", 0))
+    subset_idx = _select_metric_eval_indices(vocab_size, subset_cfg)
+    subset_count = int(subset_idx.numel())
+
+    stats["metric_geom_vocab"] = float(vocab_size)
+    stats["metric_geom_tokens"] = float(subset_count)
+    lam = float(path.get_metric_interpolation_lambda())
+    stats["metric_geom_lambda"] = lam
+
+    eval_device = torch.device("cpu")
+    eval_dtype = torch.float32
+
+    base_full = path._get_base_distance_table(device=eval_device, dtype=eval_dtype)
+    base_subset = (
+        base_full.index_select(0, subset_idx)
+        .index_select(1, subset_idx)
+        .to(dtype=torch.float64)
+    )
+
+    tables: Dict[str, torch.Tensor] = {}
+    student_full = path._scaled_learned_distance_table(
+        device=eval_device, dtype=eval_dtype
+    )
+    if student_full is not None:
+        tables["student"] = (
+            student_full.index_select(0, subset_idx)
+            .index_select(1, subset_idx)
+            .to(dtype=torch.float64)
+        )
+
+    teacher_module = getattr(metric_ema, "teacher", None) if metric_ema else None
+    if isinstance(teacher_module, torch.nn.Module):
+        teacher_full = path._scaled_learned_distance_table(
+            device=eval_device,
+            dtype=eval_dtype,
+            metric_module=teacher_module,
+        )
+        if teacher_full is not None:
+            tables["teacher"] = (
+                teacher_full.index_select(0, subset_idx)
+                .index_select(1, subset_idx)
+                .to(dtype=torch.float64)
+            )
+
+    if lam > 0.0:
+        if "student" in tables:
+            if lam >= 1.0:
+                tables["blended"] = tables["student"]
+            else:
+                tables["blended"] = (
+                    (1.0 - lam) * base_subset + lam * tables["student"]
+                )
+        else:
+            tables["blended"] = base_subset
+
+    base_pairs_all = _upper_triangle_values(base_subset)
+    pair_total = int(base_pairs_all.numel())
+    stats["metric_geom_pairs_total"] = float(pair_total)
+
+    pair_sample_cfg = max(0, int(getattr(args, "mi_metric_eval_pair_samples", 0)))
+    sample_indices = None
+    if pair_total >= 2 and 0 < pair_sample_cfg < pair_total:
+        generator = torch.Generator(device=base_pairs_all.device)
+        generator.manual_seed(int(getattr(args, "mi_metric_eval_seed", 0)))
+        perm = torch.randperm(pair_total, generator=generator)
+        sample_indices = perm[:pair_sample_cfg]
+        stats["metric_geom_pairs_used"] = float(sample_indices.numel())
+    else:
+        stats["metric_geom_pairs_used"] = float(pair_total)
+
+    if pair_total < 2:
+        logger.warning(
+            "Not enough off-diagonal pairs (%d) to compute Spearman correlation.",
+            pair_total,
+        )
+    else:
+        base_pairs = (
+            base_pairs_all
+            if sample_indices is None
+            else base_pairs_all.index_select(0, sample_indices)
+        )
+        for name, table in tables.items():
+            other_pairs = _upper_triangle_values(table)
+            if sample_indices is not None:
+                other_pairs = other_pairs.index_select(0, sample_indices)
+            rho = _spearman_corrcoef(base_pairs, other_pairs)
+            if rho is not None:
+                stats[f"metric_geom_spearman_{name}"] = rho
+
+    k_cfg = max(0, int(getattr(args, "mi_metric_eval_knn_k", 5)))
+    if subset_count > 1 and k_cfg > 0:
+        k_eff = min(k_cfg, subset_count - 1)
+        stats["metric_geom_knn_k"] = float(k_eff)
+        for key in ("student", "teacher", "blended"):
+            table = tables.get(key)
+            if table is None:
+                continue
+            overlap = _knn_overlap(base_subset, table, k_eff)
+            if overlap is not None:
+                stats[f"metric_geom_knn_overlap_{key}@{k_eff}"] = overlap
+    else:
+        stats["metric_geom_knn_k"] = 0.0
+
+    if getattr(args, "mi_metric_eval_heatmap", False):
+        if output_root is None:
+            logger.warning(
+                "Skipping metric geometry heatmaps because --output_dir is not set."
+            )
+        elif subset_count < 2:
+            logger.warning(
+                "Skipping metric geometry heatmaps because the evaluated subset has < 2 tokens."
+            )
+        else:
+            heatmap_limit = int(getattr(args, "mi_metric_eval_heatmap_subset", 0))
+            heatmap_count = (
+                subset_count if heatmap_limit <= 0 else min(heatmap_limit, subset_count)
+            )
+            heatmap_dir = output_root / "metric_geometry"
+            base_heatmap = base_subset[:heatmap_count, :heatmap_count].to(torch.float32)
+            for key in ("student", "teacher"):
+                table = tables.get(key)
+                if table is None:
+                    continue
+                _export_metric_heatmap(
+                    base_heatmap,
+                    table[:heatmap_count, :heatmap_count].to(torch.float32),
+                    output_dir=heatmap_dir,
+                    epoch=epoch,
+                    label=key,
+                    log_to_wandb=bool(getattr(args, "wandb", False)),
+                    wandb_step=epoch,
+                )
+
+    metric_keys = [
+        key
+        for key in stats.keys()
+        if key.startswith("metric_geom_spearman")
+        or key.startswith("metric_geom_knn_overlap")
+    ]
+    if metric_keys:
+        summary = ", ".join(
+            f"{key}={stats[key]:.4f}" for key in sorted(metric_keys)
+        )
+        logger.info(
+            "Metric geometry diagnostics (tokens=%d, λ=%.4f): %s",
+            subset_count,
+            lam,
+            summary,
+        )
+
+    return stats
 
 class CFGScaledModel(ModelWrapper):
     def __init__(self, model: Module, return_logits: bool = False):
@@ -112,6 +537,7 @@ def eval_model(
     fid_samples: int,
     args: Namespace,
     metric_path: Optional[MetricInducedGibbsProbPath] = None,
+    metric_ema: Optional[LearnableMetricEMA] = None,
 ):
     gc.collect()
     cfg_scaled_model = CFGScaledModel(model=model)
@@ -146,7 +572,9 @@ def eval_model(
     )
 
     num_synthetic = 0
+    num_real = 0
     snapshots_saved = False
+    gif_logged = False
     if args.output_dir:
         (Path(args.output_dir) / "snapshots").mkdir(parents=True, exist_ok=True)
 
@@ -160,6 +588,38 @@ def eval_model(
     ko_solver = None
     ko_path = metric_path
     schedule_snapshot_logged = False
+    geometry_stats: Dict[str, float] = {}
+    geometry_logged = False
+
+    def maybe_run_metric_geometry(path_obj: Optional[MetricInducedGibbsProbPath]) -> None:
+        nonlocal geometry_logged, geometry_stats
+        if geometry_logged:
+            return
+        if not getattr(args, "mi_metric_eval_geometry", False):
+            geometry_logged = True
+            return
+        if path_obj is None:
+            return
+        if not distributed_mode.is_main_process():
+            geometry_logged = True
+            return
+
+        output_root = (
+            Path(getattr(args, "output_dir"))
+            if getattr(args, "output_dir", None)
+            else None
+        )
+        try:
+            geometry_stats = _evaluate_metric_geometry(
+                path_obj,
+                args=args,
+                epoch=epoch,
+                metric_ema=metric_ema,
+                output_root=output_root,
+            )
+        except Exception as geom_exc:  # pragma: no cover - diagnostic failures
+            logger.warning("Metric geometry evaluation failed: %s", geom_exc)
+        geometry_logged = True
 
     def maybe_log_schedule_snapshot(path_obj: MetricInducedGibbsProbPath) -> None:
         nonlocal schedule_snapshot_logged
@@ -292,17 +752,50 @@ def eval_model(
 
     if ko_path is not None:
         maybe_log_schedule_snapshot(ko_path)
+        maybe_run_metric_geometry(ko_path)
 
     for data_iter_step, (samples, labels) in enumerate(data_loader):
         samples = samples.to(device, non_blocking=True)
         labels = labels.to(device, non_blocking=True)
-        fid_metric.update(samples, real=True)
 
-        if num_synthetic < fid_samples:
+        # Limit the contribution of real samples so we do not process more than fid_samples
+        remaining_real = max(fid_samples - num_real, 0)
+        real_batch = samples
+        real_labels = labels
+        if remaining_real <= 0:
+            real_batch = samples[:0]
+            real_labels = labels[:0]
+        elif real_batch.shape[0] > remaining_real:
+            real_batch = real_batch[:remaining_real]
+            real_labels = real_labels[:remaining_real]
+
+        if real_batch.shape[0] > 0:
+            fid_metric.update(real_batch, real=True)
+            num_real += real_batch.shape[0]
+
+        remaining_fake = max(fid_samples - num_synthetic, 0)
+        conditioning_samples = real_batch if real_batch.shape[0] > 0 else samples
+        conditioning_labels = real_labels if real_labels.shape[0] > 0 else labels
+        if remaining_fake <= 0:
+            conditioning_samples = conditioning_samples[:0]
+            conditioning_labels = conditioning_labels[:0]
+        elif conditioning_samples.shape[0] > remaining_fake:
+            conditioning_samples = conditioning_samples[:remaining_fake]
+            conditioning_labels = conditioning_labels[:remaining_fake]
+
+        if conditioning_samples.shape[0] > 0 and num_synthetic < fid_samples:
             # Reset NFE counter on the wrapper that will actually be used
             # For mixture/continuous branches we use cfg_scaled_model; for metric-induced we use cfg_scaled_logits_model
             # Note: metric-induced branch performs a dummy forward to infer K; we reset AFTER that to avoid +1 in the count
             cfg_scaled_model.reset_nfe_counter()
+            record_gif = (
+                bool(getattr(args, "save_eval_gif", False))
+                and bool(getattr(args, "output_dir", None))
+                and not gif_logged
+                and distributed_mode.is_main_process()
+            )
+            gif_trajectories: Optional[torch.Tensor] = None
+
             if args.discrete_flow_matching:
                 # Discrete sampling
                 if args.sym_func:
@@ -313,6 +806,7 @@ def eval_model(
                     sym: Union[float, Callable[[float], float]] = sym_schedule
                 else:
                     sym: Union[float, Callable[[float], float]] = float(args.sym)
+
                 if getattr(args, "metric_induced", False):
                     # Metric-induced Gibbs path using dedicated KO solver
                     # Lazily build logits-wrapper and KO solver with correct vocab size K
@@ -320,13 +814,15 @@ def eval_model(
                         cfg_scaled_logits_model = CFGScaledModel(model=model, return_logits=True)
                     if ko_solver is None or ko_path is None:
                         # infer K by one forward pass at t=0
-                        x_dummy = torch.zeros(samples.shape, dtype=torch.long, device=device)
+                        x_dummy = torch.zeros(
+                            conditioning_samples.shape, dtype=torch.long, device=device
+                        )
                         # IMPORTANT: do not apply CFG scaling with discrete logits
                         logits_dummy = cfg_scaled_logits_model(
                             x=x_dummy,
                             t=torch.tensor(0.0, device=device),
                             cfg_scale=0.0,
-                            label=labels,
+                            label=conditioning_labels,
                         )
                         K = int(logits_dummy.shape[-1])
                         # Build path
@@ -355,48 +851,72 @@ def eval_model(
                                 dtype=torch.float32,
                             )
                         maybe_log_schedule_snapshot(ko_path)
+                        maybe_run_metric_geometry(ko_path)
                         ko_solver = KODiscreteGibbsEulerSolver(
                             model=cfg_scaled_logits_model,
                             path=ko_path,
                             vocabulary_size=K,
                         )
                     # Reset NFE counter on the logits wrapper before stepping to avoid counting the dummy forward
-                    cfg_scaled_logits_model.reset_nfe_counter()
+                    if cfg_scaled_logits_model is not None:
+                        cfg_scaled_logits_model.reset_nfe_counter()
                     # Start tokens: uniform over [0, K) since β(0)=0 ⇒ p0 is uniform
                     K_init = ko_solver.vocabulary_size
-                    x_0 = torch.randint(0, K_init, samples.shape, device=device, dtype=torch.long)
+                    x_0 = torch.randint(
+                        0,
+                        K_init,
+                        conditioning_samples.shape,
+                        device=device,
+                        dtype=torch.long,
+                    )
                     dtype_cat = torch.float32 if args.sampling_dtype == "float32" else torch.float64
-                    synthetic_samples = ko_solver.sample(
+                    sample_result = ko_solver.sample(
                         x_init=x_0,
                         step_size=1.0 / args.discrete_fm_steps,
                         dtype_categorical=dtype_cat,
-                        label=labels,
+                        label=conditioning_labels,
                         # IMPORTANT: disable CFG scaling when using discrete logits
                         cfg_scale=0.0,
                         symmetrize=sym,
+                        return_intermediates=record_gif,
                     )
+                    if record_gif:
+                        gif_trajectories = sample_result
+                        synthetic_samples = sample_result[-1]
+                    else:
+                        synthetic_samples = sample_result
                 else:
                     x_0 = (
-                        torch.zeros(samples.shape, dtype=torch.long, device=device)
+                        torch.zeros(
+                            conditioning_samples.shape, dtype=torch.long, device=device
+                        )
                         + MASK_TOKEN
                     )
                     dtype = torch.float32 if args.sampling_dtype == "float32" else torch.float64
 
                     # Guard against missing solver (should never be None in this branch)
                     assert disc_solver is not None, "Discrete solver not initialized"
-                    synthetic_samples = disc_solver.sample(
+                    sample_result = disc_solver.sample(
                         x_init=x_0,
                         step_size=1.0 / args.discrete_fm_steps,
                         verbose=False,
                         div_free=sym,
                         dtype_categorical=dtype,
-                        label=labels,
+                        label=conditioning_labels,
                         # Disable CFG scaling for discrete models (logits)
                         cfg_scale=0.0,
+                        return_intermediates=record_gif,
                     )
+                    if record_gif:
+                        gif_trajectories = sample_result
+                        synthetic_samples = sample_result[-1]
+                    else:
+                        synthetic_samples = sample_result
             else:
                 # Continuous sampling
-                x_0 = torch.randn(samples.shape, dtype=torch.float32, device=device)
+                x_0 = torch.randn(
+                    conditioning_samples.shape, dtype=torch.float32, device=device
+                )
 
                 # Safe defaults for ODE options
                 nfe_default = 50
@@ -421,22 +941,26 @@ def eval_model(
 
                 # Guard against missing solver
                 assert cont_solver is not None, "Continuous solver not initialized"
-                synthetic_samples = cont_solver.sample(
+                sample_result = cont_solver.sample(
                     time_grid=time_grid,
                     x_init=x_0,
                     method=args.ode_method,
-                    return_intermediates=False,
+                    return_intermediates=record_gif,
                     atol=ode_atol,
                     rtol=ode_rtol,
                     step_size=ode_step,
-                    label=labels,
+                    label=conditioning_labels,
                     cfg_scale=args.cfg_scale,
                 )
 
                 # Scaling to [0, 1] from [-1, 1]
-                if isinstance(synthetic_samples, (list, tuple)):
-                    synthetic_samples = synthetic_samples[-1]
+                if isinstance(sample_result, (list, tuple)):
+                    synthetic_samples = sample_result[-1]
+                else:
+                    synthetic_samples = sample_result
                 synthetic_samples = cast(torch.Tensor, synthetic_samples)
+                if record_gif and isinstance(sample_result, torch.Tensor):
+                    gif_trajectories = sample_result
                 synthetic_samples = torch.clamp(
                     synthetic_samples * 0.5 + 0.5, min=0.0, max=1.0
                 )
@@ -446,8 +970,9 @@ def eval_model(
             _nfe_model = (
                 cfg_scaled_logits_model if getattr(args, "metric_induced", False) and 'cfg_scaled_logits_model' in locals() and cfg_scaled_logits_model is not None else cfg_scaled_model
             )
+            batch_generated = synthetic_samples.shape[0]
             logger.info(
-                f"{samples.shape[0]} samples generated in {_nfe_model.get_nfe()} evaluations."
+                f"{batch_generated} samples generated in {_nfe_model.get_nfe()} evaluations."
             )
             if num_synthetic + synthetic_samples.shape[0] > fid_samples:
                 synthetic_samples = synthetic_samples[: fid_samples - num_synthetic]
@@ -480,6 +1005,30 @@ def eval_model(
                     )
                     PIL.Image.fromarray(image_np, "RGB").save(image_path)
 
+            if (
+                gif_trajectories is not None
+                and getattr(args, "output_dir", None)
+                and not gif_logged
+                and distributed_mode.is_main_process()
+            ):
+                try:
+                    _save_sampling_gif(
+                        gif_trajectories,
+                        Path(args.output_dir),
+                        epoch,
+                        data_iter_step,
+                        is_discrete=args.discrete_flow_matching,
+                        max_batch=getattr(args, "eval_gif_max_batch", 8),
+                        stride=getattr(args, "eval_gif_stride", 16),
+                        fps=getattr(args, "eval_gif_fps", 8),
+                        log_to_wandb=getattr(args, "wandb", False),
+                        wandb_step=epoch,
+                    )
+                except Exception as gif_exc:  # pragma: no cover - PIL/image errors
+                    logger.warning("Failed to save evaluation GIF: %s", gif_exc)
+                finally:
+                    gif_logged = True
+
         if not args.compute_fid:
             return {}
 
@@ -492,10 +1041,18 @@ def eval_model(
             else:
                 _len_str = "?"
             logger.info(
-                f"Evaluating [{data_iter_step}/{_len_str}] samples generated [{num_synthetic}/{fid_samples}] running fid {running_fid}"
+                "Evaluating ["
+                f"{data_iter_step}/{_len_str}] samples generated [{num_synthetic}/{fid_samples}] "
+                f"reals [{num_real}/{fid_samples}] running fid {running_fid}"
             )
 
         if args.test_run:
             break
 
-    return {"fid": float(fid_metric.compute().detach().cpu())}
+        if num_real >= fid_samples and num_synthetic >= fid_samples:
+            break
+
+    fid_value = float(fid_metric.compute().detach().cpu())
+    stats = {"fid": fid_value}
+    stats.update(geometry_stats)
+    return stats

--- a/examples/image/training/eval_loop.py
+++ b/examples/image/training/eval_loop.py
@@ -56,7 +56,7 @@ from training.train_loop import MASK_TOKEN
 
 logger = logging.getLogger(__name__)
 
-PRINT_FREQUENCY = 50
+PRINT_FREQUENCY = 1
 
 
 def _save_sampling_gif(

--- a/examples/image/training/eval_loop.py
+++ b/examples/image/training/eval_loop.py
@@ -1049,10 +1049,19 @@ def eval_model(
     geometry_stats: Dict[str, float] = {}
     geometry_logged = False
     
-    # Track whether we need to clear cache at the end
-    need_clear_cache = False
+    # Track whether we need to clear cached resources at the end
+    need_clear_metric_cache = False
+    need_clear_lut_cache = False
     if ko_path is not None and ko_path.learnable_metric is not None:
-        need_clear_cache = True
+        need_clear_metric_cache = True
+    if (
+        getattr(args, "mi_eval_cache_lut", False)
+        and ko_path is not None
+        and ko_path.learnable_lut is not None
+    ):
+        cache_dtype = ko_path.embedding.weight.dtype
+        ko_path.precompute_lut_distance_table(device=device, dtype=cache_dtype)
+        need_clear_lut_cache = True
 
     diagnostics_enabled = bool(getattr(args, "diag_enable", False))
     if diagnostics_enabled and distributed_mode.is_main_process():
@@ -1569,7 +1578,10 @@ def eval_model(
         torch.cuda.empty_cache()
     
     # Clear learned metric cache if we used it
-    if need_clear_cache and ko_path is not None:
-        ko_path.clear_learned_metric_cache()
+    if ko_path is not None:
+        if need_clear_metric_cache:
+            ko_path.clear_learned_metric_cache()
+        if need_clear_lut_cache:
+            ko_path.clear_lut_cache()
     
     return stats

--- a/examples/image/training/eval_loop.py
+++ b/examples/image/training/eval_loop.py
@@ -350,7 +350,7 @@ def _evaluate_metric_geometry(
     )
 
     tables: Dict[str, torch.Tensor] = {}
-    student_full = path._scaled_learned_distance_table(
+    student_full = path._learned_distance_table(
         device=eval_device, dtype=eval_dtype
     )
     if student_full is not None:
@@ -362,7 +362,7 @@ def _evaluate_metric_geometry(
 
     teacher_module = getattr(metric_ema, "teacher", None) if metric_ema else None
     if isinstance(teacher_module, torch.nn.Module):
-        teacher_full = path._scaled_learned_distance_table(
+        teacher_full = path._learned_distance_table(
             device=eval_device,
             dtype=eval_dtype,
             metric_module=teacher_module,

--- a/examples/image/training/eval_loop.py
+++ b/examples/image/training/eval_loop.py
@@ -784,8 +784,11 @@ def eval_model(
         samples = samples.to(device, non_blocking=True)
         labels = labels.to(device, non_blocking=True)
 
-        fid_metric.update(samples, real=True)
-        num_real = min(num_real + samples.shape[0], fid_samples)
+        remaining_real = max(fid_samples - num_real, 0)
+        if remaining_real > 0 and samples.shape[0] > 0:
+            real_batch = samples[:remaining_real]
+            fid_metric.update(real_batch, real=True)
+            num_real += real_batch.shape[0]
 
         remaining_fake = max(fid_samples - num_synthetic, 0)
         if remaining_fake > 0 and samples.shape[0] > 0:

--- a/examples/image/training/eval_loop.py
+++ b/examples/image/training/eval_loop.py
@@ -39,6 +39,7 @@ def _autocast_cuda():
     except Exception:  # pragma: no cover
         return torch.cuda.amp.autocast()
 from flow_matching.path import MixtureDiscreteProbPath, MetricInducedGibbsProbPath
+from flow_matching.path.beta_schedules import ExpMonotoneRQSSchedule
 from flow_matching.path.metric_ema import LearnableMetricEMA
 from flow_matching.path.scheduler import PolynomialConvexScheduler
 from flow_matching.solver import MixtureDiscreteEulerSolver, KODiscreteGibbsEulerSolver
@@ -52,6 +53,7 @@ from torchmetrics.image.fid import FrechetInceptionDistance
 from torchvision.utils import save_image, make_grid
 from training import distributed_mode
 from training.edm_time_discretization import get_time_discretization
+from training.model_diagnostics import DiagnosticsRunner
 from training.train_loop import MASK_TOKEN
 
 logger = logging.getLogger(__name__)
@@ -169,6 +171,64 @@ def _save_sampling_gif(
 
     logger.info("Saved evaluation GIF to %s", gif_path)
     return gif_path
+
+
+def _build_metric_infer_time_grid(
+    args: Namespace,
+    path: MetricInducedGibbsProbPath,
+    *,
+    device: torch.device,
+) -> tuple[torch.Tensor, str]:
+    grid_type = str(getattr(args, "mi_infer_grid", "uniform_t"))
+    steps_cfg = getattr(args, "mi_infer_steps", None)
+    if steps_cfg is None:
+        steps = int(getattr(args, "discrete_fm_steps", 1024))
+    else:
+        steps = int(steps_cfg)
+    steps = max(1, steps)
+    num_points = steps + 1
+
+    if grid_type == "uniform_logbeta":
+        schedule = getattr(path, "beta_schedule", None)
+        if isinstance(schedule, ExpMonotoneRQSSchedule):
+            ell_min = getattr(args, "mi_logbeta_min", None)
+            ell_max = getattr(args, "mi_logbeta_max", None)
+            with torch.no_grad():
+                if ell_min is None or ell_max is None:
+                    t_bounds = torch.tensor(
+                        [schedule.config.t_eps, 1.0 - schedule.config.t_eps],
+                        device=schedule.y0.device,
+                        dtype=schedule.y0.dtype,
+                    )
+                    ell_bounds = schedule.ell_from_t(t_bounds)
+                    if ell_min is None:
+                        ell_min = float(ell_bounds[0].item())
+                    if ell_max is None:
+                        ell_max = float(ell_bounds[1].item())
+            ell_min = float(ell_min)
+            ell_max = float(ell_max)
+            if not math.isfinite(ell_min) or not math.isfinite(ell_max):
+                raise ValueError("mi_logbeta_min/max must be finite when using uniform_logbeta grid")
+            if ell_max <= ell_min:
+                raise ValueError("mi_logbeta_max must exceed mi_logbeta_min for uniform_logbeta grid")
+            ell_grid = torch.linspace(
+                ell_min,
+                ell_max,
+                steps=num_points,
+                device=schedule.y0.device,
+                dtype=schedule.y0.dtype,
+            )
+            t_vals, _ = schedule.t_from_ell(ell_grid)
+            t_vals = t_vals.clamp(schedule.config.t_eps, 1.0 - schedule.config.t_eps)
+            t_vals = torch.sort(t_vals)[0]
+            return t_vals.to(device=device, dtype=torch.float32), grid_type
+        else:
+            logger.warning(
+                "mi_infer_grid=uniform_logbeta requested but β schedule is not ExpMonotoneRQSSchedule; falling back to uniform_t."
+            )
+
+    t_vals = torch.linspace(0.0, 1.0, steps=num_points, device=device, dtype=torch.float32)
+    return t_vals, "uniform_t"
 
 
 def _pad_samples_to_square_grid(samples: torch.Tensor) -> torch.Tensor:
@@ -571,6 +631,32 @@ def eval_model(
     cfg_scaled_logits_model = None
     cfg_scaled_model.train(False)
 
+    infer_time_grid: Optional[torch.Tensor] = None
+    infer_grid_label: Optional[str] = None
+    infer_grid_logged = False
+
+    def get_infer_time_grid(
+        batch_device: torch.device, path_obj: MetricInducedGibbsProbPath
+    ) -> torch.Tensor:
+        nonlocal infer_time_grid, infer_grid_label, infer_grid_logged
+        if infer_time_grid is None or infer_time_grid.device != batch_device:
+            time_grid, label = _build_metric_infer_time_grid(
+                args,
+                path_obj,
+                device=batch_device,
+            )
+            infer_time_grid = time_grid
+            infer_grid_label = label
+            infer_grid_logged = False
+        if not infer_grid_logged and infer_time_grid is not None and infer_grid_label is not None:
+            logger.info(
+                "Metric-induced inference grid '%s' using %d steps",
+                infer_grid_label,
+                max(int(infer_time_grid.numel()) - 1, 0),
+            )
+            infer_grid_logged = True
+        return infer_time_grid
+
     if args.discrete_flow_matching:
         # Branch between mixture path (Meta) and metric-induced path (KO-style)
         if getattr(args, "metric_induced", False):
@@ -616,6 +702,20 @@ def eval_model(
     schedule_snapshot_logged = False
     geometry_stats: Dict[str, float] = {}
     geometry_logged = False
+
+    diagnostics_enabled = bool(getattr(args, "diag_enable", False))
+    if diagnostics_enabled and distributed_mode.is_main_process():
+        try:
+            DiagnosticsRunner(
+                model=model,
+                device=device,
+                args=args,
+                data_loader=data_loader,
+            ).run(metric_path=ko_path)
+        except Exception as diag_exc:  # pragma: no cover - diagnostics failures should not crash eval
+            logger.warning("Diagnostics run failed: %s", diag_exc)
+    if diagnostics_enabled and distributed_mode.is_dist_avail_and_initialized():
+        dist.barrier()
 
     def maybe_run_metric_geometry(path_obj: Optional[MetricInducedGibbsProbPath]) -> None:
         nonlocal geometry_logged, geometry_stats
@@ -885,10 +985,12 @@ def eval_model(
                         dtype=torch.long,
                     )
                     dtype_cat = torch.float32 if args.sampling_dtype == "float32" else torch.float64
+                    time_grid = get_infer_time_grid(conditioning_samples.device, ko_solver.path)
                     sample_result = ko_solver.sample(
                         x_init=x_0,
-                        step_size=1.0 / args.discrete_fm_steps,
+                        step_size=None,
                         dtype_categorical=dtype_cat,
+                        time_grid=time_grid,
                         label=conditioning_labels,
                         # IMPORTANT: disable CFG scaling when using discrete logits
                         cfg_scale=0.0,

--- a/examples/image/training/eval_loop.py
+++ b/examples/image/training/eval_loop.py
@@ -29,6 +29,7 @@ from typing import Callable, Dict, Iterable, Optional, Union, cast
 import PIL.Image
 
 import torch
+import torch.distributed as dist
 
 def _autocast_cuda():
     """Return an autocast context manager for CUDA with torch.amp if available, else torch.cuda.amp."""
@@ -168,6 +169,31 @@ def _save_sampling_gif(
 
     logger.info("Saved evaluation GIF to %s", gif_path)
     return gif_path
+
+
+def _pad_samples_to_square_grid(samples: torch.Tensor) -> torch.Tensor:
+    """Pad a batch of images by repeating early samples to fill a square grid."""
+
+    if samples.ndim != 4:
+        return samples
+    batch = samples.shape[0]
+    if batch == 0:
+        return samples
+
+    grid = int(math.ceil(math.sqrt(batch)))
+    target = grid * grid
+    if target <= batch:
+        return samples
+
+    pad = target - batch
+    if pad <= 0:
+        return samples
+
+    repeat = samples[:pad]
+    if repeat.numel() == 0:
+        return samples
+
+    return torch.cat((samples, repeat), dim=0)
 
 
 def _select_metric_eval_indices(vocab_size: int, subset: int) -> torch.Tensor:
@@ -758,30 +784,16 @@ def eval_model(
         samples = samples.to(device, non_blocking=True)
         labels = labels.to(device, non_blocking=True)
 
-        # Limit the contribution of real samples so we do not process more than fid_samples
-        remaining_real = max(fid_samples - num_real, 0)
-        real_batch = samples
-        real_labels = labels
-        if remaining_real <= 0:
-            real_batch = samples[:0]
-            real_labels = labels[:0]
-        elif real_batch.shape[0] > remaining_real:
-            real_batch = real_batch[:remaining_real]
-            real_labels = real_labels[:remaining_real]
-
-        if real_batch.shape[0] > 0:
-            fid_metric.update(real_batch, real=True)
-            num_real += real_batch.shape[0]
+        fid_metric.update(samples, real=True)
+        num_real = min(num_real + samples.shape[0], fid_samples)
 
         remaining_fake = max(fid_samples - num_synthetic, 0)
-        conditioning_samples = real_batch if real_batch.shape[0] > 0 else samples
-        conditioning_labels = real_labels if real_labels.shape[0] > 0 else labels
-        if remaining_fake <= 0:
-            conditioning_samples = conditioning_samples[:0]
-            conditioning_labels = conditioning_labels[:0]
-        elif conditioning_samples.shape[0] > remaining_fake:
-            conditioning_samples = conditioning_samples[:remaining_fake]
-            conditioning_labels = conditioning_labels[:remaining_fake]
+        if remaining_fake > 0 and samples.shape[0] > 0:
+            conditioning_samples = samples[:remaining_fake]
+            conditioning_labels = labels[:remaining_fake]
+        else:
+            conditioning_samples = samples[:0]
+            conditioning_labels = labels[:0]
 
         if conditioning_samples.shape[0] > 0 and num_synthetic < fid_samples:
             # Reset NFE counter on the wrapper that will actually be used
@@ -977,10 +989,13 @@ def eval_model(
             if num_synthetic + synthetic_samples.shape[0] > fid_samples:
                 synthetic_samples = synthetic_samples[: fid_samples - num_synthetic]
             fid_metric.update(synthetic_samples, real=False)
-            num_synthetic += synthetic_samples.shape[0]
+            num_synthetic = min(num_synthetic + synthetic_samples.shape[0], fid_samples)
             if not snapshots_saved and args.output_dir:
+                snapshot_batch = synthetic_samples
+                if snapshot_batch.ndim == 4:
+                    snapshot_batch = _pad_samples_to_square_grid(snapshot_batch)
                 save_image(
-                    synthetic_samples,
+                    snapshot_batch,
                     fp=Path(args.output_dir)
                     / "snapshots"
                     / f"{epoch}_{data_iter_step}.png",
@@ -1036,14 +1051,35 @@ def eval_model(
             # Sync fid metric to ensure that the processes dont deviate much.
             gc.collect()
             running_fid = fid_metric.compute()
+            if distributed_mode.is_dist_avail_and_initialized():
+                counts = torch.tensor(
+                    [num_real, num_synthetic],
+                    dtype=torch.float64,
+                    device=device,
+                )
+                dist.all_reduce(counts, op=dist.ReduceOp.SUM)
+                total_real = float(counts[0].item())
+                total_fake = float(counts[1].item())
+                target_total = float(
+                    getattr(
+                        args,
+                        "fid_samples",
+                        fid_samples * distributed_mode.get_world_size(),
+                    )
+                )
+            else:
+                total_real = float(num_real)
+                total_fake = float(num_synthetic)
+                target_total = float(fid_samples)
+            target_total = max(target_total, 1.0)
             if _data_loader_len_for_log is not None:
                 _len_str = str(_data_loader_len_for_log)
             else:
                 _len_str = "?"
             logger.info(
                 "Evaluating ["
-                f"{data_iter_step}/{_len_str}] samples generated [{num_synthetic}/{fid_samples}] "
-                f"reals [{num_real}/{fid_samples}] running fid {running_fid}"
+                f"{data_iter_step}/{_len_str}] samples generated [{total_fake:.0f}/{target_total}] "
+                f"reals [{total_real:.0f}/{target_total}] running fid {running_fid}"
             )
 
         if args.test_run:

--- a/examples/image/training/eval_loop.py
+++ b/examples/image/training/eval_loop.py
@@ -193,20 +193,36 @@ def _build_metric_infer_time_grid(
         if isinstance(schedule, ExpMonotoneRQSSchedule):
             ell_min = getattr(args, "mi_logbeta_min", None)
             ell_max = getattr(args, "mi_logbeta_max", None)
+            band_lo_cfg = getattr(args, "mi_logbeta_band_t_lo", None)
+            band_hi_cfg = getattr(args, "mi_logbeta_band_t_hi", None)
+            cfg_t_eps = float(schedule.config.t_eps)
+            default_lo = cfg_t_eps
+            default_hi = 1.0 - cfg_t_eps
+            band_lo = max(
+                default_lo,
+                float(band_lo_cfg) if band_lo_cfg is not None else default_lo,
+            )
+            band_hi = min(
+                default_hi,
+                float(band_hi_cfg) if band_hi_cfg is not None else default_hi,
+            )
+            if band_hi <= band_lo:
+                band_hi = min(default_hi, band_lo + 1e-6)
             with torch.no_grad():
-                if ell_min is None or ell_max is None:
-                    t_bounds = torch.tensor(
-                        [schedule.config.t_eps, 1.0 - schedule.config.t_eps],
-                        device=schedule.y0.device,
-                        dtype=schedule.y0.dtype,
-                    )
-                    ell_bounds = schedule.ell_from_t(t_bounds)
-                    if ell_min is None:
-                        ell_min = float(ell_bounds[0].item())
-                    if ell_max is None:
-                        ell_max = float(ell_bounds[1].item())
-            ell_min = float(ell_min)
-            ell_max = float(ell_max)
+                t_bounds = torch.tensor(
+                    [band_lo, band_hi],
+                    device=schedule.y0.device,
+                    dtype=schedule.y0.dtype,
+                )
+                ell_bounds = schedule.ell_from_t(t_bounds)
+                derived_min = float(torch.min(ell_bounds).item())
+                derived_max = float(torch.max(ell_bounds).item())
+            ell_min = (
+                derived_min if ell_min is None else max(float(ell_min), derived_min)
+            )
+            ell_max = (
+                derived_max if ell_max is None else min(float(ell_max), derived_max)
+            )
             if not math.isfinite(ell_min) or not math.isfinite(ell_max):
                 raise ValueError("mi_logbeta_min/max must be finite when using uniform_logbeta grid")
             if ell_max <= ell_min:

--- a/examples/image/training/eval_loop.py
+++ b/examples/image/training/eval_loop.py
@@ -42,6 +42,7 @@ from flow_matching.path import MixtureDiscreteProbPath, MetricInducedGibbsProbPa
 from flow_matching.path.beta_schedules import ExpMonotoneRQSSchedule
 from flow_matching.path.metric_ema import LearnableMetricEMA
 from flow_matching.path.scheduler import PolynomialConvexScheduler
+from flow_matching.path.metric_analysis import analyze_metric, quick_metric_check
 from flow_matching.solver import MixtureDiscreteEulerSolver, KODiscreteGibbsEulerSolver
 from flow_matching.solver.ode_solver import ODESolver
 from flow_matching.utils import ModelWrapper
@@ -180,6 +181,15 @@ def _build_metric_infer_time_grid(
     device: torch.device,
 ) -> tuple[torch.Tensor, str]:
     grid_type = str(getattr(args, "mi_infer_grid", "uniform_t"))
+    
+    # Get evaluation alpha: if not specified, fall back to training alpha
+    eval_alpha_cfg = getattr(args, "mi_logbeta_eval_alpha", None)
+    if eval_alpha_cfg is None:
+        eval_alpha = float(getattr(args, "mi_logbeta_mis_alpha", 0.0))
+    else:
+        eval_alpha = float(eval_alpha_cfg)
+    eval_alpha = min(max(eval_alpha, 0.0), 1.0)  # Clamp to [0, 1]
+    
     steps_cfg = getattr(args, "mi_infer_steps", None)
     if steps_cfg is None:
         steps = int(getattr(args, "discrete_fm_steps", 1024))
@@ -227,17 +237,162 @@ def _build_metric_infer_time_grid(
                 raise ValueError("mi_logbeta_min/max must be finite when using uniform_logbeta grid")
             if ell_max <= ell_min:
                 raise ValueError("mi_logbeta_max must exceed mi_logbeta_min for uniform_logbeta grid")
-            ell_grid = torch.linspace(
-                ell_min,
-                ell_max,
-                steps=num_points,
-                device=schedule.y0.device,
-                dtype=schedule.y0.dtype,
-            )
-            t_vals, _ = schedule.t_from_ell(ell_grid)
-            t_vals = t_vals.clamp(schedule.config.t_eps, 1.0 - schedule.config.t_eps)
-            t_vals = torch.sort(t_vals)[0]
-            return t_vals.to(device=device, dtype=torch.float32), grid_type
+            
+            # Get sampling strategy
+            sampling_strategy = str(getattr(args, "mi_logbeta_sampling_strategy", "uniform"))
+            
+            # Compute mu and sigma based on strategy
+            def compute_lognormal_params():
+                """Compute mu and sigma for log-normal sampling"""
+                mu_cfg = getattr(args, "mi_logbeta_lognormal_mu", None)
+                sigma_cfg = getattr(args, "mi_logbeta_lognormal_sigma", None)
+                
+                if sampling_strategy == "log_normal_broad":
+                    # Broad: center on full interval
+                    mu_default = (ell_min + ell_max) / 2
+                    sigma_default = (ell_max - ell_min) / 4
+                    mu = mu_default if mu_cfg is None else float(mu_cfg)
+                    sigma = sigma_default if sigma_cfg is None else float(sigma_cfg)
+                    return mu, sigma
+                    
+                elif sampling_strategy == "log_normal_focused":
+                    # Focused: center on informative region
+                    # First, compute informative region in beta space
+                    vocab_size = getattr(path, "vocab_size", 256)  # From metric geometry
+                    H_max = math.log(vocab_size)
+                    H_min_ratio = float(getattr(args, "mi_logbeta_informative_H_min_ratio", 0.01))
+                    H_max_ratio = float(getattr(args, "mi_logbeta_informative_H_max_ratio", 0.99))
+                    H_min_threshold = H_min_ratio * H_max
+                    H_max_threshold = H_max_ratio * H_max
+                    
+                    # Use sigmoid model to find corresponding beta values
+                    # H(beta) = H_max / (1 + exp(-beta/beta_transition + shift))
+                    # Solve for beta: beta = beta_transition * (shift - log(H_max/H - 1))
+                    beta_transition = 1.0
+                    shift = 3.0
+                    
+                    beta_info_min = beta_transition * (shift - math.log(H_max / H_min_threshold - 1))
+                    beta_info_max = beta_transition * (shift - math.log(H_max / H_max_threshold - 1))
+                    
+                    # Clamp beta to positive range (avoid log of negative/zero)
+                    beta_info_min = max(beta_info_min, 0.01)  # Minimum β = 0.01
+                    beta_info_max = max(beta_info_max, 0.02)  # Ensure β_max > β_min
+                    
+                    # Ensure β_max > β_min
+                    if beta_info_max <= beta_info_min:
+                        beta_info_max = beta_info_min * 2.0
+                    
+                    # Convert to log-beta
+                    ell_info_min = math.log(beta_info_min)
+                    ell_info_max = math.log(beta_info_max)
+                    
+                    # Mu: center of informative region
+                    mu_default = (ell_info_min + ell_info_max) / 2
+                    # Sigma: 1-sigma covers informative region
+                    sigma_default = (ell_info_max - ell_info_min) / 2
+                    
+                    mu = mu_default if mu_cfg is None else float(mu_cfg)
+                    sigma = sigma_default if sigma_cfg is None else float(sigma_cfg)
+                    
+                    logger.info(
+                        f"Focused log-normal auto-computed: "
+                        f"H_informative=[{H_min_threshold:.2f}, {H_max_threshold:.2f}] nats, "
+                        f"beta_informative=[{beta_info_min:.2f}, {beta_info_max:.2f}], "
+                        f"log_beta_informative=[{ell_info_min:.3f}, {ell_info_max:.3f}], "
+                        f"mu={mu:.4f}, sigma={sigma:.4f}"
+                    )
+                    return mu, sigma
+                    
+                else:
+                    # Default values if needed
+                    mu = 0.0 if mu_cfg is None else float(mu_cfg)
+                    sigma = 2.5 if sigma_cfg is None else float(sigma_cfg)
+                    return mu, sigma
+            
+            # Implement mixed sampling if eval_alpha > 0
+            if eval_alpha > 0:
+                # Number of samples from each component
+                n_uniform = int(eval_alpha * num_points)
+                n_logbeta = num_points - n_uniform
+                
+                # Generate uniform-t component
+                t_uniform = torch.linspace(
+                    0.0,
+                    1.0,
+                    steps=n_uniform,
+                    device=schedule.y0.device,
+                    dtype=schedule.y0.dtype,
+                )
+                
+                # Generate log-β component (depends on sampling strategy)
+                if sampling_strategy in ["log_normal_broad", "log_normal_focused"]:
+                    mu, sigma = compute_lognormal_params()
+                    
+                    # Sample from N(mu, sigma^2) and clip to [ell_min, ell_max]
+                    ell_samples = torch.randn(
+                        n_logbeta,
+                        device=schedule.y0.device,
+                        dtype=schedule.y0.dtype,
+                    ) * sigma + mu
+                    ell_grid_logbeta = torch.clamp(ell_samples, ell_min, ell_max)
+                else:
+                    # Uniform sampling in log-β space
+                    ell_grid_logbeta = torch.linspace(
+                        ell_min,
+                        ell_max,
+                        steps=n_logbeta,
+                        device=schedule.y0.device,
+                        dtype=schedule.y0.dtype,
+                    )
+                
+                t_logbeta, _ = schedule.t_from_ell(ell_grid_logbeta)
+                t_logbeta = t_logbeta.clamp(schedule.config.t_eps, 1.0 - schedule.config.t_eps)
+                
+                # Combine and sort
+                t_vals = torch.cat([t_uniform, t_logbeta])
+                t_vals = torch.sort(t_vals)[0]
+                
+                # Create descriptive label
+                if sampling_strategy == "log_normal_broad":
+                    strategy_suffix = "_broad"
+                elif sampling_strategy == "log_normal_focused":
+                    strategy_suffix = "_focused"
+                else:
+                    strategy_suffix = ""
+                grid_label = f"mixed_alpha{eval_alpha:.2f}{strategy_suffix}"
+                return t_vals.to(device=device, dtype=torch.float32), grid_label
+            else:
+                # Pure log-β sampling (alpha=0)
+                if sampling_strategy in ["log_normal_broad", "log_normal_focused"]:
+                    mu, sigma = compute_lognormal_params()
+                    
+                    # Sample from N(mu, sigma^2) and clip to [ell_min, ell_max]
+                    ell_samples = torch.randn(
+                        num_points,
+                        device=schedule.y0.device,
+                        dtype=schedule.y0.dtype,
+                    ) * sigma + mu
+                    ell_grid = torch.clamp(ell_samples, ell_min, ell_max)
+                    
+                    if sampling_strategy == "log_normal_focused":
+                        grid_label = "focused_logbeta"
+                    else:
+                        grid_label = "broad_logbeta"
+                else:
+                    # Uniform sampling in log-β space
+                    ell_grid = torch.linspace(
+                        ell_min,
+                        ell_max,
+                        steps=num_points,
+                        device=schedule.y0.device,
+                        dtype=schedule.y0.dtype,
+                    )
+                    grid_label = grid_type
+                
+                t_vals, _ = schedule.t_from_ell(ell_grid)
+                t_vals = t_vals.clamp(schedule.config.t_eps, 1.0 - schedule.config.t_eps)
+                t_vals = torch.sort(t_vals)[0]
+                return t_vals.to(device=device, dtype=torch.float32), grid_label
         else:
             logger.warning(
                 "mi_infer_grid=uniform_logbeta requested but β schedule is not ExpMonotoneRQSSchedule; falling back to uniform_t."
@@ -584,6 +739,127 @@ def _evaluate_metric_geometry(
 
     return stats
 
+
+def _run_detailed_metric_analysis(
+    path: MetricInducedGibbsProbPath,
+    *,
+    args: Namespace,
+    epoch: int,
+    metric_ema: Optional[LearnableMetricEMA],
+    output_root: Optional[Path],
+) -> Dict[str, float]:
+    """
+    Run comprehensive metric analysis including t-SNE/UMAP visualizations.
+    This provides deep insights into what the metric learned.
+    """
+    if not getattr(args, "mi_metric_detailed_analysis", False):
+        return {}
+    
+    if not distributed_mode.is_main_process():
+        return {}
+    
+    if output_root is None:
+        logger.warning("Skipping detailed metric analysis because --output_dir is not set.")
+        return {}
+    
+    learnable_metric = getattr(path, "learnable_metric", None)
+    if learnable_metric is None:
+        logger.warning("Skipping detailed metric analysis because no learnable metric found.")
+        return {}
+    
+    # Create output directory for this epoch's analysis
+    analysis_dir = output_root / "metric_analysis" / f"epoch_{epoch:04d}"
+    
+    try:
+        # Use UMAP if available, fall back to t-SNE
+        # Default: enable both if not explicitly disabled
+        use_umap = getattr(args, "mi_metric_use_umap", False)
+        use_tsne = getattr(args, "mi_metric_use_tsne", False)
+        
+        # If neither flag is set, enable both by default
+        if not use_umap and not use_tsne:
+            use_umap = True
+            use_tsne = True
+        
+        logger.info("Running detailed metric analysis (epoch %d)...", epoch)
+        
+        # Run analysis on student metric
+        device = str(learnable_metric.codes.device)
+        student_results = analyze_metric(
+            learnable_metric,
+            output_dir=str(analysis_dir / "student"),
+            device=device,
+            use_umap=use_umap,
+            use_tsne=use_tsne,
+            verbose=False,  # Don't clutter logs
+            save_plots=True,
+        )
+        
+        # Also analyze EMA teacher metric if available
+        teacher_module = getattr(metric_ema, "teacher", None) if metric_ema else None
+        if isinstance(teacher_module, torch.nn.Module):
+            logger.info("Running detailed metric analysis for EMA teacher...")
+            teacher_results = analyze_metric(
+                teacher_module,
+                output_dir=str(analysis_dir / "teacher"),
+                device=device,
+                use_umap=use_umap,
+                use_tsne=use_tsne,
+                verbose=False,
+                save_plots=True,
+            )
+            # Prefix teacher stats
+            teacher_results = {f"teacher_{k}": v for k, v in teacher_results.items()}
+            student_results.update(teacher_results)
+        
+        # Log key metrics to wandb
+        if getattr(args, "wandb", False):
+            try:
+                try:
+                    import swanlab as wandb  # type: ignore
+                except Exception:  # pragma: no cover
+                    import wandb  # type: ignore
+                
+                # Log key statistics (only numeric values, exclude complex types)
+                wandb_metrics = {}
+                for k, v in student_results.items():
+                    # Skip paths, nearest_neighbors dicts, and other complex types
+                    if k.endswith("_path") or k.endswith("neighbors") or isinstance(v, (dict, list)):
+                        continue
+                    if isinstance(v, (int, float)):
+                        wandb_metrics[f"metric_analysis/{k}"] = v
+                
+                # Log visualizations as images
+                viz_keys = [k for k in student_results.keys() if k.endswith("_path")]
+                for key in viz_keys:
+                    path_str = student_results[key]
+                    if isinstance(path_str, str) and Path(path_str).exists():
+                        img_key = key.replace("_path", "").replace("_", "/")
+                        try:
+                            wandb_metrics[f"metric_analysis/{img_key}"] = wandb.Image(path_str)  # type: ignore
+                        except Exception:
+                            # Swanlab might not support wandb.Image, skip silently
+                            pass
+                
+                if wandb_metrics:
+                    wandb.log(wandb_metrics, step=epoch)  # type: ignore
+                    
+            except Exception as wandb_exc:  # pragma: no cover
+                logger.debug("Failed to log metric analysis to wandb: %s", wandb_exc)
+        
+        logger.info(
+            "Detailed metric analysis complete: distance_std=%.4f, CV=%.4f",
+            student_results.get("distance_std", 0.0),
+            student_results.get("coefficient_of_variation", 0.0),
+        )
+        
+        return student_results
+        
+    except Exception as analysis_exc:  # pragma: no cover
+        logger.warning("Detailed metric analysis failed: %s", analysis_exc)
+        return {}
+
+
 class CFGScaledModel(ModelWrapper):
     def __init__(self, model: Module, return_logits: bool = False):
         super().__init__(model)
@@ -640,6 +916,8 @@ def eval_model(
     args: Namespace,
     metric_path: Optional[MetricInducedGibbsProbPath] = None,
     metric_ema: Optional[LearnableMetricEMA] = None,
+    schedule_ema: Optional["BetaScheduleEMA"] = None,  # NEW: Use EMA schedule for eval
+    fid_metric: Optional[FrechetInceptionDistance] = None,
 ):
     gc.collect()
     cfg_scaled_model = CFGScaledModel(model=model)
@@ -695,9 +973,10 @@ def eval_model(
         cont_solver = ODESolver(velocity_model=cfg_scaled_model)
         cont_ode_opts = args.ode_options
 
-    fid_metric = FrechetInceptionDistance(normalize=True).to(
-        device=device, non_blocking=True
-    )
+    owns_fid_metric = fid_metric is None
+    if fid_metric is None:
+        fid_metric = FrechetInceptionDistance(normalize=True)
+    fid_metric = fid_metric.to(device=device, non_blocking=True)
 
     num_synthetic = 0
     num_real = 0
@@ -714,10 +993,66 @@ def eval_model(
 
     # Lazily constructed KO solver and path (once K is known)
     ko_solver = None
+    # Use EMA schedule for eval if available (train/eval consistency)
     ko_path = metric_path
+    ko_path_raw = None  # For comparison
+    use_ema_for_eval = schedule_ema is not None and metric_path is not None
+    compare_schedules = use_ema_for_eval and getattr(args, "mi_compare_schedule_eval", False)
+    
+    if use_ema_for_eval:
+        # Create a temporary path with EMA schedule AND EMA metric for evaluation
+        # This ensures UNet is evaluated on the same schedule/metric it was trained on
+        import copy
+        ko_path = copy.copy(metric_path)  # Shallow copy
+        # Use schedule_ema.teacher (the EMA-tracked parameters) which has full schedule interface
+        # NOT schedule_ema itself (which only wraps beta_and_derivative)
+        ko_path.beta_schedule = schedule_ema.teacher  # Replace with EMA's teacher
+        
+        # CRITICAL: Also replace metric with EMA metric (if available)
+        # This ensures train/eval consistency for the entire path
+        # User can override with --mi_eval_use_raw_metric to test raw student metric
+        use_raw_metric = getattr(args, "mi_eval_use_raw_metric", False)
+        
+        if metric_ema is not None and hasattr(metric_ema, 'teacher') and metric_ema.teacher is not None:
+            if not use_raw_metric:
+                # Default: Use EMA teacher (smooth, stable)
+                ko_path.learnable_metric = metric_ema.teacher
+                logger.info("Eval using EMA schedule + EMA metric (train/eval consistency)")
+                # Precompute learned metric distance table for eval (huge speedup!)
+                ko_path.precompute_learned_metric_table(
+                    device=device, dtype=torch.float32, metric_module=metric_ema.teacher
+                )
+            else:
+                # User requested: Use raw student metric
+                logger.info("Eval using EMA schedule + RAW student metric (--mi_eval_use_raw_metric enabled)")
+                # Precompute with raw student metric
+                if ko_path.learnable_metric is not None:
+                    ko_path.precompute_learned_metric_table(
+                        device=device, dtype=torch.float32
+                    )
+        else:
+            logger.info("Eval using EMA schedule (train/eval consistency)")
+            # Also precompute if we have a learnable metric (even without EMA)
+            if ko_path.learnable_metric is not None:
+                ko_path.precompute_learned_metric_table(
+                    device=device, dtype=torch.float32
+                )
+        
+        if compare_schedules:
+            # Keep raw path for comparison
+            ko_path_raw = metric_path
+            logger.info("Will also evaluate with raw schedule for comparison")
+    elif metric_path is not None:
+        logger.info("Eval using raw schedule (no EMA available)")
+    
     schedule_snapshot_logged = False
     geometry_stats: Dict[str, float] = {}
     geometry_logged = False
+    
+    # Track whether we need to clear cache at the end
+    need_clear_cache = False
+    if ko_path is not None and ko_path.learnable_metric is not None:
+        need_clear_cache = True
 
     diagnostics_enabled = bool(getattr(args, "diag_enable", False))
     if diagnostics_enabled and distributed_mode.is_main_process():
@@ -759,6 +1094,17 @@ def eval_model(
                 metric_ema=metric_ema,
                 output_root=output_root,
             )
+            
+            # Run detailed metric analysis (t-SNE/UMAP visualizations)
+            detailed_stats = _run_detailed_metric_analysis(
+                path_obj,
+                args=args,
+                epoch=epoch,
+                metric_ema=metric_ema,
+                output_root=output_root,
+            )
+            geometry_stats.update(detailed_stats)
+            
         except Exception as geom_exc:  # pragma: no cover - diagnostic failures
             logger.warning("Metric geometry evaluation failed: %s", geom_exc)
         geometry_logged = True
@@ -1212,4 +1558,18 @@ def eval_model(
     fid_value = float(fid_metric.compute().detach().cpu())
     stats = {"fid": fid_value}
     stats.update(geometry_stats)
+    if owns_fid_metric:
+        try:
+            fid_metric.reset()
+        except Exception:
+            pass
+        del fid_metric
+    gc.collect()
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
+    
+    # Clear learned metric cache if we used it
+    if need_clear_cache and ko_path is not None:
+        ko_path.clear_learned_metric_cache()
+    
     return stats

--- a/examples/image/training/grad_scaler.py
+++ b/examples/image/training/grad_scaler.py
@@ -6,7 +6,7 @@
 import torch
 
 from torch import Tensor
-from typing import Any
+from typing import Any, Callable, Optional
 
 
 def _create_grad_scaler(enabled: bool):
@@ -55,6 +55,7 @@ class NativeScalerWithGradNormCount:
         parameters=None,
         create_graph=False,
         update_grad=True,
+        pre_step_fn: Optional[Callable[[], None]] = None,
     ):
         if self._enabled:
             self._scaler.scale(loss).backward(create_graph=create_graph)
@@ -70,6 +71,8 @@ class NativeScalerWithGradNormCount:
                 if self._enabled:
                     self._scaler.unscale_(optimizer)
                 norm = get_grad_norm_(parameters)
+            if pre_step_fn is not None:
+                pre_step_fn()
             optimizer.step() if not self._enabled else self._scaler.step(optimizer)
             if self._enabled:
                 self._scaler.update()

--- a/examples/image/training/load_and_save.py
+++ b/examples/image/training/load_and_save.py
@@ -83,7 +83,54 @@ def load_model(
             for name, module in extra_modules.items():
                 state_dict = checkpoint["extra_modules"].get(name)
                 if state_dict is not None:
-                    module.load_state_dict(state_dict)
+                    # Handle legacy checkpoint format for MahalanobisTokenMetric
+                    from flow_matching.path.mixture import MahalanobisTokenMetric
+                    from flow_matching.path.metric_ema import LearnableMetricEMA
+                    
+                    if isinstance(module, MahalanobisTokenMetric):
+                        # Check if this is a legacy format (has 'codes' but not 'codes_raw')
+                        if "codes" in state_dict and "codes_raw" not in state_dict:
+                            print(f"Converting legacy metric format for '{name}'...")
+                            # Use the property setter to trigger automatic conversion
+                            module.codes = state_dict["codes"]
+                            if "_lower_params" in state_dict:
+                                module._lower_params.data.copy_(state_dict["_lower_params"])
+                            if "_extra_state" in state_dict:
+                                module.set_extra_state(state_dict["_extra_state"])
+                            print(f"  ✓ Converted: codes → codes_raw + log_scale")
+                        else:
+                            # New format, load normally
+                            module.load_state_dict(state_dict)
+                    elif isinstance(module, LearnableMetricEMA):
+                        # Handle LearnableMetricEMA with legacy teacher metric
+                        # Check if teacher has legacy format
+                        if "teacher.codes" in state_dict and "teacher.codes_raw" not in state_dict:
+                            print(f"Converting legacy EMA teacher metric format for '{name}'...")
+                            # Extract teacher state
+                            teacher_state = {
+                                k.replace("teacher.", ""): v 
+                                for k, v in state_dict.items() 
+                                if k.startswith("teacher.")
+                            }
+                            # Convert teacher via property setter
+                            if isinstance(module.teacher, MahalanobisTokenMetric):
+                                module.teacher.codes = teacher_state["codes"]
+                                if "_lower_params" in teacher_state:
+                                    module.teacher._lower_params.data.copy_(teacher_state["_lower_params"])
+                                if "_extra_state" in teacher_state:
+                                    module.teacher.set_extra_state(teacher_state["_extra_state"])
+                            # Load non-teacher parts
+                            for k, v in state_dict.items():
+                                if not k.startswith("teacher."):
+                                    # Load buffers like num_updates
+                                    if k in dict(module.named_buffers()):
+                                        getattr(module, k).copy_(v)
+                            print(f"  ✓ Converted EMA teacher: codes → codes_raw + log_scale")
+                        else:
+                            # New format, load normally
+                            module.load_state_dict(state_dict)
+                    else:
+                        module.load_state_dict(state_dict)
         checkpoint_args = checkpoint.get("args")
         if checkpoint_args is not None:
             for attr in (
@@ -99,9 +146,23 @@ def load_model(
             and "epoch" in checkpoint
             and not (hasattr(args, "eval") and args.eval)
         ):
-            optimizer.load_state_dict(checkpoint["optimizer"])
+            # Handle freeze schedule mode: skip optimizer loading if param groups mismatch
+            freeze_schedule = getattr(args, "mi_freeze_beta_schedule", False)
+            
+            if freeze_schedule:
+                # In freeze mode, param groups differ: checkpoint has schedule params, current doesn't
+                # Skip optimizer state loading, but keep lr_schedule and epoch
+                print(f"Freeze mode: Skipping optimizer state loading (param group mismatch)")
+                print(f"  Checkpoint was trained with schedule params, now excluded from optimizer")
+                print(f"  UNet will start with fresh optimizer state (momentum reset)")
+            else:
+                # Normal mode: load optimizer state
+                optimizer.load_state_dict(checkpoint["optimizer"])
+                print("Loaded optimizer state")
+            
+            # Always load lr_schedule and epoch
             lr_schedule.load_state_dict(checkpoint["lr_schedule"])
             args.start_epoch = checkpoint["epoch"] + 1
             if "scaler" in checkpoint:
                 loss_scaler.load_state_dict(checkpoint["scaler"])
-            print("With optim & sched!")
+            print(f"Resumed from epoch {checkpoint['epoch']}, continuing to epoch {args.start_epoch}")

--- a/examples/image/training/lut_diagnostics_integration.py
+++ b/examples/image/training/lut_diagnostics_integration.py
@@ -1,0 +1,247 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the CC-by-NC license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Integration helpers for LUT diagnostics in training loop.
+
+Provides utilities to:
+  - Create fixed probe batch for consistent metrics
+  - Log LUT diagnostics每 epoch
+  - Save LUT snapshots for plotting
+  - Handle wandb/swanlab logging
+"""
+
+import logging
+from pathlib import Path
+from typing import Dict, Optional
+
+import torch
+from torch import Tensor
+import torch.nn as nn
+
+from flow_matching.path import MetricInducedGibbsProbPath
+from flow_matching.path.lut_diagnostics import LUTDiagnostics
+
+logger = logging.getLogger(__name__)
+
+
+def create_probe_batch(
+    dataset,
+    num_samples: int = 128,
+    device: torch.device = torch.device("cpu"),
+    seed: int = 42,
+) -> Tensor:
+    """Create a fixed probe batch for consistent diagnostics.
+    
+    Args:
+        dataset: Dataset to sample from
+        num_samples: Number of samples
+        device: Device to place batch on
+        seed: Random seed for reproducibility
+    
+    Returns:
+        [num_samples, C, H, W] tensor
+    """
+    rng = torch.Generator()
+    rng.manual_seed(seed)
+    
+    indices = torch.randperm(len(dataset), generator=rng)[:num_samples]
+    
+    samples = []
+    for idx in indices:
+        img, _ = dataset[idx]
+        samples.append(img)
+    
+    batch = torch.stack(samples, dim=0)  # [N, C, H, W]
+    
+    # Convert to int64 tokens if needed
+    if batch.dtype == torch.float32:
+        # Assume [0, 1] range
+        batch = (batch * 255).long().clamp(0, 255)
+    
+    return batch.to(device)
+
+
+def log_lut_diagnostics_epoch(
+    path: MetricInducedGibbsProbPath,
+    probe_batch: Tensor,
+    diagnostics: LUTDiagnostics,
+    epoch: int,
+    optimizer: Optional[torch.optim.Optimizer] = None,
+    prev_lut: Optional[Tensor] = None,
+    wandb_run=None,
+    channel_names: Optional[list] = None,
+) -> Dict[str, Tensor]:
+    """Compute and log LUT diagnostics for one epoch.
+    
+    Args:
+        path: Metric-induced Gibbs path with learnable LUT
+        probe_batch: Fixed probe batch [B, C, H, W]
+        diagnostics: LUTDiagnostics instance
+        epoch: Current epoch number
+        optimizer: Optimizer (to extract LR and gradients)
+        prev_lut: Previous epoch's LUT weights (for dynamics)
+        wandb_run: Optional wandb/swanlab run object
+        channel_names: Optional channel names (e.g., ['R', 'G', 'B'])
+    
+    Returns:
+        Dictionary of all computed metrics
+    """
+    if path.learnable_lut is None:
+        logger.warning("No learnable LUT found in path; skipping diagnostics")
+        return {}
+    
+    # Get current LUT weights
+    lut_weights = path.learnable_lut.weight.detach()  # [C, V]
+    
+    # Extract gradient and LR (if optimizer available)
+    grad = None
+    lr = None
+    if optimizer is not None:
+        # Find LUT parameter group
+        for param_group in optimizer.param_groups:
+            if param_group.get("name") == "learnable_lut":
+                lr = param_group["lr"]
+                # Get gradient from parameter
+                if path.learnable_lut.weight.grad is not None:
+                    grad = path.learnable_lut.weight.grad.detach()
+                break
+    
+    # Beta function for path quality metrics
+    def beta_fn(t: Tensor) -> Tensor:
+        return path.beta_schedule(t)
+    
+    # Beta values at probe times (for distance scaling)
+    beta_values = torch.tensor([
+        beta_fn(torch.tensor(t, device=lut_weights.device)).item()
+        for t in diagnostics.probe_times
+    ], device=lut_weights.device)
+    
+    # Compute all metrics
+    metrics = diagnostics.compute_all_metrics(
+        embeddings=lut_weights,
+        probe_batch=probe_batch,
+        beta_fn=beta_fn,
+        embeddings_prev=prev_lut,
+        grad=grad,
+        lr=lr,
+        beta_values=beta_values,
+    )
+    
+    # Log summary to console
+    diagnostics.log_metrics_summary(metrics, epoch)
+    
+    # Log to wandb/swanlab
+    if wandb_run is not None:
+        # Convert metrics to scalars for logging
+        flat_metrics = {}
+        for key, value in metrics.items():
+            if isinstance(value, Tensor):
+                if value.numel() == 1:
+                    flat_metrics[f"lut/{key}"] = value.item()
+                else:
+                    # Log per-channel values
+                    for i, v in enumerate(value):
+                        ch_name = channel_names[i] if channel_names and i < len(channel_names) else f"ch{i}"
+                        flat_metrics[f"lut/{key}_{ch_name}"] = v.item()
+            elif isinstance(value, (int, float, bool)):
+                flat_metrics[f"lut/{key}"] = value
+        
+        wandb_run.log(flat_metrics, step=epoch)
+    
+    return metrics
+
+
+def save_lut_snapshot(
+    path: MetricInducedGibbsProbPath,
+    output_dir: Path,
+    epoch: int,
+    save_init: bool = False,
+) -> None:
+    """Save LUT weights for later plotting.
+    
+    Args:
+        path: Metric-induced path
+        output_dir: Directory to save snapshots
+        epoch: Current epoch
+        save_init: If True, also save initial/baseline LUT
+    """
+    if path.learnable_lut is None:
+        return
+    
+    snapshot_dir = output_dir / "lut_snapshots"
+    snapshot_dir.mkdir(parents=True, exist_ok=True)
+    
+    # Save current LUT
+    lut_weights = path.learnable_lut.weight.detach().cpu()
+    torch.save({
+        "epoch": epoch,
+        "lut_weights": lut_weights,
+        "num_channels": path.learnable_lut.num_channels,
+        "vocab_size": path.learnable_lut.vocab_size,
+        "embed_range": path.learnable_lut.embed_range,
+    }, snapshot_dir / f"lut_epoch_{epoch:04d}.pt")
+    
+    # Save init/baseline (once)
+    if save_init:
+        init_weights = path.learnable_lut._linear_init().cpu()
+        torch.save({
+            "epoch": -1,
+            "lut_weights": init_weights,
+            "num_channels": path.learnable_lut.num_channels,
+            "vocab_size": path.learnable_lut.vocab_size,
+            "embed_range": path.learnable_lut.embed_range,
+        }, snapshot_dir / "lut_init.pt")
+
+
+def setup_lut_diagnostics(
+    path: MetricInducedGibbsProbPath,
+    dataset,
+    device: torch.device,
+    probe_samples: int = 128,
+    probe_times: Optional[list] = None,
+) -> tuple[Optional[LUTDiagnostics], Optional[Tensor]]:
+    """Setup LUT diagnostics and probe batch.
+    
+    Args:
+        path: Metric-induced path
+        dataset: Training dataset
+        device: Device to use
+        probe_samples: Number of probe samples
+        probe_times: Times to probe (default: [0.2, 0.5, 0.8])
+    
+    Returns:
+        (diagnostics, probe_batch) tuple, or (None, None) if no LUT
+    """
+    if path.learnable_lut is None:
+        logger.info("No learnable LUT in path; skipping diagnostics setup")
+        return None, None
+    
+    logger.info(f"Setting up LUT diagnostics with {probe_samples} probe samples")
+    
+    # Create diagnostics tracker
+    diagnostics = LUTDiagnostics(
+        num_channels=path.learnable_lut.num_channels,
+        vocab_size=path.learnable_lut.vocab_size,
+        probe_times=probe_times,
+    )
+    
+    # Register baseline (linear init)
+    baseline_lut = path.learnable_lut._linear_init().to(device)
+    diagnostics.register_baseline(baseline_lut)
+    
+    # Create fixed probe batch
+    probe_batch = create_probe_batch(
+        dataset=dataset,
+        num_samples=probe_samples,
+        device=device,
+    )
+    
+    logger.info(
+        f"LUT diagnostics ready: {diagnostics.num_channels} channels, "
+        f"{diagnostics.vocab_size} vocab, probe times={diagnostics.probe_times}"
+    )
+    
+    return diagnostics, probe_batch

--- a/examples/image/training/lut_diagnostics_integration.py
+++ b/examples/image/training/lut_diagnostics_integration.py
@@ -15,6 +15,7 @@ Provides utilities to:
 
 import logging
 import math
+import sys
 from pathlib import Path
 from typing import Dict, Optional
 
@@ -26,10 +27,22 @@ import torch.nn as nn
 from flow_matching.path import MetricInducedGibbsProbPath
 from flow_matching.path.lut_diagnostics import LUTDiagnostics
 
+_THIS_DIR = Path(__file__).resolve().parent
+_IMAGE_DIR = _THIS_DIR.parent
+if str(_IMAGE_DIR) not in sys.path:
+    sys.path.insert(0, str(_IMAGE_DIR))
+
+from lut_quantile_analysis import (  # noqa: E402
+    BaselineResults,
+    analyze_baselines,
+    plot_baseline_comparison,
+    scalarize_embedding,
+)
+
 logger = logging.getLogger(__name__)
 
 
-def _scalarize_lut_embeddings(weight: Tensor, *, metric: str) -> Tensor:
+def _scalarize_lut_embeddings(weight: Tensor, *, metric: str, scalar_mode: str = "uniform") -> Tensor:
     """Convert LUT embeddings [C,V,D] into scalar representation for diagnostics."""
     if weight is None:
         return weight
@@ -42,15 +55,29 @@ def _scalarize_lut_embeddings(weight: Tensor, *, metric: str) -> Tensor:
         raise ValueError(f"Unexpected LUT weight shape {tuple(weight.shape)}")
 
     if metric == "cosine":
-        normed = F.normalize(weight, p=2, dim=-1, eps=1e-12)
-        if normed.shape[-1] >= 2:
-            theta = torch.atan2(normed[:, :, 1], normed[:, :, 0])
-            theta = torch.remainder(theta, 2.0 * math.pi)
-            return theta
-        return normed.squeeze(-1)
+        channels = []
+        for c in range(weight.shape[0]):
+            channels.append(scalarize_embedding(weight[c], mode=scalar_mode))
+        return torch.stack(channels, dim=0)
 
     # Default: use L2 norm for scalar summary
     return torch.linalg.vector_norm(weight, ord=2, dim=-1)
+
+
+def _estimate_histogram_from_probe(probe_batch: Tensor, vocab_size: int) -> Tensor:
+    """Estimate per-channel token histogram from probe batch."""
+    if probe_batch.dtype not in (torch.int32, torch.int64, torch.int16, torch.uint8):
+        tokens = probe_batch.round().clamp(0, vocab_size - 1).to(torch.long)
+    else:
+        tokens = probe_batch.to(torch.long)
+    B, C, *spatial = tokens.shape
+    tokens = tokens.view(B, C, -1)
+    histograms = []
+    for c in range(C):
+        channel_tokens = tokens[:, c, :].reshape(-1).cpu()
+        counts = torch.bincount(channel_tokens, minlength=vocab_size).float()
+        histograms.append(counts)
+    return torch.stack(histograms, dim=0)
 
 
 def create_probe_batch(
@@ -90,6 +117,46 @@ def create_probe_batch(
     return batch.to(device)
 
 
+
+def _save_detailed_quantile_plots(
+    path: MetricInducedGibbsProbPath,
+    probe_batch: Tensor,
+    epoch: int,
+    output_dir: Path,
+    *,
+    scalar_mode: str = "uniform",
+    channel_names: Optional[list] = None,
+) -> None:
+    """Generate detailed quantile diagnostics plots for each LUT channel."""
+    if path.learnable_lut is None:
+        return
+
+    lut_weight = path.learnable_lut.weight.detach().cpu()
+    vocab_size = path.learnable_lut.vocab_size
+    hist = _estimate_histogram_from_probe(probe_batch, vocab_size)
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    C = lut_weight.shape[0]
+    if channel_names is None:
+        channel_names = [f"ch{i}" for i in range(C)]
+
+    for c in range(C):
+        results: BaselineResults = analyze_baselines(
+            lut_weight,
+            hist,
+            channel_idx=c,
+            scalar_mode=scalar_mode,
+        )
+        channel_label = channel_names[c] if c < len(channel_names) else f"ch{c}"
+        figure_path = output_dir / f"epoch{epoch:04d}_{channel_label}.png"
+        plot_baseline_comparison(
+            results,
+            str(figure_path),
+            channel_label=channel_label,
+            epoch=epoch,
+        )
+
 def log_lut_diagnostics_epoch(
     path: MetricInducedGibbsProbPath,
     probe_batch: Tensor,
@@ -99,6 +166,8 @@ def log_lut_diagnostics_epoch(
     prev_lut: Optional[Tensor] = None,
     wandb_run=None,
     channel_names: Optional[list] = None,
+    detailed_plot_dir: Optional[Path] = None,
+    scalar_mode: str = "uniform",
 ) -> Dict[str, Tensor]:
     """Compute and log LUT diagnostics for one epoch.
     
@@ -111,6 +180,8 @@ def log_lut_diagnostics_epoch(
         prev_lut: Previous epoch's LUT weights (for dynamics)
         wandb_run: Optional wandb/swanlab run object
         channel_names: Optional channel names (e.g., ['R', 'G', 'B'])
+        detailed_plot_dir: Optional path to save detailed quantile plots
+        scalar_mode: Scalarization mode passed to quantile analysis
     
     Returns:
         Dictionary of all computed metrics
@@ -123,7 +194,7 @@ def log_lut_diagnostics_epoch(
 
     # Get current LUT weights
     lut_weights_raw = path.learnable_lut.weight.detach()
-    lut_weights = _scalarize_lut_embeddings(lut_weights_raw, metric=metric_name)
+    lut_weights = _scalarize_lut_embeddings(lut_weights_raw, metric=metric_name, scalar_mode=scalar_mode)
     
     # Extract gradient and LR (if optimizer available)
     grad = None
@@ -136,12 +207,12 @@ def log_lut_diagnostics_epoch(
                 # Get gradient from parameter
                 if path.learnable_lut.weight.grad is not None:
                     grad = _scalarize_lut_embeddings(
-                        path.learnable_lut.weight.grad.detach(), metric=metric_name
+                        path.learnable_lut.weight.grad.detach(), metric=metric_name, scalar_mode=scalar_mode
                     )
                 break
     if grad is None and path.learnable_lut.weight.grad is not None:
         grad = _scalarize_lut_embeddings(
-            path.learnable_lut.weight.grad.detach(), metric=metric_name
+            path.learnable_lut.weight.grad.detach(), metric=metric_name, scalar_mode=scalar_mode
         )
     
     # Beta function for path quality metrics
@@ -159,12 +230,22 @@ def log_lut_diagnostics_epoch(
         embeddings=lut_weights,
         probe_batch=probe_batch,
         beta_fn=beta_fn,
-        embeddings_prev=_scalarize_lut_embeddings(prev_lut, metric=metric_name) if prev_lut is not None else None,
+        embeddings_prev=_scalarize_lut_embeddings(prev_lut, metric=metric_name, scalar_mode=scalar_mode) if prev_lut is not None else None,
         grad=grad,
         lr=lr,
         beta_values=beta_values,
     )
-    
+
+    if detailed_plot_dir is not None:
+        _save_detailed_quantile_plots(
+            path,
+            probe_batch,
+            epoch,
+            Path(detailed_plot_dir),
+            scalar_mode=scalar_mode,
+            channel_names=channel_names,
+        )
+
     # Log summary to console
     diagnostics.log_metrics_summary(metrics, epoch)
     

--- a/examples/image/training/lut_diagnostics_integration.py
+++ b/examples/image/training/lut_diagnostics_integration.py
@@ -14,10 +14,12 @@ Provides utilities to:
 """
 
 import logging
+import math
 from pathlib import Path
 from typing import Dict, Optional
 
 import torch
+import torch.nn.functional as F
 from torch import Tensor
 import torch.nn as nn
 
@@ -25,6 +27,30 @@ from flow_matching.path import MetricInducedGibbsProbPath
 from flow_matching.path.lut_diagnostics import LUTDiagnostics
 
 logger = logging.getLogger(__name__)
+
+
+def _scalarize_lut_embeddings(weight: Tensor, *, metric: str) -> Tensor:
+    """Convert LUT embeddings [C,V,D] into scalar representation for diagnostics."""
+    if weight is None:
+        return weight
+    if weight.ndim == 2:
+        return weight
+    if weight.ndim == 3 and weight.shape[-1] == 1:
+        return weight.squeeze(-1)
+
+    if weight.ndim != 3:
+        raise ValueError(f"Unexpected LUT weight shape {tuple(weight.shape)}")
+
+    if metric == "cosine":
+        normed = F.normalize(weight, p=2, dim=-1, eps=1e-12)
+        if normed.shape[-1] >= 2:
+            theta = torch.atan2(normed[:, :, 1], normed[:, :, 0])
+            theta = torch.remainder(theta, 2.0 * math.pi)
+            return theta
+        return normed.squeeze(-1)
+
+    # Default: use L2 norm for scalar summary
+    return torch.linalg.vector_norm(weight, ord=2, dim=-1)
 
 
 def create_probe_batch(
@@ -93,8 +119,11 @@ def log_lut_diagnostics_epoch(
         logger.warning("No learnable LUT found in path; skipping diagnostics")
         return {}
     
+    metric_name = getattr(path, "metric_name", "lp")
+
     # Get current LUT weights
-    lut_weights = path.learnable_lut.weight.detach()  # [C, V]
+    lut_weights_raw = path.learnable_lut.weight.detach()
+    lut_weights = _scalarize_lut_embeddings(lut_weights_raw, metric=metric_name)
     
     # Extract gradient and LR (if optimizer available)
     grad = None
@@ -106,8 +135,14 @@ def log_lut_diagnostics_epoch(
                 lr = param_group["lr"]
                 # Get gradient from parameter
                 if path.learnable_lut.weight.grad is not None:
-                    grad = path.learnable_lut.weight.grad.detach()
+                    grad = _scalarize_lut_embeddings(
+                        path.learnable_lut.weight.grad.detach(), metric=metric_name
+                    )
                 break
+    if grad is None and path.learnable_lut.weight.grad is not None:
+        grad = _scalarize_lut_embeddings(
+            path.learnable_lut.weight.grad.detach(), metric=metric_name
+        )
     
     # Beta function for path quality metrics
     def beta_fn(t: Tensor) -> Tensor:
@@ -124,7 +159,7 @@ def log_lut_diagnostics_epoch(
         embeddings=lut_weights,
         probe_batch=probe_batch,
         beta_fn=beta_fn,
-        embeddings_prev=prev_lut,
+        embeddings_prev=_scalarize_lut_embeddings(prev_lut, metric=metric_name) if prev_lut is not None else None,
         grad=grad,
         lr=lr,
         beta_values=beta_values,

--- a/examples/image/training/model_diagnostics.py
+++ b/examples/image/training/model_diagnostics.py
@@ -1,0 +1,570 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the CC-by-NC license found in the
+# LICENSE file in the root directory of this source tree.
+"""Model-level diagnostics for weight/activation stability analysis.
+
+These utilities implement the diagnostics requested in the EDM2 analysis:
+- Per-layer weight norms (RMS, Frobenius, spectral)
+- Effective learning rate (update ratio) between checkpoints
+- Activation RMS tracking via forward hooks on a fixed batch
+- Attention statistics (Q/K RMS, logit std, attention entropy)
+
+The diagnostics are designed to run offline during evaluation and emit CSV
+summaries that can be post-processed for visualization.
+"""
+
+from __future__ import annotations
+
+import csv
+import logging
+import math
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
+
+import torch
+from torch import nn
+from torch.nn import init as nn_init
+from torch.nn.parallel import DistributedDataParallel
+
+from models.unet import AttentionBlock, ResBlock
+
+logger = logging.getLogger(__name__)
+
+
+def _get_module(model: nn.Module) -> nn.Module:
+    if isinstance(model, DistributedDataParallel):
+        return model.module
+    return model
+
+
+def _tensor_frobenius_norm(tensor: torch.Tensor) -> float:
+    return float(torch.linalg.norm(tensor.float()).item())
+
+
+def _tensor_rms(tensor: torch.Tensor) -> float:
+    return float(torch.sqrt(torch.mean(tensor.float().pow(2))).item())
+
+
+def _fan_in_normalized_rms(tensor: torch.Tensor) -> float:
+    rms = torch.sqrt(torch.mean(tensor.float().pow(2)))
+    if tensor.ndim < 2:
+        return float(rms.item())
+    try:
+        fan_in, _ = nn_init._calculate_fan_in_and_fan_out(tensor)
+    except ValueError:
+        return float(rms.item())
+    fan_in = max(float(fan_in), 1.0)
+    return float(rms * math.sqrt(fan_in))
+
+
+def _spectral_norm_power_iteration(tensor: torch.Tensor, num_iters: int = 8) -> float:
+    weight = tensor.float().reshape(tensor.shape[0], -1) if tensor.ndim >= 2 else tensor.float().reshape(1, -1)
+    if weight.numel() == 0:
+        return 0.0
+    u = torch.randn(weight.size(0), device=weight.device)
+    u = u / (u.norm() + 1e-12)
+    for _ in range(max(num_iters, 1)):
+        v = torch.matmul(weight.t(), u)
+        v = v / (v.norm() + 1e-12)
+        u = torch.matmul(weight, v)
+        u = u / (u.norm() + 1e-12)
+    sigma = torch.dot(u, torch.matmul(weight, v))
+    return float(sigma.item())
+
+
+@dataclass
+class WeightMetrics:
+    checkpoint: str
+    step: Optional[int]
+    layer: str
+    rms_fanin: float
+    frobenius: float
+    spectral: float
+
+
+@dataclass
+class UpdateRatio:
+    checkpoint_prev: str
+    checkpoint_curr: str
+    step_prev: Optional[int]
+    step_curr: Optional[int]
+    layer: str
+    ratio: float
+
+
+@dataclass
+class ActivationRecord:
+    checkpoint: str
+    step: Optional[int]
+    module: str
+    num_channels: int
+    rms_min: float
+    rms_median: float
+    rms_max: float
+
+
+@dataclass
+class AttentionRecord:
+    checkpoint: str
+    step: Optional[int]
+    module: str
+    q_rms: float
+    k_rms: float
+    logit_std: float
+    entropy_mean: float
+    entropy_min: float
+    entropy_max: float
+
+
+class _ActivationCollector:
+    def __init__(self, root: nn.Module) -> None:
+        self._root = root
+        self._activation_records: List[ActivationRecord] = []
+        self._attention_records: List[AttentionRecord] = []
+        self._handles: List[torch.utils.hooks.RemovableHandle] = []
+        self._attn_handles: List[torch.utils.hooks.RemovableHandle] = []
+
+    def __enter__(self) -> "_ActivationCollector":
+        self._register()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        self.close()
+
+    def close(self) -> None:
+        for handle in self._handles:
+            handle.remove()
+        for handle in self._attn_handles:
+            handle.remove()
+        self._handles.clear()
+        self._attn_handles.clear()
+
+    def records(self) -> Tuple[List[ActivationRecord], List[AttentionRecord]]:
+        return self._activation_records, self._attention_records
+
+    def _register(self) -> None:
+        for name, module in self._root.named_modules():
+            if isinstance(module, (ResBlock, AttentionBlock)):
+                handle = module.register_forward_hook(self._make_activation_hook(name))
+                self._handles.append(handle)
+            if isinstance(module, AttentionBlock):
+                handle = module.attention.register_forward_hook(
+                    self._make_attention_hook(name)
+                )
+                self._attn_handles.append(handle)
+
+    def _make_activation_hook(self, name: str):
+        def hook(_module: nn.Module, _inputs: Tuple[torch.Tensor, ...], output) -> None:
+            tensor = output[0] if isinstance(output, (tuple, list)) else output
+            if not isinstance(tensor, torch.Tensor):
+                return
+            data = tensor.detach().float()
+            if data.ndim < 3:
+                return
+            # Collapse spatial dimensions
+            dims = tuple(range(2, data.ndim))
+            channel_rms = torch.sqrt(torch.mean(data.pow(2), dim=dims))
+            if channel_rms.numel() == 0:
+                return
+            self._activation_records.append(
+                ActivationRecord(
+                    checkpoint="",
+                    step=None,
+                    module=name,
+                    num_channels=int(channel_rms.numel()),
+                    rms_min=float(channel_rms.min().item()),
+                    rms_median=float(channel_rms.median().item()),
+                    rms_max=float(channel_rms.max().item()),
+                )
+            )
+
+        return hook
+
+    def _make_attention_hook(self, parent_name: str):
+        def hook(_module: nn.Module, inputs: Tuple[torch.Tensor, ...], _output) -> None:
+            if not inputs:
+                return
+            qkv = inputs[0]
+            if not isinstance(qkv, torch.Tensor):
+                return
+            bs, width, length = qkv.shape
+            attention_block = self._locate_attention_block(parent_name)
+            if attention_block is None:
+                return
+            num_heads = attention_block.num_heads
+            if width % (3 * num_heads) != 0:
+                return
+            head_dim = width // (3 * num_heads)
+            q, k, v = qkv.chunk(3, dim=1)
+            q = q.view(bs, num_heads, head_dim, length)
+            k = k.view(bs, num_heads, head_dim, length)
+            q_rms = torch.sqrt(torch.mean(q.float().pow(2)))
+            k_rms = torch.sqrt(torch.mean(k.float().pow(2)))
+
+            scale = 1.0 / math.sqrt(math.sqrt(float(head_dim)))
+            q_flat = (q.float() * scale).reshape(bs * num_heads, head_dim, length)
+            k_flat = (k.float() * scale).reshape(bs * num_heads, head_dim, length)
+            logits = torch.bmm(q_flat.transpose(1, 2), k_flat)
+            logit_std = logits.std()
+
+            attn = torch.softmax(logits.detach(), dim=-1)
+            entropy = -(attn * torch.log(attn.clamp_min(1e-9))).sum(dim=-1)
+            self._attention_records.append(
+                AttentionRecord(
+                    checkpoint="",
+                    step=None,
+                    module=f"{parent_name}.attention",
+                    q_rms=float(q_rms.item()),
+                    k_rms=float(k_rms.item()),
+                    logit_std=float(logit_std.item()),
+                    entropy_mean=float(entropy.mean().item()),
+                    entropy_min=float(entropy.min().item()),
+                    entropy_max=float(entropy.max().item()),
+                )
+            )
+
+        return hook
+
+    def _locate_attention_block(self, name: str) -> Optional[AttentionBlock]:
+        module = dict(self._root.named_modules()).get(name)
+        if isinstance(module, AttentionBlock):
+            return module
+        return None
+
+
+class DiagnosticsRunner:
+    """Execute diagnostics across a list of checkpoints and dump CSV summaries."""
+
+    def __init__(
+        self,
+        model: nn.Module,
+        device: torch.device,
+        args,
+        data_loader,
+    ) -> None:
+        self.model = model
+        self.device = device
+        self.args = args
+        self.data_loader = data_loader
+        self.power_iters = int(getattr(args, "diag_power_iters", 8))
+        self.batch_size = int(getattr(args, "diag_batch_size", getattr(args, "batch_size", 32)))
+        diag_time = float(getattr(args, "diag_time", 0.5))
+        self.diag_time = float(min(max(diag_time, 0.0), 1.0))
+        self.checkpoint_paths = self._resolve_checkpoint_paths()
+        self.output_dir = self._resolve_output_dir()
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+
+        self.weight_records: List[WeightMetrics] = []
+        self.update_records: List[UpdateRatio] = []
+        self.activation_records: List[ActivationRecord] = []
+        self.attention_records: List[AttentionRecord] = []
+
+    def _resolve_checkpoint_paths(self) -> List[Path]:
+        paths: List[str] = list(getattr(self.args, "diag_checkpoint", []) or [])
+        if not paths:
+            resume = getattr(self.args, "resume", None)
+            if resume:
+                paths.append(resume)
+        resolved: List[Path] = []
+        for p in paths:
+            path = Path(p).expanduser()
+            if path.exists():
+                resolved.append(path)
+            else:
+                logger.warning("Diagnostics checkpoint %s does not exist", path)
+        return resolved
+
+    def _resolve_output_dir(self) -> Path:
+        override = getattr(self.args, "diag_output_dir", None)
+        if override:
+            return Path(override).expanduser()
+        base = getattr(self.args, "output_dir", None)
+        if base:
+            return Path(base) / "diagnostics"
+        return Path.cwd() / "diagnostics"
+
+    def run(self, metric_path: Optional[Any] = None) -> None:
+        if not self.checkpoint_paths:
+            logger.warning("Diagnostics enabled but no checkpoints were provided")
+            return
+        model_core = _get_module(self.model)
+        orig_state = {k: v.detach().cpu().clone() for k, v in model_core.state_dict().items()}
+        prev_state: Optional[Dict[str, torch.Tensor]] = None
+        prev_name: Optional[str] = None
+        prev_step: Optional[int] = None
+
+        batch_data = self._prepare_batch()
+        for ckpt_path in self.checkpoint_paths:
+            step = self._load_checkpoint(model_core, ckpt_path, metric_path)
+            logger.info("Running diagnostics for %s (step=%s)", ckpt_path, step)
+            self._collect_weight_metrics(model_core, ckpt_path.name, step)
+            if prev_state is not None and prev_name is not None:
+                self._collect_update_ratios(model_core, ckpt_path.name, step, prev_name, prev_step, prev_state)
+            self._collect_activation_metrics(model_core, metric_path, batch_data, ckpt_path.name, step)
+            prev_state = {
+                name: param.detach().cpu().clone()
+                for name, param in model_core.named_parameters()
+            }
+            prev_name = ckpt_path.name
+            prev_step = step
+
+        model_core.load_state_dict(orig_state)
+        self._write_csvs()
+
+    def _prepare_batch(self):
+        iterator = iter(self.data_loader)
+        batch = next(iterator)
+        if isinstance(batch, (tuple, list)):
+            samples = batch[0]
+            labels = batch[1] if len(batch) > 1 else None
+        else:
+            samples = batch
+            labels = None
+        samples = samples[: self.batch_size].to(self.device, non_blocking=True)
+        if labels is not None:
+            labels = labels[: self.batch_size].to(self.device, non_blocking=True)
+        return samples, labels
+
+    def _load_checkpoint(
+        self,
+    model_core: nn.Module,
+    ckpt_path: Path,
+    metric_path: Optional[Any],
+    ) -> Optional[int]:
+        checkpoint = torch.load(ckpt_path, map_location="cpu")
+        state_dict = checkpoint.get("model", checkpoint)
+        model_core.load_state_dict(state_dict)
+        step = checkpoint.get("epoch")
+        extra_modules = checkpoint.get("extra_modules", {})
+        if metric_path is not None and isinstance(extra_modules, dict):
+            beta_schedule = getattr(metric_path, "beta_schedule", None)
+            if isinstance(beta_schedule, nn.Module):
+                beta_state = extra_modules.get("metric_beta_schedule")
+                if beta_state:
+                    beta_schedule.load_state_dict(beta_state)
+            learnable_metric = getattr(metric_path, "learnable_metric", None)
+            if isinstance(learnable_metric, nn.Module):
+                metric_state = extra_modules.get("metric_learnable_metric")
+                if metric_state:
+                    learnable_metric.load_state_dict(metric_state)
+        return step
+
+    def _collect_weight_metrics(
+        self,
+        model_core: nn.Module,
+        checkpoint_name: str,
+        step: Optional[int],
+    ) -> None:
+        for name, param in model_core.named_parameters():
+            if param.ndim == 0:
+                continue
+            tensor = param.detach()
+            self.weight_records.append(
+                WeightMetrics(
+                    checkpoint=checkpoint_name,
+                    step=step,
+                    layer=name,
+                    rms_fanin=_fan_in_normalized_rms(tensor),
+                    frobenius=_tensor_frobenius_norm(tensor),
+                    spectral=_spectral_norm_power_iteration(tensor, self.power_iters),
+                )
+            )
+
+    def _collect_update_ratios(
+        self,
+        model_core: nn.Module,
+        checkpoint_name: str,
+        step: Optional[int],
+        prev_checkpoint: str,
+        prev_step: Optional[int],
+        prev_state: Dict[str, torch.Tensor],
+    ) -> None:
+        eps = 1e-12
+        for name, param in model_core.named_parameters():
+            if param.ndim == 0 or name not in prev_state:
+                continue
+            current = param.detach().float()
+            previous = prev_state[name].to(current.device)
+            delta = current - previous
+            denom = current.norm().item()
+            ratio = delta.norm().item() / (denom + eps)
+            self.update_records.append(
+                UpdateRatio(
+                    checkpoint_prev=prev_checkpoint,
+                    checkpoint_curr=checkpoint_name,
+                    step_prev=prev_step,
+                    step_curr=step,
+                    layer=name,
+                    ratio=ratio,
+                )
+            )
+
+    def _collect_activation_metrics(
+        self,
+    model_core: nn.Module,
+    metric_path: Optional[Any],
+        batch_data,
+        checkpoint_name: str,
+        step: Optional[int],
+    ) -> None:
+        samples, labels = batch_data
+        samples = samples.clone()
+        labels = labels.clone()
+        with torch.no_grad():
+            if getattr(self.args, "metric_induced", False) and metric_path is not None:
+                tokens = (samples * 255.0).to(torch.long)
+                t = torch.full((tokens.shape[0],), self.diag_time, device=self.device)
+                x0 = torch.zeros_like(tokens)
+                path_sample = metric_path.sample(t=t, x_0=x0, x_1=tokens)
+                x_t = path_sample.x_t_soft if path_sample.x_t_soft is not None else path_sample.x_t
+            else:
+                x_t = samples
+                t = torch.full((samples.shape[0],), self.diag_time, device=self.device)
+            extra = {"label": labels} if labels.numel() else {}
+            model_core.eval()
+            with _ActivationCollector(model_core) as collector:
+                _ = model_core(x_t, t=t, extra=extra)
+                activations, attentions = collector.records()
+        for record in activations:
+            self.activation_records.append(
+                ActivationRecord(
+                    checkpoint=checkpoint_name,
+                    step=step,
+                    module=record.module,
+                    num_channels=record.num_channels,
+                    rms_min=record.rms_min,
+                    rms_median=record.rms_median,
+                    rms_max=record.rms_max,
+                )
+            )
+        for record in attentions:
+            self.attention_records.append(
+                AttentionRecord(
+                    checkpoint=checkpoint_name,
+                    step=step,
+                    module=record.module,
+                    q_rms=record.q_rms,
+                    k_rms=record.k_rms,
+                    logit_std=record.logit_std,
+                    entropy_mean=record.entropy_mean,
+                    entropy_min=record.entropy_min,
+                    entropy_max=record.entropy_max,
+                )
+            )
+
+    def _write_csvs(self) -> None:
+        if self.weight_records:
+            self._write_csv(
+                "weights.csv",
+                [
+                    "checkpoint",
+                    "step",
+                    "layer",
+                    "rms_fanin",
+                    "frobenius",
+                    "spectral",
+                ],
+                (
+                    {
+                        "checkpoint": rec.checkpoint,
+                        "step": rec.step if rec.step is not None else "",
+                        "layer": rec.layer,
+                        "rms_fanin": rec.rms_fanin,
+                        "frobenius": rec.frobenius,
+                        "spectral": rec.spectral,
+                    }
+                    for rec in self.weight_records
+                ),
+            )
+        if self.update_records:
+            self._write_csv(
+                "update_ratios.csv",
+                [
+                    "checkpoint_prev",
+                    "step_prev",
+                    "checkpoint_curr",
+                    "step_curr",
+                    "layer",
+                    "ratio",
+                ],
+                (
+                    {
+                        "checkpoint_prev": rec.checkpoint_prev,
+                        "step_prev": rec.step_prev if rec.step_prev is not None else "",
+                        "checkpoint_curr": rec.checkpoint_curr,
+                        "step_curr": rec.step_curr if rec.step_curr is not None else "",
+                        "layer": rec.layer,
+                        "ratio": rec.ratio,
+                    }
+                    for rec in self.update_records
+                ),
+            )
+        if self.activation_records:
+            self._write_csv(
+                "activations.csv",
+                [
+                    "checkpoint",
+                    "step",
+                    "module",
+                    "num_channels",
+                    "rms_min",
+                    "rms_median",
+                    "rms_max",
+                ],
+                (
+                    {
+                        "checkpoint": rec.checkpoint,
+                        "step": rec.step if rec.step is not None else "",
+                        "module": rec.module,
+                        "num_channels": rec.num_channels,
+                        "rms_min": rec.rms_min,
+                        "rms_median": rec.rms_median,
+                        "rms_max": rec.rms_max,
+                    }
+                    for rec in self.activation_records
+                ),
+            )
+        if self.attention_records:
+            self._write_csv(
+                "attention.csv",
+                [
+                    "checkpoint",
+                    "step",
+                    "module",
+                    "q_rms",
+                    "k_rms",
+                    "logit_std",
+                    "entropy_mean",
+                    "entropy_min",
+                    "entropy_max",
+                ],
+                (
+                    {
+                        "checkpoint": rec.checkpoint,
+                        "step": rec.step if rec.step is not None else "",
+                        "module": rec.module,
+                        "q_rms": rec.q_rms,
+                        "k_rms": rec.k_rms,
+                        "logit_std": rec.logit_std,
+                        "entropy_mean": rec.entropy_mean,
+                        "entropy_min": rec.entropy_min,
+                        "entropy_max": rec.entropy_max,
+                    }
+                    for rec in self.attention_records
+                ),
+            )
+
+    def _write_csv(self, filename: str, fieldnames: Sequence[str], rows: Iterable[Dict[str, object]]) -> None:
+        path = self.output_dir / filename
+        with path.open("w", newline="", encoding="utf-8") as f:
+            writer = csv.DictWriter(f, fieldnames=fieldnames)
+            writer.writeheader()
+            for row in rows:
+                writer.writerow(row)
+        logger.info("Diagnostics wrote %s", path)
+
+
+__all__ = ["DiagnosticsRunner"]

--- a/examples/image/training/train_loop.py
+++ b/examples/image/training/train_loop.py
@@ -12,6 +12,7 @@ from typing import Iterable, Optional
 
 import torch
 import torch.nn as nn
+import numpy as np
 from flow_matching.path import (
     CondOTProbPath,
     MixtureDiscreteProbPath,
@@ -100,6 +101,69 @@ def skewed_timestep_sample(num_samples: int, device: torch.device) -> torch.Tens
     time = 1 / (1 + sigma)
     time = torch.clip(time, min=0.0001, max=1.0)
     return time
+
+
+def compute_geodesic_energy_embedding(
+    logits: torch.Tensor,
+    x_t: torch.Tensor,
+    t: torch.Tensor,
+    metric_module: nn.Module,
+) -> torch.Tensor:
+    """
+    Compute geodesic energy regularization based on velocity in embedding space.
+    
+    Energy = ||v_t||²_M where v_t = (embed(x_1_pred) - embed(x_t)) / (1 - t)
+    
+    This penalizes high-velocity trajectories in the learned metric space,
+    encouraging paths that follow geodesics and reducing entropy of intermediate
+    distributions p(x_t | x_1, t).
+    
+    Args:
+        logits: Model output logits [B, H, W, V] where V is vocab size (256)
+        x_t: Current state [B, H, W] (discrete tokens) or [B, H, W, V] (soft)
+        t: Time values [B] in [0, 1]
+        metric_module: Learnable metric with .codes attribute [V, d]
+    
+    Returns:
+        Scalar energy value (mean over batch and spatial dimensions)
+    
+    References:
+        - Energy-guided geometric flow matching: 10-20% entropy reduction
+        - Geodesic Gaussian regularization: smoother paths, lower variance
+        - Entropic Gromov-Wasserstein: 5-15% entropy drops with λ tuning
+    """
+    # Get metric embedding codes [vocab_size, embedding_dim]
+    codes = metric_module.codes  # [256, d]
+    
+    # Predicted distribution over x_1
+    x_1_pred = torch.nn.functional.softmax(logits, dim=-1)  # [B, H, W, 256]
+    
+    # Convert x_t to soft distribution if needed
+    if x_t.dtype == torch.long or x_t.dim() == 3:
+        # Hard tokens [B, H, W] → one-hot [B, H, W, 256]
+        vocab_size = codes.shape[0]
+        x_t_soft = torch.nn.functional.one_hot(
+            x_t.long(), num_classes=vocab_size
+        ).float()
+    else:
+        # Already soft [B, H, W, 256]
+        x_t_soft = x_t
+    
+    # Compute embeddings: weighted average of codes
+    # x @ codes: [B, H, W, 256] @ [256, d] → [B, H, W, d]
+    x_t_embed = x_t_soft @ codes  # [B, H, W, d]
+    x_1_embed = x_1_pred @ codes  # [B, H, W, d]
+    
+    # Velocity in embedding space: change per unit time remaining
+    # v_t = (x_1 - x_t) / (1 - t)  where t ∈ [0, 1]
+    delta_t = 1.0 - t.view(-1, 1, 1, 1) + 1e-8  # [B, 1, 1, 1]
+    v_t = (x_1_embed - x_t_embed) / delta_t  # [B, H, W, d]
+    
+    # Energy: L2 norm squared (already in metric space, no need for M weighting)
+    # ||v_t||² = sum_d v_t[d]²
+    energy = (v_t ** 2).sum(dim=-1).mean()  # scalar
+    
+    return energy
 
 
 class AdaptiveKLController(nn.Module):
@@ -196,20 +260,108 @@ def _anneal_scalar(
     step: int, total_steps: int, start: float, end: float, schedule: str
 ) -> float:
     """Return an annealed scalar following the provided schedule."""
-
     if total_steps <= 0:
         return end
-
-    progress = min(max(step / float(total_steps), 0.0), 1.0)
-    if schedule == "quadratic":
-        weight = (1.0 - progress) ** 2
-    elif schedule == "linear":
-        weight = 1.0 - progress
+    
+    if step <= 0:
+        return start
+    if step >= total_steps:
+        return end
+    
+    progress = step / total_steps
+    
+    if schedule == "linear":
+        return start + (end - start) * progress
     elif schedule == "cosine":
-        weight = 0.5 * (math.cos(math.pi * progress) + 1.0)
+        cos_factor = 0.5 * (1 + math.cos(math.pi * progress))
+        return end + (start - end) * cos_factor
+    elif schedule == "exp":
+        return start * math.exp(progress * math.log(end / start))
     else:
-        raise ValueError(f"Unsupported Gumbel annealing schedule: {schedule}")
-    return end + (start - end) * weight
+        raise ValueError(f"Unknown schedule: {schedule}")
+
+
+def adjust_metric_learning_rate(
+    optimizer: torch.optim.Optimizer,
+    epoch: int,
+    args: argparse.Namespace,
+) -> None:
+    """Adjust learning rate for metric parameters based on decay schedule.
+    
+    This allows the metric to stabilize in later training while UNet continues
+    adapting to the learned geometry. Inspired by staged learning strategies.
+    
+    Args:
+        optimizer: The optimizer containing metric parameter groups
+        epoch: Current training epoch
+        args: Training arguments containing decay configuration
+    """
+    if not getattr(args, "mi_learnable_metric", False):
+        return
+    
+    decay_start = int(getattr(args, "mi_metric_lr_decay_start", 3500))
+    if epoch < decay_start:
+        return
+    
+    decay_mode = getattr(args, "mi_metric_lr_decay_mode", "cosine")
+    if decay_mode == "none":
+        return
+    
+    # Base learning rate for metric (before decay)
+    base_lr = args.lr * float(getattr(args, "mi_metric_lr_scale", 0.1))
+    end_ratio = float(getattr(args, "mi_metric_lr_decay_end_ratio", 0.1))
+    
+    # Compute decay factor based on mode
+    if decay_mode == "cosine":
+        # Cosine annealing from 1.0 to end_ratio
+        progress = (epoch - decay_start) / (args.epochs - decay_start)
+        progress = min(progress, 1.0)
+        
+        decay_factor = end_ratio + (1.0 - end_ratio) * 0.5 * (
+            1 + math.cos(math.pi * progress)
+        )
+        
+    elif decay_mode == "exp":
+        # Exponential decay
+        decay_steps = (epoch - decay_start) / 100.0
+        # Decay to end_ratio over ~10 steps (1000 epochs)
+        decay_factor = max(end_ratio, end_ratio ** (decay_steps / 10.0))
+        
+    elif decay_mode == "step":
+        # Step-wise decay at fixed milestones
+        if epoch >= 4000:
+            decay_factor = 0.25
+        elif epoch >= 3500:
+            decay_factor = 0.5
+        else:
+            decay_factor = 1.0
+    else:
+        decay_factor = 1.0
+    
+    # Apply to metric parameter groups only
+    adjusted_any = False
+    for param_group in optimizer.param_groups:
+        # Identify metric parameters by group name
+        group_name = param_group.get("name", "")
+        # Also check if this group has fewer parameters (metric typically has 1-2 params)
+        # and weight_decay is set (metric uses weight_decay, UNet typically doesn't)
+        is_metric_group = (
+            "learnable_metric" in group_name 
+            or "metric" in group_name
+            or (param_group.get("weight_decay", 0) > 0 and len(param_group["params"]) <= 10)
+        )
+        if is_metric_group:
+            new_lr = base_lr * decay_factor
+            param_group["lr"] = new_lr
+            adjusted_any = True
+    
+    # Log only once per epoch (rank 0 only)
+    if adjusted_any and distributed_mode.is_main_process():
+        logger.info(
+            f"Epoch {epoch}: Metric LR adjusted to {base_lr * decay_factor:.2e} "
+            f"(mode={decay_mode}, factor={decay_factor:.4f})"
+        )
+
 
 
 def train_one_epoch(
@@ -252,12 +404,34 @@ def train_one_epoch(
     else:
         path = CondOTProbPath()
 
+    # Snapshot LUT state at epoch start for delta computations at epoch end.
+    # Stored on args so state persists across function calls. Non-fatal if any error.
+    if hasattr(path, "learnable_lut") and path.learnable_lut is not None:
+        try:
+            with torch.no_grad():
+                start_w = path.learnable_lut().detach().cpu().clone()
+            setattr(args, "_epoch_lut_start", start_w)
+            if hasattr(path.learnable_lut, "scale_c") and path.learnable_lut.scale_c is not None:
+                setattr(args, "_epoch_lut_scale_c_start", path.learnable_lut.scale_c.detach().cpu().clone())
+        except Exception:
+            pass
+
     beta_schedule_module: Optional[nn.Module] = None
     if isinstance(path, MetricInducedGibbsProbPath) and isinstance(
         path.beta_schedule, nn.Module
     ):
         beta_schedule_module = path.beta_schedule
 
+    # Freeze schedule: params frozen but EMA continues (soft landing mechanism)
+    freeze_schedule = getattr(args, "mi_freeze_beta_schedule", False)
+    if freeze_schedule and schedule_ema is not None and epoch == args.start_epoch:
+        # Only log once at the first epoch, and only on rank 0
+        if distributed_mode.is_main_process():
+            logger.info(
+                "Freeze mode: schedule params frozen (no gradient), EMA continues (smooth training target). "
+                "EMA will gradually converge to frozen values."
+            )
+    
     teacher_schedule_available = (
         schedule_ema is not None and beta_schedule_module is not None
     )
@@ -268,6 +442,7 @@ def train_one_epoch(
     )
     use_path_ema = teacher_schedule_available or teacher_metric_available
     use_path_trust_region = use_path_ema and kl_controller is not None
+    
     if kl_controller is not None and not use_path_ema:
         logger.warning(
             "KL controller was provided without an EMA teacher; disabling the controller."
@@ -320,7 +495,10 @@ def train_one_epoch(
     if _dl_len is not None:
         updates_per_epoch = (_dl_len + accum_iter - 1) // accum_iter
     gumbel_update_step = int(getattr(args, "_gumbel_update_step", 0))
-    if gumbel_schedule_active and updates_per_epoch is not None:
+    # CRITICAL: If explicitly set to 0 (e.g., when resuming but wanting fresh annealing),
+    # don't override it with epoch_offset. Only use epoch_offset if counter is uninitialized.
+    was_explicitly_reset = hasattr(args, "_annealing_counters_reset") and getattr(args, "_annealing_counters_reset", False)
+    if gumbel_schedule_active and updates_per_epoch is not None and not was_explicitly_reset:
         epoch_offset = epoch * updates_per_epoch
         if gumbel_update_step < epoch_offset:
             gumbel_update_step = epoch_offset
@@ -338,7 +516,8 @@ def train_one_epoch(
         path.get_metric_interpolation_lambda() if metric_interp_active else None
     )
     metric_interp_update_step = int(getattr(args, "_metric_interp_update_step", 0))
-    if metric_interp_active and updates_per_epoch is not None:
+    # CRITICAL: Same logic as gumbel_update_step - respect explicit reset to 0
+    if metric_interp_active and updates_per_epoch is not None and not was_explicitly_reset:
         epoch_offset_interp = epoch * updates_per_epoch
         if metric_interp_update_step < epoch_offset_interp:
             metric_interp_update_step = epoch_offset_interp
@@ -531,6 +710,7 @@ def train_one_epoch(
 
             mix_alpha_raw = float(getattr(args, "mi_logbeta_mis_alpha", 0.0))
             mix_alpha = float(min(max(mix_alpha_raw, 0.0), 1.0))
+            use_is = bool(getattr(args, "mi_logbeta_use_is", False))
 
             batch_size = samples.shape[0]
             uniform_span = max(uniform_hi - uniform_lo, 1e-6)
@@ -561,24 +741,35 @@ def train_one_epoch(
                         1.0 - mix_alpha,
                     )
                     setattr(args, "_mi_logbeta_mis_announced", True)
+                if not use_is and not getattr(args, "_mi_logbeta_no_is_announced", False):
+                    logger.info(
+                        "Importance sampling DISABLED: using direct log-β sampling without reweighting"
+                    )
+                    setattr(args, "_mi_logbeta_no_is_announced", True)
 
-                interval = max(float(lmax_val) - float(lmin_val), 1e-6)
-                t_for_schedule = t.to(device=t_logbeta.device, dtype=t_logbeta.dtype)
-                beta_vals, beta_deriv = schedule.beta_and_derivative(t_for_schedule)
-                beta_vals = beta_vals.clamp_min(1e-12)
-                q_logbeta = (beta_deriv / beta_vals).clamp_min(1e-12) / interval
-                q_logbeta = q_logbeta.to(device=device, dtype=torch.float32)
-                one_over_span = torch.tensor(
-                    1.0 / uniform_span,
-                    device=device,
-                    dtype=q_logbeta.dtype,
-                )
-                q_uniform = torch.zeros_like(q_logbeta)
-                within_uniform = (t >= uniform_lo) & (t <= uniform_hi)
-                q_uniform = torch.where(within_uniform, one_over_span, q_uniform)
-                q_mix = mix_alpha * q_uniform + (1.0 - mix_alpha) * q_logbeta
-                logbeta_weights = (1.0 / q_mix.clamp_min(1e-12)).to(device=device)
-                mis_uniform_frac = float(selector.float().mean().detach().cpu().item())
+                # Only compute IS weights when explicitly enabled
+                if use_is:
+                    interval = max(float(lmax_val) - float(lmin_val), 1e-6)
+                    t_for_schedule = t.to(device=t_logbeta.device, dtype=t_logbeta.dtype)
+                    beta_vals, beta_deriv = schedule.beta_and_derivative(t_for_schedule)
+                    beta_vals = beta_vals.clamp_min(1e-12)
+                    q_logbeta = (beta_deriv / beta_vals).clamp_min(1e-12) / interval
+                    q_logbeta = q_logbeta.to(device=device, dtype=torch.float32)
+                    one_over_span = torch.tensor(
+                        1.0 / uniform_span,
+                        device=device,
+                        dtype=q_logbeta.dtype,
+                    )
+                    q_uniform = torch.zeros_like(q_logbeta)
+                    within_uniform = (t >= uniform_lo) & (t <= uniform_hi)
+                    q_uniform = torch.where(within_uniform, one_over_span, q_uniform)
+                    q_mix = mix_alpha * q_uniform + (1.0 - mix_alpha) * q_logbeta
+                    logbeta_weights = (1.0 / q_mix.clamp_min(1e-12)).to(device=device)
+                    mis_uniform_frac = float(selector.float().mean().detach().cpu().item())
+                else:
+                    # IS disabled: no reweighting
+                    logbeta_weights = None
+                    mis_uniform_frac = float(selector.float().mean().detach().cpu().item()) if mix_alpha > 0.0 else None
             else:
                 t = t_uniform
 
@@ -638,6 +829,20 @@ def train_one_epoch(
             if logbeta_reg_penalty is not None:
                 loss = loss + logbeta_reg_penalty
 
+            # Bounded residual scale penalty (L2 on scale parameter c)
+            scale_penalty: Optional[torch.Tensor] = None
+            scale_penalty_weight = getattr(args, "mi_lut_scale_penalty_weight", 0.01)
+            if (
+                scale_penalty_weight > 0.0
+                and hasattr(path, "learnable_lut")
+                and path.learnable_lut is not None
+                and hasattr(path.learnable_lut, "scale_c")
+                and path.learnable_lut.scale_c is not None
+            ):
+                # L2 penalty on scale parameter c to keep it near 0
+                scale_penalty = scale_penalty_weight * (path.learnable_lut.scale_c ** 2).sum()
+                loss = loss + scale_penalty
+
             if use_path_trust_region:
                 x1_flat = samples.view(samples.shape[0], -1)
                 with torch.no_grad():
@@ -672,6 +877,43 @@ def train_one_epoch(
                 kl_sum_for_step += float(schedule_kl_value.detach())
                 kl_micro_steps += 1
 
+            # Geodesic energy regularization (optional)
+            geodesic_energy_val: Optional[torch.Tensor] = None
+            geodesic_penalty: Optional[torch.Tensor] = None
+            
+            geodesic_weight = getattr(args, "mi_geodesic_energy_weight", 0.0)
+            if geodesic_weight > 0.0:
+                if isinstance(path, MetricInducedGibbsProbPath):
+                    if path.learnable_metric is not None:
+                        # Only apply when learned metric is active
+                        current_lambda = path.get_metric_interpolation_lambda()
+                        if current_lambda > 0.0:
+                            # Compute geodesic energy
+                            geo_energy = compute_geodesic_energy_embedding(
+                                logits=logits,
+                                x_t=path_sample.x_t,  # Use discrete tokens
+                                t=t,
+                                metric_module=path.learnable_metric,
+                            )
+                            
+                            # Weight by metric interpolation (stronger as lambda increases)
+                            # and by user-specified regularization strength
+                            geo_penalty = geodesic_weight * current_lambda * geo_energy
+                            
+                            # Add to total loss
+                            loss = loss + geo_penalty
+                            
+                            # Store for logging (detach to avoid gradients)
+                            geodesic_energy_val = geo_energy.detach()
+                            
+                            # Announce once per training
+                            if not getattr(args, "_geodesic_energy_announced", False):
+                                logger.info(
+                                    f"[Geodesic Energy] Enabled with λ={geodesic_weight:.4f}, "
+                                    f"current metric interpolation={current_lambda:.3f}"
+                                )
+                                setattr(args, "_geodesic_energy_announced", True)
+
             wandb_logger = None
             if getattr(args, "wandb", False) and distributed_mode.is_main_process():
                 try:
@@ -689,6 +931,13 @@ def train_one_epoch(
                     w = logbeta_weights.detach()
                     ess_num = (w.sum() ** 2) / (w.square().sum() + 1e-12)
                     wandb_log_data["diag/ess_frac"] = float((ess_num / (w.numel() + 1e-12)).item())
+                    wandb_log_data["diag/weight_mean"] = float(w.mean().item())
+                    wandb_log_data["diag/weight_std"] = float(w.std().item())
+                    wandb_log_data["diag/weight_max"] = float(w.max().item())
+                    wandb_log_data["diag/weight_min"] = float(w.min().item())
+                else:
+                    # IS disabled: ESS = 1.0 (all samples have equal weight)
+                    wandb_log_data["diag/ess_frac"] = 1.0
                 if mis_uniform_frac is not None:
                     wandb_log_data["diag/mis_uniform_frac"] = mis_uniform_frac
                 if logbeta_reg_penalty is not None:
@@ -709,158 +958,49 @@ def train_one_epoch(
                                 ),
                             }
                         )
+                
+                # Log geodesic energy regularization
+                if geodesic_energy_val is not None:
+                    wandb_log_data["train/geodesic_energy"] = float(
+                        geodesic_energy_val.cpu().item()
+                    )
+                if geodesic_penalty is not None:
+                    wandb_log_data["train/geodesic_penalty"] = float(
+                        geodesic_penalty.detach().cpu().item()
+                    )
 
-                if data_iter_step % (PRINT_FREQUENCY * 10) == 0:
-                    max_points = int(getattr(args, "wandb_entropy_max_points", 4096) or 4096)
-                    entropy_table = getattr(args, "_entropy_vs_t_table", None)
-                    entropy_rows = getattr(args, "_entropy_vs_t_rows", None)
-                    if not isinstance(entropy_rows, deque):
-                        existing_rows = list(entropy_rows) if entropy_rows is not None else []
-                        entropy_rows = deque(existing_rows[-max_points:], maxlen=max_points)
-                        setattr(args, "_entropy_vs_t_rows", entropy_rows)
-                    elif entropy_rows.maxlen != max_points:
-                        entropy_rows = deque(list(entropy_rows)[-max_points:], maxlen=max_points)
-                        setattr(args, "_entropy_vs_t_rows", entropy_rows)
-                    if entropy_table is None:
-                        entropy_table = wandb_logger.echarts.Table()
-                        setattr(args, "_entropy_vs_t_table", entropy_table)
+                # Log bounded residual scale parameters and penalty
+                if (
+                    hasattr(path, "learnable_lut")
+                    and path.learnable_lut is not None
+                    and hasattr(path.learnable_lut, "scale_c")
+                    and path.learnable_lut.scale_c is not None
+                ):
+                    scale_c = path.learnable_lut.scale_c.detach().cpu()
+                    # Log each channel's scale_c value
+                    for ch_idx in range(scale_c.numel()):
+                        wandb_log_data[f"lut/scale_c_ch{ch_idx}"] = float(scale_c[ch_idx].item())
+                    # Log scale_c statistics
+                    wandb_log_data["lut/scale_c_mean"] = float(scale_c.mean().item())
+                    wandb_log_data["lut/scale_c_std"] = float(scale_c.std().item())
+                    wandb_log_data["lut/scale_c_min"] = float(scale_c.min().item())
+                    wandb_log_data["lut/scale_c_max"] = float(scale_c.max().item())
+                
+                # Log scale penalty if it exists
+                if scale_penalty is not None:
+                    wandb_log_data["loss/scale_penalty"] = float(
+                        scale_penalty.detach().cpu().item()
+                    )
 
+                # Log entropy vs t chart (reduced frequency to save space)
+                if data_iter_step % (PRINT_FREQUENCY * 20) == 0:  # Reduced from 10x to 20x
                     t_cpu = t.detach().float().cpu()
                     entropy_cpu = target_entropy.detach().float().cpu()
-                    counter = int(getattr(args, "_entropy_vs_t_counter", 0))
-                    new_rows = []
-                    for t_val, entropy_val in zip(t_cpu.tolist(), entropy_cpu.tolist()):
-                        # Track arrival order in column 2 so visualMap can encode recency with color.
-                        new_rows.append([
-                            float(t_val),
-                            float(entropy_val),
-                            float(counter),
-                        ])
-                        counter += 1
-                    setattr(args, "_entropy_vs_t_counter", counter)
-                    entropy_rows.extend(new_rows)
-
-                    rows_list = list(entropy_rows)
-                    entropy_table.add(["t", "entropy", "index"], rows_list)
-
-                    scatter_chart = wandb_logger.echarts.Scatter()
-                    scatter_chart.add_xaxis([])
-                    options_mod = getattr(wandb_logger.echarts, "options", None)
-                    label_opts = (
-                        options_mod.LabelOpts(is_show=False)
-                        if options_mod is not None
-                        else None
-                    )
-                    scatter_chart.add_yaxis(
-                        "entropy",
-                        rows_list,
-                        symbol_size=3.5,
-                        label_opts=label_opts,
-                        encode={"x": 0, "y": 1},
-                    )
-                    palette = [
-                        "#003f5c",
-                        "#2f4b7c",
-                        "#665191",
-                        "#a05195",
-                        "#d45087",
-                        "#f95d6a",
-                    ]
-                    if rows_list:
-                        min_t = min(row[0] for row in rows_list)
-                        max_t = max(row[0] for row in rows_list)
-                        if math.isfinite(min_t) and math.isfinite(max_t):
-                            if abs(max_t - min_t) < 1e-9:
-                                pad = max(abs(min_t), 1.0) * 1e-3
-                                min_axis = min_t - pad
-                                max_axis = max_t + pad
-                            else:
-                                min_axis = min_t
-                                max_axis = max_t
-                        else:
-                            min_axis = 0.0
-                            max_axis = 1.0
-                        color_min = min(row[2] for row in rows_list)
-                        color_max = max(row[2] for row in rows_list)
-                        if abs(color_max - color_min) < 1e-9:
-                            color_pad = max(abs(color_min), 1.0)
-                            color_min -= color_pad * 0.5
-                            color_max += color_pad * 0.5
-                    else:
-                        min_axis = 0.0
-                        max_axis = 1.0
-                        color_min = 0.0
-                        color_max = float(len(rows_list))
-
-                    diff = max(color_max - color_min, 1e-6)
-                    segment_count = len(palette)
-                    pieces = []
-                    for idx, color_hex in enumerate(palette):
-                        start_ratio = idx / segment_count
-                        end_ratio = (idx + 1) / segment_count
-                        piece_min = color_min + diff * start_ratio
-                        piece_max = (
-                            color_min + diff * end_ratio
-                            if idx < segment_count - 1
-                            else color_max
-                        )
-                        pieces.append(
-                            {
-                                "min": piece_min,
-                                "max": piece_max,
-                                "color": color_hex,
-                            }
-                        )
-
-                    echarts_opts = options_mod
-                    if echarts_opts is not None:
-                        tooltip_fmt = getattr(
-                            echarts_opts.TooltipOpts,
-                            "formatter",
-                            None,
-                        )
-                        tooltip_kwargs = {}
-                        if tooltip_fmt is None:
-                            tooltip_kwargs["formatter"] = "t: {c0}<br/>entropy: {c1}<br/>idx: {c2}"
-                        else:
-                            tooltip_kwargs = {"formatter": "t: {c0}<br/>entropy: {c1}<br/>idx: {c2}"}
-                        scatter_chart.set_global_opts(
-                            title_opts=echarts_opts.TitleOpts(
-                                title="Target Entropy vs t",
-                                pos_left="center",
-                            ),
-                            xaxis_opts=echarts_opts.AxisOpts(
-                                name="t",
-                                type_="value",
-                                min_=min_axis,
-                                max_=max_axis,
-                            ),
-                            yaxis_opts=echarts_opts.AxisOpts(
-                                name="entropy",
-                                type_="value",
-                            ),
-                            tooltip_opts=echarts_opts.TooltipOpts(**tooltip_kwargs),
-                            datazoom_opts=[
-                                echarts_opts.DataZoomOpts(type_="slider"),
-                                echarts_opts.DataZoomOpts(type_="inside"),
-                            ],
-                            visualmap_opts=echarts_opts.VisualMapOpts(
-                                dimension=2,
-                                is_piecewise=True,
-                                pieces=pieces,
-                                min_=color_min,
-                                max_=color_max,
-                                orient="horizontal",
-                                pos_top="5%",
-                                pos_left="center",
-                            ),
-                        )
-                        scatter_chart.set_series_opts(
-                            itemstyle_opts=echarts_opts.ItemStyleOpts(opacity=0.35),
-                        )
-
-                    wandb_log_data["diag/entropy_vs_t_table"] = entropy_table
-                    wandb_log_data["diag/entropy_vs_t"] = scatter_chart
+                    
+                    # Log simple statistics (always)
+                    wandb_log_data["diag/entropy_mean"] = float(entropy_cpu.mean().item())
+                    wandb_log_data["diag/entropy_std"] = float(entropy_cpu.std().item())
+                    wandb_log_data["diag/t_mean"] = float(t_cpu.mean().item())
                 wandb_logger.log(wandb_log_data)
         elif args.discrete_flow_matching:
             samples = (samples * 255.0).to(torch.long)
@@ -919,12 +1059,60 @@ def train_one_epoch(
         )
         grad_step_skipped = False
         if apply_update:
+            torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
             if grad_norm is None:
                 grad_step_skipped = True
             elif isinstance(grad_norm, torch.Tensor):
                 grad_step_skipped = not torch.isfinite(grad_norm.detach()).all().item()
             else:
                 grad_step_skipped = not math.isfinite(float(grad_norm))
+            
+            # Compute gradient norms before clipping for logging
+            metric_grad_norm_value = None
+            if hasattr(path, "learnable_metric") and path.learnable_metric is not None:
+                # Compute metric gradient norm BEFORE clipping
+                metric_params = list(path.learnable_metric.parameters())
+                if metric_params:
+                    metric_grad_norm_value = torch.nn.utils.clip_grad_norm_(
+                        metric_params, max_norm=float('inf')
+                    )
+                    # Now actually clip to max_norm=1.0
+                    torch.nn.utils.clip_grad_norm_(metric_params, max_norm=1.0)
+            
+            # LUT gradient diagnostics
+            lut_grad_norm_value = None
+            lut_param_delta = None
+            if hasattr(path, "learnable_lut") and path.learnable_lut is not None:
+                lut_params = list(path.learnable_lut.parameters())
+                if lut_params and lut_params[0].grad is not None:
+                    # Compute gradient norm
+                    lut_grad_norm_value = torch.nn.utils.clip_grad_norm_(
+                        lut_params, max_norm=float('inf')
+                    )
+                    # Store pre-update LUT for delta computation
+                    if not hasattr(args, '_prev_lut_weight'):
+                        args._prev_lut_weight = lut_params[0].data.detach().clone()
+                    else:
+                        # Compute parameter change
+                        lut_param_delta = (lut_params[0].data - args._prev_lut_weight).norm().item()
+                        args._prev_lut_weight = lut_params[0].data.detach().clone()
+            
+            # Post-update projection REMOVED for reparameterization mode
+            # In reparameterization mode (default), Frobenius constraint is enforced by construction
+            # via codes property: codes = scale * (codes_raw / ||codes_raw||_F)
+            # This avoids fighting the optimizer and eliminates gradient explosion
+            #
+            # Legacy post-update projection (only for old checkpoints with use_reparameterization=False):
+            # if apply_update and not grad_step_skipped:
+            #     if hasattr(path, "learnable_metric") and path.learnable_metric is not None:
+            #         if not getattr(path.learnable_metric, 'use_reparameterization', True):
+            #             with torch.no_grad():
+            #                 lower = path.learnable_metric.cholesky_factor()
+            #                 Z = path.learnable_metric.codes @ lower.T
+            #                 fro_norm = torch.linalg.norm(Z, ord='fro')
+            #                 if fro_norm > 1e-8:
+            #                     path.learnable_metric.codes.mul_(1.0 / fro_norm)
+            
             optimizer.zero_grad(set_to_none=True)
         if apply_update and isinstance(model, EMA):
             model.update_ema()
@@ -941,7 +1129,11 @@ def train_one_epoch(
             and teacher_schedule_available
             and beta_schedule_module is not None
         ):
-            schedule_ema.update(beta_schedule_module)
+            # Only update schedule EMA if schedule is not frozen
+            freeze_schedule = getattr(args, "mi_freeze_beta_schedule", False)
+            if not freeze_schedule:
+                schedule_ema.update(beta_schedule_module)
+            # If frozen, skip EMA update (student == teacher, no need to track)
         if (
             apply_update
             and not grad_step_skipped
@@ -1032,6 +1224,13 @@ def train_one_epoch(
                 log_msg += f", tau = {float(current_gumbel_tau):.4g}"
             if metric_interp_active and current_metric_interp is not None:
                 log_msg += f", lambda = {float(current_metric_interp):.4g}"
+            
+            # Add LUT diagnostics to log message
+            if lut_grad_norm_value is not None:
+                log_msg += f", lut_grad = {float(lut_grad_norm_value):.4g}"
+            if lut_param_delta is not None:
+                log_msg += f", lut_delta = {float(lut_param_delta):.6f}"
+            
             logger.info(log_msg)
 
             # Optional Weights & Biases step-level logging (main process only)
@@ -1042,6 +1241,57 @@ def train_one_epoch(
                         global_step = epoch * _dl_len + data_iter_step
                     else:
                         global_step = None
+                    
+                    # Compute metric diagnostics for logging
+                    metric_diagnostics = {}
+                    if hasattr(path, "learnable_metric") and path.learnable_metric is not None:
+                        with torch.no_grad():
+                            Z = path.learnable_metric.transformed_codes(
+                                device=device, dtype=torch.float32
+                            )
+                            fro_norm = torch.linalg.norm(Z, ord='fro')
+                            dist_table = path.learnable_metric.pairwise_distance_table(
+                                device=device, dtype=torch.float32
+                            )
+                            metric_diagnostics = {
+                                "metric/frobenius_norm": float(fro_norm.cpu()),
+                                "metric/distance_mean": float(dist_table.mean().cpu()),
+                                "metric/distance_std": float(dist_table.std().cpu()),
+                                "metric/distance_max": float(dist_table.max().cpu()),
+                                "metric/distance_min": float(dist_table.min().cpu()),
+                            }
+                            # Log learned scale (in reparameterization mode)
+                            if hasattr(path.learnable_metric, 'log_scale'):
+                                metric_diagnostics["metric/learned_scale"] = float(
+                                    torch.exp(path.learnable_metric.log_scale).cpu()
+                                )
+                            if metric_grad_norm_value is not None:
+                                metric_diagnostics["metric/grad_norm"] = float(
+                                    metric_grad_norm_value.cpu() if isinstance(metric_grad_norm_value, torch.Tensor) 
+                                    else metric_grad_norm_value
+                                )
+                    
+                    # Add LUT diagnostics
+                    lut_diagnostics = {}
+                    if hasattr(path, "learnable_lut") and path.learnable_lut is not None:
+                        with torch.no_grad():
+                            # Use forward() to get renormalized weights if enabled
+                            lut_weight = path.learnable_lut()
+                            lut_diagnostics["lut/weight_mean"] = float(lut_weight.mean().cpu())
+                            lut_diagnostics["lut/weight_std"] = float(lut_weight.std().cpu())
+                            lut_diagnostics["lut/weight_min"] = float(lut_weight.min().cpu())
+                            lut_diagnostics["lut/weight_max"] = float(lut_weight.max().cpu())
+                            # Per-channel std
+                            for ch_idx in range(lut_weight.shape[0]):
+                                lut_diagnostics[f"lut/ch{ch_idx}_std"] = float(lut_weight[ch_idx].std().cpu())
+                        if lut_grad_norm_value is not None:
+                            lut_diagnostics["lut/grad_norm"] = float(
+                                lut_grad_norm_value.cpu() if isinstance(lut_grad_norm_value, torch.Tensor) 
+                                else lut_grad_norm_value
+                            )
+                        if lut_param_delta is not None:
+                            lut_diagnostics["lut/param_delta"] = float(lut_param_delta)
+                    
                     wandb.log(  # type: ignore[attr-defined]
                         {
                             "train/step_loss": float(batch_loss.compute().detach().cpu()),
@@ -1049,6 +1299,13 @@ def train_one_epoch(
                             "train/uw_loss": float(uw_loss) if 'uw_loss' in locals() else float(loss_value),
                             "train/lr": float(lr),
                             "epoch": int(epoch),
+                            **metric_diagnostics,
+                            **lut_diagnostics,
+                            **({
+                                "train/model_grad_norm": float(
+                                    grad_norm.cpu() if isinstance(grad_norm, torch.Tensor) else grad_norm
+                                )
+                            } if grad_norm is not None and not grad_step_skipped else {}),
                             **(
                                 {
                                     "train/schedule_kl": float(
@@ -1147,5 +1404,278 @@ def train_one_epoch(
         for attr in ("_schedule_kl_window", "_schedule_kl_window_sum"):
             if hasattr(args, attr):
                 delattr(args, attr)
+    
+    # LUT diagnostics at end of epoch (every 25 epochs)
+    # Per-epoch numeric LUT diagnostics (always compute on main process).
+    if hasattr(path, "learnable_lut") and path.learnable_lut is not None:
+        try:
+            if distributed_mode.is_main_process():
+                with torch.no_grad():
+                    lut_w = path.learnable_lut()  # forward() may renormalize
+                    lut_w_cpu = lut_w.detach().cpu()
+                    # Basic statistics
+                    stats.update(
+                        {
+                            "lut/weight_mean": float(lut_w_cpu.mean().item()),
+                            "lut/weight_std": float(lut_w_cpu.std().item()),
+                            "lut/weight_min": float(lut_w_cpu.min().item()),
+                            "lut/weight_max": float(lut_w_cpu.max().item()),
+                        }
+                    )
+
+                    # Per-channel norms and (if available) renorm targets
+                    try:
+                        per_chan_norm = torch.linalg.vector_norm(lut_w_cpu, dim=(1, 2))
+                        for i, val in enumerate(per_chan_norm.tolist()):
+                            stats[f"lut/ch{i}_norm"] = float(val)
+                        # base norm buffer exists on module (no-noise baseline)
+                        base_buf = getattr(path.learnable_lut, "_base_fro_norm_per_channel", None)
+                        if base_buf is not None:
+                            base_cpu = base_buf.detach().cpu()
+                            renorm_factors = (base_cpu / (per_chan_norm + getattr(path.learnable_lut, "renorm_eps", 1e-12)))
+                            for i, val in enumerate(renorm_factors.tolist()):
+                                stats[f"lut/ch{i}_renorm_factor"] = float(val)
+                    except Exception:
+                        pass
+
+                    # Bounded residual scale diagnostics
+                    if hasattr(path.learnable_lut, "scale_c") and path.learnable_lut.scale_c is not None:
+                        sc = path.learnable_lut.scale_c.detach().cpu()
+                        s0 = float(getattr(path.learnable_lut, "scale_baseline", 1.0))
+                        eps = float(getattr(path.learnable_lut, "scale_epsilon", 0.25))
+                        s_vals = s0 * (1.0 + eps * torch.tanh(sc))
+                        stats.update(
+                            {
+                                "lut/scale_c_mean": float(sc.mean().item()),
+                                "lut/scale_c_std": float(sc.std().item()),
+                                "lut/scale_s_mean": float(s_vals.mean().item()),
+                                "lut/scale_s_min": float(s_vals.min().item()),
+                                "lut/scale_s_max": float(s_vals.max().item()),
+                            }
+                        )
+
+                    # Orthogonality check for multi-dim embeddings (cheap: only max off-diag)
+                    try:
+                        if lut_w_cpu.ndim == 3 and lut_w_cpu.shape[2] > 1:
+                            C, V, D = lut_w_cpu.shape
+                            for ch in range(C):
+                                W = lut_w_cpu[ch].numpy()  # [V, D]
+                                G = W.T @ W
+                                off_diag = np.abs(G - np.diag(np.diag(G)))
+                                stats[f"lut/ch{ch}_orth_offdiag_max"] = float(off_diag.max())
+                    except Exception:
+                        # numpy may not be imported; skip if any error
+                        pass
+
+                    # Parameter delta since epoch start (if snapshot exists)
+                    prev = getattr(args, "_epoch_lut_start", None)
+                    if prev is not None:
+                        try:
+                            delta = (lut_w_cpu - prev).norm().item()
+                            stats["lut/epoch_param_delta"] = float(delta)
+                        except Exception:
+                            pass
+
+                # Also call the richer visualization every 25 epochs (unchanged)
+                if epoch % 25 == 0:
+                    _log_lut_diagnostics(path, epoch, logger, args)
+        except Exception:
+            logger.exception("Error while collecting per-epoch LUT diagnostics")
+    
     return stats
 
+
+def _log_lut_diagnostics(path: MetricInducedGibbsProbPath, epoch: int, logger: logging.Logger, args: argparse.Namespace) -> None:
+    """Visualize LUT diagnostics with matplotlib plots.
+    
+    Creates a comprehensive visualization showing:
+    1. LUT curves for all channels
+    2. Channel correlations and metrics
+    3. Health indicators
+    """
+    try:
+        import matplotlib
+        matplotlib.use('Agg')  # Non-interactive backend
+        import matplotlib.pyplot as plt
+        import numpy as np
+    except ImportError:
+        logger.warning("matplotlib not available, skipping LUT visualization")
+        return
+    
+    with torch.no_grad():
+        # Use forward() to get renormalized weights (if enabled)
+        lut_weights_raw = path.learnable_lut().cpu()  # [C, V, D]
+        shape = lut_weights_raw.shape
+        
+        # Handle both [C, V] (legacy 1D) and [C, V, D] (new multi-dim) formats
+        if len(shape) == 2:
+            # Legacy 1D format: [C, V]
+            C, V = shape
+            D = 1
+            lut_weights = lut_weights_raw.numpy()
+            is_multidim = False
+        elif len(shape) == 3:
+            # New multi-dim format: [C, V, D]
+            C, V, D = shape
+            if D == 1:
+                # Squeeze out singleton dimension for backward compatibility
+                lut_weights = lut_weights_raw.squeeze(-1).numpy()  # [C, V]
+                is_multidim = False
+            else:
+                # Compute L2 norm per token as scalar proxy for visualization
+                lut_weights = torch.norm(lut_weights_raw, p=2, dim=-1).numpy()  # [C, V]
+                is_multidim = True
+        else:
+            logger.error(f"Unexpected LUT weight shape: {shape}")
+            return
+        
+        channel_names = ['R', 'G', 'B'] if C == 3 else [f'Ch{i}' for i in range(C)]
+        colors = ['red', 'green', 'blue'] if C == 3 else [f'C{i}' for i in range(C)]
+        
+        # Create figure with subplots
+        fig = plt.figure(figsize=(16, 10))
+        gs = fig.add_gridspec(3, 3, hspace=0.3, wspace=0.3)
+        
+        # 1. Main LUT curves
+        ax1 = fig.add_subplot(gs[0:2, 0:2])
+        x = np.arange(V)
+        for c, (name, color) in enumerate(zip(channel_names, colors)):
+            ax1.plot(x, lut_weights[c], label=name, color=color, alpha=0.8, linewidth=1.5)
+        ax1.set_xlabel('Token Value', fontsize=12)
+        ylabel = 'L2 Norm of Embedding' if is_multidim else 'Embedding Value'
+        ax1.set_ylabel(ylabel, fontsize=12)
+        title_suffix = f' (D={D})' if is_multidim else ''
+        ax1.set_title(f'LUT Curves{title_suffix} - Epoch {epoch}', fontsize=14, fontweight='bold')
+        ax1.legend(loc='best')
+        ax1.grid(True, alpha=0.3)
+        
+        # 2. Channel L2 Norms
+        ax2 = fig.add_subplot(gs[0, 2])
+        norms = [np.linalg.norm(lut_weights[c]) for c in range(C)]
+        ax2.bar(channel_names, norms, color=colors, alpha=0.7)
+        ax2.set_ylabel('L2 Norm', fontsize=11)
+        ax2.set_title('Channel Norms', fontsize=12, fontweight='bold')
+        ax2.grid(True, alpha=0.3, axis='y')
+        for i, v in enumerate(norms):
+            ax2.text(i, v + 0.05, f'{v:.2f}', ha='center', va='bottom', fontsize=9)
+        
+        # 3. Spearman ρ (rank correlation)
+        ax3 = fig.add_subplot(gs[1, 2])
+        init_order = np.arange(V, dtype=np.float32)
+        rhos = []
+        for c in range(C):
+            emb = lut_weights[c]
+            rank_emb = np.argsort(np.argsort(emb)).astype(np.float32)
+            # Pearson correlation of ranks = Spearman
+            rho = np.corrcoef(rank_emb, init_order)[0, 1]
+            rhos.append(rho)
+        ax3.bar(channel_names, rhos, color=colors, alpha=0.7)
+        ax3.set_ylabel('Spearman ρ', fontsize=11)
+        ax3.set_title('Rank Preservation', fontsize=12, fontweight='bold')
+        ax3.axhline(y=1.0, color='gray', linestyle='--', linewidth=1, alpha=0.5)
+        ax3.set_ylim([min(rhos) - 0.01, 1.01])
+        ax3.grid(True, alpha=0.3, axis='y')
+        for i, v in enumerate(rhos):
+            ax3.text(i, v - 0.005, f'{v:.4f}', ha='center', va='top', fontsize=9)
+        
+        # 4. Inversions (monotonicity)
+        ax4 = fig.add_subplot(gs[2, 0])
+        inversions = []
+        for c in range(C):
+            diffs = lut_weights[c][1:] - lut_weights[c][:-1]
+            inv_count = np.sum(diffs < 0)
+            inversions.append(inv_count)
+        ax4.bar(channel_names, inversions, color=colors, alpha=0.7)
+        ax4.set_ylabel('Inversion Count', fontsize=11)
+        ax4.set_title('Monotonicity Check', fontsize=12, fontweight='bold')
+        ax4.grid(True, alpha=0.3, axis='y')
+        for i, v in enumerate(inversions):
+            ax4.text(i, v + 0.5, f'{int(v)}', ha='center', va='bottom', fontsize=9)
+        
+        # 5. Channel correlations (heatmap)
+        ax5 = fig.add_subplot(gs[2, 1])
+        if C > 1:
+            corr_matrix = np.corrcoef(lut_weights)
+            im = ax5.imshow(corr_matrix, cmap='RdYlGn_r', vmin=0.95, vmax=1.0, aspect='auto')
+            ax5.set_xticks(range(C))
+            ax5.set_yticks(range(C))
+            ax5.set_xticklabels(channel_names)
+            ax5.set_yticklabels(channel_names)
+            ax5.set_title('Channel Correlation', fontsize=12, fontweight='bold')
+            # Add correlation values
+            for i in range(C):
+                for j in range(C):
+                    text = ax5.text(j, i, f'{corr_matrix[i, j]:.4f}',
+                                   ha='center', va='center', color='black', fontsize=9)
+            plt.colorbar(im, ax=ax5, fraction=0.046, pad=0.04)
+        else:
+            ax5.text(0.5, 0.5, 'Single Channel', ha='center', va='center', fontsize=12)
+            ax5.set_xticks([])
+            ax5.set_yticks([])
+        
+        # 6. Health summary
+        ax6 = fig.add_subplot(gs[2, 2])
+        ax6.axis('off')
+        health_text = f"Epoch {epoch}\n\n"
+        health_text += "Health Status:\n"
+        all_good = True
+        for c, name in enumerate(channel_names):
+            emb = lut_weights[c]
+            diffs = emb[1:] - emb[:-1]
+            inv_count = np.sum(diffs < 0)
+            inv_ratio = inv_count / (V - 1)
+            std_val = np.std(emb)
+            
+            issues = []
+            if inv_ratio > 0.06:
+                issues.append(f"inv>{int(inv_ratio*100)}%")
+                all_good = False
+            if std_val > 2.0:
+                issues.append(f"std>{std_val:.1f}")
+                all_good = False
+            if std_val < 0.2:
+                issues.append(f"std<{std_val:.2f}")
+                all_good = False
+            if emb[0] > emb[-1]:
+                issues.append("flipped")
+                all_good = False
+            
+            if issues:
+                health_text += f"  {name}: ⚠ {', '.join(issues)}\n"
+            else:
+                health_text += f"  {name}: ✓\n"
+        
+        if all_good:
+            health_text += "\n[OK] All checks passed"
+        
+        ax6.text(0.1, 0.9, health_text, transform=ax6.transAxes,
+                fontsize=10, verticalalignment='top', family='monospace',
+                bbox=dict(boxstyle='round', facecolor='wheat', alpha=0.3))
+        
+        # Save and log
+        plt.suptitle(f'LUT Diagnostics - Epoch {epoch}', fontsize=16, fontweight='bold', y=0.98)
+        
+        # Save to file
+        save_dir = getattr(args, 'output_dir', './output_dir')
+        import os
+        os.makedirs(save_dir, exist_ok=True)
+        save_path = os.path.join(save_dir, f'lut_diagnostics_epoch_{epoch:04d}.png')
+        plt.savefig(save_path, dpi=150, bbox_inches='tight')
+        logger.info(f"LUT diagnostics visualization saved to {save_path}")
+        
+        # Log to wandb if available
+        if getattr(args, 'wandb', False):
+            try:
+                import wandb
+                # Only log if wandb is actually initialized
+                if wandb.run is not None:
+                    wandb.log({"lut/diagnostics": wandb.Image(save_path)}, step=epoch)
+                    logger.info(f"✓ LUT diagnostics uploaded to wandb (run: {wandb.run.name})")
+                else:
+                    logger.info("wandb not initialized, image saved locally only")
+            except ImportError:
+                logger.info("wandb not installed, image saved locally only")
+            except Exception as e:
+                logger.info(f"wandb upload skipped ({type(e).__name__}), image saved locally")
+        
+        plt.close(fig)

--- a/examples/image/training/train_loop.py
+++ b/examples/image/training/train_loop.py
@@ -53,6 +53,31 @@ def _autocast(dtype: Optional[torch.dtype] = None):  # type: ignore[name-defined
         return torch.cuda.amp.autocast(dtype=dtype)
 
 
+def _collect_weight_norm_modules(module: nn.Module) -> list[nn.Module]:
+    cached = getattr(module, "_cached_weight_norm_targets", None)
+    if cached is not None:
+        return cached
+
+    targets: list[nn.Module] = []
+    seen: set[int] = set()
+
+    attr = getattr(module, "weight_norm_targets", None)
+    if isinstance(attr, (list, tuple)):
+        for candidate in attr:
+            if isinstance(candidate, nn.Module) and id(candidate) not in seen:
+                targets.append(candidate)
+                seen.add(id(candidate))
+
+    for submodule in module.modules():
+        if hasattr(submodule, "force_weight_renorm") and id(submodule) not in seen:
+            targets.append(submodule)
+            seen.add(id(submodule))
+
+    setattr(module, "_cached_weight_norm_targets", targets)
+    setattr(module, "weight_norm_targets", targets)
+    return targets
+
+
 def _importance_weighted_mean(
     values: torch.Tensor, weights: Optional[torch.Tensor]
 ) -> torch.Tensor:
@@ -203,6 +228,13 @@ def train_one_epoch(
 ):
     gc.collect()
     model.train(True)
+    weight_norm_modules = _collect_weight_norm_modules(model)
+
+    def _renorm_weight_norm_modules() -> None:
+        for module in weight_norm_modules:
+            if hasattr(module, "force_weight_renorm"):
+                module.force_weight_renorm()
+
     batch_loss = MeanMetric().to(device, non_blocking=True)
     epoch_loss = MeanMetric().to(device, non_blocking=True)
 
@@ -313,7 +345,7 @@ def train_one_epoch(
 
     for data_iter_step, (samples, labels) in enumerate(data_loader):
         if data_iter_step % accum_iter == 0:
-            optimizer.zero_grad()
+            optimizer.zero_grad(set_to_none=True)
             batch_loss.reset()
             if data_iter_step > 0 and args.test_run:
                 break
@@ -486,7 +518,7 @@ def train_one_epoch(
                 if mis_uniform_frac is not None:
                     wandb_log_data["diag/mis_uniform_frac"] = mis_uniform_frac
 
-                if data_iter_step % (PRINT_FREQUENCY * 2) == 0:
+                if data_iter_step % (PRINT_FREQUENCY * 10) == 0:
                     max_points = int(getattr(args, "wandb_entropy_max_points", 4096) or 4096)
                     entropy_table = getattr(args, "_entropy_vs_t_table", None)
                     entropy_rows = getattr(args, "_entropy_vs_t_rows", None)
@@ -691,6 +723,7 @@ def train_one_epoch(
             optimizer,
             parameters=model.parameters(),
             update_grad=apply_update,
+            pre_step_fn=_renorm_weight_norm_modules if weight_norm_modules else None,
         )
         grad_step_skipped = False
         if apply_update:
@@ -700,6 +733,7 @@ def train_one_epoch(
                 grad_step_skipped = not torch.isfinite(grad_norm.detach()).all().item()
             else:
                 grad_step_skipped = not math.isfinite(float(grad_norm))
+            optimizer.zero_grad(set_to_none=True)
         if apply_update and isinstance(model, EMA):
             model.update_ema()
         elif (

--- a/examples/image/training/train_loop.py
+++ b/examples/image/training/train_loop.py
@@ -20,6 +20,7 @@ from flow_matching.path import (
     BetaScheduleEMA,
     LearnableMetricEMA,
 )
+from flow_matching.path.beta_schedules import ExpMonotoneRQSSchedule
 from flow_matching.path.scheduler import PolynomialConvexScheduler
 from models.ema import EMA
 from torch.nn.parallel import DistributedDataParallel
@@ -317,7 +318,43 @@ def train_one_epoch(
         if getattr(args, "ko_metric_induced", False):
             # KO: 256-way classification; no mask token
             samples = (samples * 255.0).to(torch.long)
-            t = torch.rand(samples.shape[0], device=device)
+            logbeta_weights: Optional[torch.Tensor] = None
+            schedule = getattr(path, "beta_schedule", None)
+            lmin = getattr(args, "mi_logbeta_min", None)
+            lmax = getattr(args, "mi_logbeta_max", None)
+            use_logbeta_sampling = (
+                isinstance(schedule, ExpMonotoneRQSSchedule)
+                and hasattr(schedule, "sample_t_uniform_logbeta")
+                and lmin is not None
+                and lmax is not None
+            )
+            if use_logbeta_sampling and lmax <= lmin:
+                if not getattr(args, "_mi_logbeta_interval_warned", False):
+                    logger.warning(
+                        "Ignoring log-β sampling interval with l_min >= l_max (%.4f, %.4f)",
+                        lmin,
+                        lmax,
+                    )
+                    setattr(args, "_mi_logbeta_interval_warned", True)
+                use_logbeta_sampling = False
+
+            if use_logbeta_sampling:
+                t_samples, weights = schedule.sample_t_uniform_logbeta(
+                    batch_shape=(samples.shape[0],),
+                    lmin=float(lmin),
+                    lmax=float(lmax),
+                )
+                t = t_samples.to(device=device)
+                logbeta_weights = weights.to(device=device, dtype=torch.float32)
+                if not getattr(args, "_mi_logbeta_sampling_announced", False):
+                    logger.info(
+                        "Using uniform log-β sampling with interval [%.4f, %.4f]",
+                        float(lmin),
+                        float(lmax),
+                    )
+                    setattr(args, "_mi_logbeta_sampling_announced", True)
+            else:
+                t = torch.rand(samples.shape[0], device=device)
 
             # Provide dummy x_0 for signature compatibility (not used by metric-induced path)
             x_0 = torch.zeros_like(samples)
@@ -331,9 +368,21 @@ def train_one_epoch(
                     logits = model(x_t_model, t=t, extra=conditioning)
             else:
                 logits = model(x_t_model, t=t, extra=conditioning)
-            loss = torch.nn.functional.cross_entropy(
-                logits.float().reshape([-1, 256]), samples.reshape([-1])
-            ).mean()
+            vocab_size = logits.shape[-1]
+            logits_flat = logits.float().reshape(-1, vocab_size)
+            targets_flat = samples.reshape(-1)
+            token_loss = torch.nn.functional.cross_entropy(
+                logits_flat, targets_flat, reduction="none"
+            )
+            per_sample_loss = token_loss.view(samples.shape[0], -1).mean(dim=1)
+            if logbeta_weights is None:
+                weighted_loss = per_sample_loss
+            else:
+                logbeta_weights = logbeta_weights.to(
+                    device=per_sample_loss.device, dtype=per_sample_loss.dtype
+                )
+                weighted_loss = per_sample_loss * logbeta_weights
+            loss = weighted_loss.mean()
 
             if use_path_trust_region:
                 x1_flat = samples.view(samples.shape[0], -1)
@@ -358,7 +407,10 @@ def train_one_epoch(
                     teacher_probs
                     * (torch.log(teacher_probs) - torch.log(student_probs))
                 ).sum(dim=-1)
-                schedule_kl_value = kl_tensor.mean()
+                if logbeta_weights is not None:
+                    schedule_kl_value = (kl_tensor * logbeta_weights).mean()
+                else:
+                    schedule_kl_value = kl_tensor.mean()
                 schedule_kl_penalty = kl_controller.compute_penalty(schedule_kl_value)
                 loss = loss + schedule_kl_penalty
                 kl_metric.update(schedule_kl_value.detach())

--- a/examples/image/training/train_loop.py
+++ b/examples/image/training/train_loop.py
@@ -458,69 +458,157 @@ def train_one_epoch(
                     ess_num = (w.sum() ** 2) / (w.square().sum() + 1e-12)
                     wandb_log_data["diag/ess_frac"] = float((ess_num / (w.numel() + 1e-12)).item())
 
-                entropy_table = getattr(args, "_entropy_vs_t_table", None)
-                entropy_rows = getattr(args, "_entropy_vs_t_rows", None)
-                if entropy_table is None or entropy_rows is None:
-                    entropy_table = wandb_logger.echarts.Table()
-                    entropy_rows = []
-                    setattr(args, "_entropy_vs_t_table", entropy_table)
-                    setattr(args, "_entropy_vs_t_rows", entropy_rows)
+                if data_iter_step % (PRINT_FREQUENCY * 2) == 0:
+                    max_points = int(getattr(args, "wandb_entropy_max_points", 4096) or 4096)
+                    entropy_table = getattr(args, "_entropy_vs_t_table", None)
+                    entropy_rows = getattr(args, "_entropy_vs_t_rows", None)
+                    if not isinstance(entropy_rows, deque):
+                        existing_rows = list(entropy_rows) if entropy_rows is not None else []
+                        entropy_rows = deque(existing_rows[-max_points:], maxlen=max_points)
+                        setattr(args, "_entropy_vs_t_rows", entropy_rows)
+                    elif entropy_rows.maxlen != max_points:
+                        entropy_rows = deque(list(entropy_rows)[-max_points:], maxlen=max_points)
+                        setattr(args, "_entropy_vs_t_rows", entropy_rows)
+                    if entropy_table is None:
+                        entropy_table = wandb_logger.echarts.Table()
+                        setattr(args, "_entropy_vs_t_table", entropy_table)
 
-                t_cpu = t.detach().cpu().float()
-                entropy_cpu = target_entropy.detach().cpu().float()
-                new_rows = [
-                    [float(t_val), float(entropy_val)]
-                    for t_val, entropy_val in zip(t_cpu.tolist(), entropy_cpu.tolist())
-                ]
-                entropy_rows.extend(new_rows)
-                max_points = int(getattr(args, "wandb_entropy_max_points", 4096) or 4096)
-                if len(entropy_rows) > max_points:
-                    del entropy_rows[:-max_points]
+                    t_cpu = t.detach().float().cpu()
+                    entropy_cpu = target_entropy.detach().float().cpu()
+                    counter = int(getattr(args, "_entropy_vs_t_counter", 0))
+                    new_rows = []
+                    for t_val, entropy_val in zip(t_cpu.tolist(), entropy_cpu.tolist()):
+                        # Track arrival order in column 2 so visualMap can encode recency with color.
+                        new_rows.append([
+                            float(t_val),
+                            float(entropy_val),
+                            float(counter),
+                        ])
+                        counter += 1
+                    setattr(args, "_entropy_vs_t_counter", counter)
+                    entropy_rows.extend(new_rows)
 
-                entropy_table.add(["t", "entropy"], entropy_rows)
+                    rows_list = list(entropy_rows)
+                    entropy_table.add(["t", "entropy", "index"], rows_list)
 
-                scatter_chart = wandb_logger.echarts.Scatter()
-                scatter_chart.add_xaxis([row[0] for row in entropy_rows])
-                scatter_chart.add_yaxis(
-                    "entropy",
-                    [row[1] for row in entropy_rows],
-                    symbol_size=6,
-                )
-                echarts_opts = getattr(wandb_logger.echarts, "options", None)
-                if echarts_opts is not None:
-                    tooltip_fmt = getattr(
-                        echarts_opts.TooltipOpts,
-                        "formatter",
-                        None,
+                    scatter_chart = wandb_logger.echarts.Scatter()
+                    scatter_chart.add_xaxis([])
+                    options_mod = getattr(wandb_logger.echarts, "options", None)
+                    label_opts = (
+                        options_mod.LabelOpts(is_show=False)
+                        if options_mod is not None
+                        else None
                     )
-                    tooltip_kwargs = {}
-                    if tooltip_fmt is None:
-                        tooltip_kwargs["formatter"] = "t: {c0}<br/>entropy: {c1}"
+                    scatter_chart.add_yaxis(
+                        "entropy",
+                        rows_list,
+                        symbol_size=3.5,
+                        label_opts=label_opts,
+                        encode={"x": 0, "y": 1},
+                    )
+                    palette = [
+                        "#003f5c",
+                        "#2f4b7c",
+                        "#665191",
+                        "#a05195",
+                        "#d45087",
+                        "#f95d6a",
+                    ]
+                    if rows_list:
+                        min_t = min(row[0] for row in rows_list)
+                        max_t = max(row[0] for row in rows_list)
+                        if math.isfinite(min_t) and math.isfinite(max_t):
+                            if abs(max_t - min_t) < 1e-9:
+                                pad = max(abs(min_t), 1.0) * 1e-3
+                                min_axis = min_t - pad
+                                max_axis = max_t + pad
+                            else:
+                                min_axis = min_t
+                                max_axis = max_t
+                        else:
+                            min_axis = 0.0
+                            max_axis = 1.0
+                        color_min = min(row[2] for row in rows_list)
+                        color_max = max(row[2] for row in rows_list)
+                        if abs(color_max - color_min) < 1e-9:
+                            color_pad = max(abs(color_min), 1.0)
+                            color_min -= color_pad * 0.5
+                            color_max += color_pad * 0.5
                     else:
-                        tooltip_kwargs = {"formatter": "t: {c0}<br/>entropy: {c1}"}
-                    scatter_chart.set_global_opts(
-                        title_opts=echarts_opts.TitleOpts(
-                            title="Target Entropy vs t",
-                            pos_left="center",
-                        ),
-                        xaxis_opts=echarts_opts.AxisOpts(
-                            name="t",
-                            type_="value",
-                            min_=0.0,
-                            max_=1.0,
-                        ),
-                        yaxis_opts=echarts_opts.AxisOpts(
-                            name="entropy",
-                            type_="value",
-                        ),
-                        tooltip_opts=echarts_opts.TooltipOpts(**tooltip_kwargs),
-                    )
-                    scatter_chart.set_series_opts(
-                        itemstyle_opts=echarts_opts.ItemStyleOpts(opacity=0.6),
-                    )
+                        min_axis = 0.0
+                        max_axis = 1.0
+                        color_min = 0.0
+                        color_max = float(len(rows_list))
 
-                wandb_log_data["diag/entropy_vs_t_table"] = entropy_table
-                wandb_log_data["diag/entropy_vs_t"] = scatter_chart
+                    diff = max(color_max - color_min, 1e-6)
+                    segment_count = len(palette)
+                    pieces = []
+                    for idx, color_hex in enumerate(palette):
+                        start_ratio = idx / segment_count
+                        end_ratio = (idx + 1) / segment_count
+                        piece_min = color_min + diff * start_ratio
+                        piece_max = (
+                            color_min + diff * end_ratio
+                            if idx < segment_count - 1
+                            else color_max
+                        )
+                        pieces.append(
+                            {
+                                "min": piece_min,
+                                "max": piece_max,
+                                "color": color_hex,
+                            }
+                        )
+
+                    echarts_opts = options_mod
+                    if echarts_opts is not None:
+                        tooltip_fmt = getattr(
+                            echarts_opts.TooltipOpts,
+                            "formatter",
+                            None,
+                        )
+                        tooltip_kwargs = {}
+                        if tooltip_fmt is None:
+                            tooltip_kwargs["formatter"] = "t: {c0}<br/>entropy: {c1}<br/>idx: {c2}"
+                        else:
+                            tooltip_kwargs = {"formatter": "t: {c0}<br/>entropy: {c1}<br/>idx: {c2}"}
+                        scatter_chart.set_global_opts(
+                            title_opts=echarts_opts.TitleOpts(
+                                title="Target Entropy vs t",
+                                pos_left="center",
+                            ),
+                            xaxis_opts=echarts_opts.AxisOpts(
+                                name="t",
+                                type_="value",
+                                min_=min_axis,
+                                max_=max_axis,
+                            ),
+                            yaxis_opts=echarts_opts.AxisOpts(
+                                name="entropy",
+                                type_="value",
+                            ),
+                            tooltip_opts=echarts_opts.TooltipOpts(**tooltip_kwargs),
+                            datazoom_opts=[
+                                echarts_opts.DataZoomOpts(type_="slider"),
+                                echarts_opts.DataZoomOpts(type_="inside"),
+                            ],
+                            visualmap_opts=echarts_opts.VisualMapOpts(
+                                dimension=2,
+                                is_piecewise=True,
+                                pieces=pieces,
+                                min_=color_min,
+                                max_=color_max,
+                                orient="horizontal",
+                                pos_top="5%",
+                                pos_left="center",
+                            ),
+                        )
+                        scatter_chart.set_series_opts(
+                            itemstyle_opts=echarts_opts.ItemStyleOpts(opacity=0.35),
+                        )
+
+                    wandb_log_data["diag/entropy_vs_t_table"] = entropy_table
+                    wandb_log_data["diag/entropy_vs_t"] = scatter_chart
                 wandb_logger.log(wandb_log_data)
         elif args.discrete_flow_matching:
             samples = (samples * 255.0).to(torch.long)

--- a/examples/image/training/train_loop.py
+++ b/examples/image/training/train_loop.py
@@ -388,7 +388,23 @@ def train_one_epoch(
             token_loss = torch.nn.functional.cross_entropy(
                 logits_flat, targets_flat, reduction="none"
             )
+            target_tokens = samples.view(samples.shape[0], -1)
+            token_counts = torch.zeros(
+                target_tokens.shape[0],
+                vocab_size,
+                device=target_tokens.device,
+                dtype=torch.float32,
+            )
+            token_counts.scatter_add_(
+                1,
+                target_tokens,
+                torch.ones_like(target_tokens, dtype=torch.float32),
+            )
+            token_probs = token_counts / token_counts.sum(dim=1, keepdim=True).clamp_min(1e-12)
+            token_probs = token_probs.clamp_min(1e-12)
+            target_entropy = -(token_probs * token_probs.log()).sum(dim=1)
             per_sample_loss = token_loss.view(samples.shape[0], -1).mean(dim=1)
+            uw_loss = per_sample_loss.mean().item()
             loss = _importance_weighted_mean(per_sample_loss, logbeta_weights)
 
             if use_path_trust_region:
@@ -424,6 +440,88 @@ def train_one_epoch(
                 kl_updates_total += 1
                 kl_sum_for_step += float(schedule_kl_value.detach())
                 kl_micro_steps += 1
+
+            wandb_logger = None
+            if getattr(args, "wandb", False) and distributed_mode.is_main_process():
+                try:
+                    import swanlab as wandb  # type: ignore
+                    wandb_logger = wandb
+                except ImportError:
+                    wandb_logger = None
+
+            if wandb_logger is not None:
+                wandb_log_data = {
+                    "diag/target_entropy_mean": float(target_entropy.mean().detach().cpu().item()),
+                }
+                if logbeta_weights is not None:
+                    w = logbeta_weights.detach()
+                    ess_num = (w.sum() ** 2) / (w.square().sum() + 1e-12)
+                    wandb_log_data["diag/ess_frac"] = float((ess_num / (w.numel() + 1e-12)).item())
+
+                entropy_table = getattr(args, "_entropy_vs_t_table", None)
+                entropy_rows = getattr(args, "_entropy_vs_t_rows", None)
+                if entropy_table is None or entropy_rows is None:
+                    entropy_table = wandb_logger.echarts.Table()
+                    entropy_rows = []
+                    setattr(args, "_entropy_vs_t_table", entropy_table)
+                    setattr(args, "_entropy_vs_t_rows", entropy_rows)
+
+                t_cpu = t.detach().cpu().float()
+                entropy_cpu = target_entropy.detach().cpu().float()
+                new_rows = [
+                    [float(t_val), float(entropy_val)]
+                    for t_val, entropy_val in zip(t_cpu.tolist(), entropy_cpu.tolist())
+                ]
+                entropy_rows.extend(new_rows)
+                max_points = int(getattr(args, "wandb_entropy_max_points", 4096) or 4096)
+                if len(entropy_rows) > max_points:
+                    del entropy_rows[:-max_points]
+
+                entropy_table.add(["t", "entropy"], entropy_rows)
+
+                scatter_chart = wandb_logger.echarts.Scatter()
+                scatter_chart.add_xaxis([row[0] for row in entropy_rows])
+                scatter_chart.add_yaxis(
+                    "entropy",
+                    [row[1] for row in entropy_rows],
+                    symbol_size=6,
+                )
+                echarts_opts = getattr(wandb_logger.echarts, "options", None)
+                if echarts_opts is not None:
+                    tooltip_fmt = getattr(
+                        echarts_opts.TooltipOpts,
+                        "formatter",
+                        None,
+                    )
+                    tooltip_kwargs = {}
+                    if tooltip_fmt is None:
+                        tooltip_kwargs["formatter"] = "t: {c0}<br/>entropy: {c1}"
+                    else:
+                        tooltip_kwargs = {"formatter": "t: {c0}<br/>entropy: {c1}"}
+                    scatter_chart.set_global_opts(
+                        title_opts=echarts_opts.TitleOpts(
+                            title="Target Entropy vs t",
+                            pos_left="center",
+                        ),
+                        xaxis_opts=echarts_opts.AxisOpts(
+                            name="t",
+                            type_="value",
+                            min_=0.0,
+                            max_=1.0,
+                        ),
+                        yaxis_opts=echarts_opts.AxisOpts(
+                            name="entropy",
+                            type_="value",
+                        ),
+                        tooltip_opts=echarts_opts.TooltipOpts(**tooltip_kwargs),
+                    )
+                    scatter_chart.set_series_opts(
+                        itemstyle_opts=echarts_opts.ItemStyleOpts(opacity=0.6),
+                    )
+
+                wandb_log_data["diag/entropy_vs_t_table"] = entropy_table
+                wandb_log_data["diag/entropy_vs_t"] = scatter_chart
+                wandb_logger.log(wandb_log_data)
         elif args.discrete_flow_matching:
             samples = (samples * 255.0).to(torch.long)
             t = torch.rand(samples.shape[0]).to(device)
@@ -604,6 +702,7 @@ def train_one_epoch(
                         {
                             "train/step_loss": float(batch_loss.compute().detach().cpu()),
                             "train/inst_loss": float(loss_value),
+                            "train/uw_loss": float(uw_loss) if 'uw_loss' in locals() else float(loss_value),
                             "train/lr": float(lr),
                             "epoch": int(epoch),
                             **(

--- a/examples/image/training/train_loop.py
+++ b/examples/image/training/train_loop.py
@@ -390,6 +390,9 @@ def train_one_epoch(
     batch_loss = MeanMetric().to(device, non_blocking=True)
     epoch_loss = MeanMetric().to(device, non_blocking=True)
     entropy_metric = MeanMetric().to(device, non_blocking=True)
+    cosine_scale_ratio_metric = MeanMetric().to(device, non_blocking=True)
+    cosine_effective_neighbor_metric = MeanMetric().to(device, non_blocking=True)
+    cosine_metrics_updated = False
     entropy_samples: list[torch.Tensor] = []
 
     accum_iter = args.accum_iter
@@ -451,6 +454,16 @@ def train_one_epoch(
         )
         kl_controller = None
         use_path_trust_region = False
+
+    cosine_monitor_enabled = (
+        isinstance(path, MetricInducedGibbsProbPath)
+        and getattr(path, "metric_name", "") == "cosine"
+        and getattr(path, "learnable_lut", None) is not None
+    )
+    cosine_base_neighbor = float(getattr(args, "_mi_lut_cosine_base_neighbor", 0.0) or 0.0)
+    cosine_raw_neighbor = float(getattr(args, "_mi_lut_cosine_neighbor_median", 0.0) or 0.0)
+    if not (cosine_monitor_enabled and cosine_base_neighbor > 0.0 and cosine_raw_neighbor > 0.0):
+        cosine_monitor_enabled = False
 
     kl_metric = kl_penalty_metric = None
     kl_updates_total = 0
@@ -561,6 +574,8 @@ def train_one_epoch(
         step_entropy_mean: Optional[float] = None
         step_entropy_median: Optional[float] = None
         step_entropy_p90: Optional[float] = None
+        step_scale_ratio: Optional[float] = None
+        step_effective_neighbor: Optional[float] = None
 
         if getattr(args, "ko_metric_induced", False):
             # KO: 256-way classification; no mask token
@@ -842,6 +857,31 @@ def train_one_epoch(
             if logbeta_reg_penalty is not None:
                 loss = loss + logbeta_reg_penalty
 
+            beta_t_values, _ = path.beta(t)
+            if cosine_monitor_enabled:
+                beta_mean_value = float(beta_t_values.mean().detach().item())
+                lut_scale = float(getattr(path, "_lut_cosine_scale", 1.0) or 1.0)
+                effective_neighbor = beta_mean_value * lut_scale * cosine_raw_neighbor
+                ratio = (
+                    effective_neighbor / cosine_base_neighbor
+                    if cosine_base_neighbor > 0.0
+                    else float("nan")
+                )
+                if math.isfinite(ratio):
+                    cosine_scale_ratio_metric.update(
+                        torch.tensor(ratio, device=device, dtype=torch.float32)
+                    )
+                    cosine_metrics_updated = True
+                if math.isfinite(effective_neighbor):
+                    cosine_effective_neighbor_metric.update(
+                        torch.tensor(effective_neighbor, device=device, dtype=torch.float32)
+                    )
+                    cosine_metrics_updated = True
+                step_scale_ratio = ratio if math.isfinite(ratio) else None
+                step_effective_neighbor = (
+                    effective_neighbor if math.isfinite(effective_neighbor) else None
+                )
+
             # KL trust region to baseline geometry for LUT (teacher = baseline distances)
             lut_kl_weight = float(getattr(args, "mi_lut_kl_weight", 0.0) or 0.0)
             if (
@@ -869,8 +909,7 @@ def train_one_epoch(
                 K = path.vocab_size
                 base_rows = base_table.index_select(0, x1_flat.view(-1)).view(B, S, K)
                 # Compute teacher probs from baseline with the same beta(t)
-                beta_t, _ = path.beta(t)
-                beta_t = beta_t.view(B, 1, 1).to(device=base_rows.device, dtype=base_rows.dtype)
+                beta_t = beta_t_values.view(B, 1, 1).to(device=base_rows.device, dtype=base_rows.dtype)
                 logits_base = -beta_t * base_rows
                 logits_base = logits_base - logits_base.max(dim=-1, keepdim=True).values
                 teacher_probs = torch.softmax(logits_base, dim=-1).to(device=path_probs.device, dtype=path_probs.dtype)
@@ -1290,6 +1329,10 @@ def train_one_epoch(
                 log_msg += f", H={step_entropy_mean:.3f}"
                 if step_entropy_median is not None:
                     log_msg += f" (p50={step_entropy_median:.3f})"
+            if step_scale_ratio is not None:
+                log_msg += f", cos_ratio={step_scale_ratio:.3f}"
+                if step_effective_neighbor is not None:
+                    log_msg += f" (eff={step_effective_neighbor:.3e})"
             
             # Add LUT diagnostics to log message
             if lut_grad_norm_value is not None:
@@ -1384,6 +1427,14 @@ def train_one_epoch(
                             "train/uw_loss": float(uw_loss) if 'uw_loss' in locals() else float(loss_value),
                             "train/lr": float(lr),
                             "epoch": int(epoch),
+                            **(
+                                {
+                                    "train/cosine_scale_ratio": float(step_scale_ratio),
+                                    "train/cosine_effective_neighbor": float(step_effective_neighbor),
+                                }
+                                if step_scale_ratio is not None and step_effective_neighbor is not None
+                                else {}
+                            ),
                             **metric_diagnostics,
                             **lut_diagnostics,
                             **({
@@ -1492,6 +1543,20 @@ def train_one_epoch(
                     "entropy/p50": float(torch.quantile(entropy_epoch_tensor, 0.5).item()),
                     "entropy/p90": float(torch.quantile(entropy_epoch_tensor, 0.9).item()),
                     "entropy/batch_mean": float(entropy_metric.compute().detach().cpu()),
+                }
+            )
+        except Exception:
+            pass
+    if cosine_monitor_enabled and cosine_metrics_updated:
+        try:
+            stats.update(
+                {
+                    "cosine/scale_ratio": float(
+                        cosine_scale_ratio_metric.compute().detach().cpu()
+                    ),
+                    "cosine/effective_neighbor": float(
+                        cosine_effective_neighbor_metric.compute().detach().cpu()
+                    ),
                 }
             )
         except Exception:

--- a/examples/image/training/train_loop.py
+++ b/examples/image/training/train_loop.py
@@ -471,10 +471,13 @@ def train_one_epoch(
                             kl_window_sum -= removed
                         kl_window.append(mean_kl_step)
                         kl_window_sum += mean_kl_step
-                        if len(kl_window) == kl_window.maxlen:
+                        if len(kl_window) > 0:
                             averaged_kl = kl_window_sum / len(kl_window)
-                            kl_controller.update(averaged_kl)
-                            kl_avg_for_logging = averaged_kl
+                            if math.isfinite(averaged_kl):
+                                kl_controller.update(averaged_kl)
+                                kl_avg_for_logging = averaged_kl
+                            else:
+                                kl_avg_for_logging = None
                         else:
                             kl_avg_for_logging = None
                     else:

--- a/examples/image/training/train_loop.py
+++ b/examples/image/training/train_loop.py
@@ -249,31 +249,6 @@ def train_one_epoch(
         kl_metric = MeanMetric().to(device, non_blocking=True)
         kl_penalty_metric = MeanMetric().to(device, non_blocking=True)
 
-    if kl_controller is not None and not use_path_ema:
-        logger.warning(
-            "KL controller was provided without an EMA teacher; disabling the controller."
-        )
-        kl_controller = None
-        use_path_trust_region = False
-
-    kl_metric = kl_penalty_metric = None
-    kl_updates_total = 0
-    kl_sum_for_step = 0.0
-    kl_micro_steps = 0
-    kl_avg_for_logging: Optional[float] = None
-    kl_avg_window = int(getattr(args, "mi_beta_kl_avg_window", 1) or 1)
-    if kl_avg_window <= 0:
-        logger.warning(
-            "mi_beta_kl_avg_window must be positive; received %s. Falling back to 1.",
-            kl_avg_window,
-        )
-        kl_avg_window = 1
-    kl_window = deque(maxlen=kl_avg_window) if use_path_trust_region else None
-    kl_window_sum = 0.0
-    if use_path_trust_region:
-        kl_metric = MeanMetric().to(device, non_blocking=True)
-        kl_penalty_metric = MeanMetric().to(device, non_blocking=True)
-
     # Try to get dataloader length for global step computation
     try:
         _dl_len = len(data_loader)  # type: ignore[arg-type]

--- a/examples/image/training/train_loop.py
+++ b/examples/image/training/train_loop.py
@@ -547,6 +547,8 @@ def train_one_epoch(
     cosine_scale_ratio_metric = MeanMetric().to(device, non_blocking=True)
     geodesic_penalty_metric = MeanMetric().to(device, non_blocking=True)
     geodesic_penalty_updated = False
+    geometry_penalty_metric = MeanMetric().to(device, non_blocking=True)
+    geometry_penalty_updated = False
     lut_reg_align = float(getattr(args, "mi_lut_reg_align", 0.0))
     lut_reg_step = float(getattr(args, "mi_lut_reg_step", 0.0))
     lut_reg_curvature = float(getattr(args, "mi_lut_reg_curvature", 0.0))
@@ -1023,6 +1025,7 @@ def train_one_epoch(
 
             if logbeta_reg_penalty is not None:
                 loss = loss + logbeta_reg_penalty
+            geometry_penalty_value: Optional[torch.Tensor] = None
             if geometry_enabled:
                 penalty, geom_metrics = _compute_lut_regularizer_and_metrics(
                     path=path,
@@ -1033,7 +1036,10 @@ def train_one_epoch(
                     compute_metrics=lut_geometry_log or geometry_reg_enabled,
                 )
                 if geometry_reg_enabled:
+                    geometry_penalty_value = penalty.detach()
                     loss = loss + penalty
+                    geometry_penalty_metric.update(geometry_penalty_value)
+                    geometry_penalty_updated = True
                 if geom_metrics:
                     geom_metrics_step = geom_metrics
                     geometry_count += 1
@@ -1234,6 +1240,10 @@ def train_one_epoch(
                                 ),
                             }
                         )
+                if geometry_penalty_value is not None:
+                    wandb_log_data["loss/lut_geometry_penalty"] = float(
+                        geometry_penalty_value.cpu().item()
+                    )
                 if geom_metrics_step:
                     for key, value in geom_metrics_step.items():
                         wandb_log_data[key.replace("lut_", "lut/")] = float(value)
@@ -1599,10 +1609,11 @@ def train_one_epoch(
                     wandb_payload = {
                         "train/step_loss": float(batch_loss.compute().detach().cpu()),
                         "train/inst_loss": float(loss_value),
-                        "train/uw_loss": float(uw_loss) if "uw_loss" in locals() else float(loss_value),
                         "train/lr": float(lr),
                         "epoch": int(epoch),
                     }
+                    if logbeta_weights is not None and "uw_loss" in locals():
+                        wandb_payload["train/uw_loss"] = float(uw_loss)
                     if step_scale_ratio is not None and step_effective_neighbor is not None:
                         wandb_payload.update(
                             {
@@ -1649,6 +1660,10 @@ def train_one_epoch(
                                     ),
                                 }
                             )
+                    if geometry_penalty_value is not None:
+                        wandb_payload["loss/lut_geometry_penalty"] = float(
+                            geometry_penalty_value.cpu().item()
+                        )
                     if geom_metrics_step:
                         for key, value in geom_metrics_step.items():
                             wandb_payload[key.replace("lut_", "train/lut_")] = value
@@ -1664,6 +1679,13 @@ def train_one_epoch(
     setattr(args, "_mi_logbeta_reg_step", logbeta_reg_update_step)
     lr_schedule.step()
     stats = {"loss": float(epoch_loss.compute().detach().cpu())}
+    if geometry_penalty_updated:
+        try:
+            stats["loss/lut_geometry_penalty"] = float(
+                geometry_penalty_metric.compute().detach().cpu().item()
+            )
+        except Exception:
+            pass
     if geodesic_penalty_updated:
         try:
             stats["train/geodesic_penalty"] = float(

--- a/examples/image/training/train_loop.py
+++ b/examples/image/training/train_loop.py
@@ -7,11 +7,12 @@ import argparse
 import gc
 import logging
 import math
-from collections import deque
+from collections import deque, defaultdict
 from typing import Iterable, Optional
 
 import torch
 import torch.nn as nn
+import torch.nn.functional as F
 import numpy as np
 from flow_matching.path import (
     CondOTProbPath,
@@ -32,10 +33,163 @@ from training import distributed_mode
 
 logger = logging.getLogger(__name__)
 
+
+def _resolve_wandb_module(args: argparse.Namespace) -> Optional[object]:
+    """
+    Try importing swanlab (preferred) and fall back to the official wandb client.
+    Cache the result on args to reuse the module across logging paths.
+    """
+    if not getattr(args, "wandb", False):
+        return None
+    cached = getattr(args, "_cached_wandb_module", None)
+    attempted = getattr(args, "_cached_wandb_attempted", False)
+    if attempted:
+        return cached
+    setattr(args, "_cached_wandb_attempted", True)
+    if not distributed_mode.is_main_process():
+        setattr(args, "_cached_wandb_module", None)
+        return None
+
+    module: Optional[object] = None
+    try:
+        import swanlab as wandb  # type: ignore
+
+        module = wandb
+    except ImportError:
+        try:
+            import wandb  # type: ignore
+
+            module = wandb
+        except ImportError:
+            module = None
+            if not getattr(args, "_wandb_import_warned", False):
+                logger.warning(
+                    "Weights & Biases logging disabled: unable to import swanlab or wandb."
+                )
+                setattr(args, "_wandb_import_warned", True)
+    setattr(args, "_cached_wandb_module", module)
+    return module
+
+
 # NOTE: KO metric-induced path trains on 256-way tokens (no mask token).
 # The original mixture path branch used a MASK_TOKEN=256 scheme.
 MASK_TOKEN = 256
 PRINT_FREQUENCY = 10
+
+
+def _ks_uniform_metric(values: torch.Tensor) -> float:
+    if values.numel() <= 1:
+        return 0.0
+    sorted_vals, _ = torch.sort(values)
+    n = sorted_vals.numel()
+    min_val = sorted_vals[0]
+    max_val = sorted_vals[-1]
+    if (max_val - min_val).abs() < 1e-9:
+        return 0.0
+    standardized = (sorted_vals - min_val) / (max_val - min_val + 1e-12)
+    uniform_cdf = torch.linspace(0.0, 1.0, n, device=sorted_vals.device, dtype=sorted_vals.dtype)
+    d = torch.max(torch.abs(standardized - uniform_cdf))
+    return float(d.detach().cpu())
+
+
+def _compute_lut_regularizer_and_metrics(
+    path: ProbPath,
+    device: torch.device,
+    reg_align: float,
+    reg_step: float,
+    reg_curv: float,
+    compute_metrics: bool,
+) -> tuple[torch.Tensor, dict[str, float]]:
+    lut = getattr(path, "learnable_lut", None)
+    if lut is None:
+        return torch.tensor(0.0, device=device), {}
+    weight = lut.weight if hasattr(lut, "weight") else lut()
+    if weight is None:
+        return torch.tensor(0.0, device=device), {}
+    weight = weight.to(device=device)
+    if weight.size(1) < 2:
+        return torch.tensor(0.0, device=device), {}
+    dtype = weight.dtype
+    normed = F.normalize(weight, dim=-1, eps=1e-12)
+
+    align_term = (1.0 - (normed[:, :-1, :] * normed[:, 1:, :]).sum(dim=-1)).mean()
+
+    diff = normed[:, 1:, :] - normed[:, :-1, :]
+    if diff.size(1) >= 2:
+        diff_prev = diff[:, :-1, :]
+        diff_next = diff[:, 1:, :]
+        denom = diff_prev.norm(dim=-1) * diff_next.norm(dim=-1) + 1e-12
+        cos_steps = (diff_prev * diff_next).sum(dim=-1) / denom
+        step_term = torch.clamp(-cos_steps, min=0.0).mean()
+    else:
+        cos_steps = torch.empty(0, device=device, dtype=dtype)
+        step_term = weight.new_tensor(0.0)
+
+    if weight.size(1) >= 3:
+        curvature_mag = (normed[:, 2:, :] - 2 * normed[:, 1:-1, :] + normed[:, :-2, :]).norm(dim=-1)
+        curvature_term = curvature_mag.mean()
+    else:
+        curvature_mag = torch.empty(0, device=device, dtype=dtype)
+        curvature_term = weight.new_tensor(0.0)
+
+    penalty = (
+        reg_align * align_term
+        + reg_step * step_term
+        + reg_curv * curvature_term
+    )
+
+    metrics: dict[str, float] = {}
+    if compute_metrics:
+        angles_cos = torch.clamp(
+            (normed[:, :-1, :] * normed[:, 1:, :]).sum(dim=-1),
+            -1.0 + 1e-6,
+            1.0 - 1e-6,
+        )
+        angles = torch.acos(angles_cos)
+        if angles.numel() > 0:
+            angles_flat = angles.reshape(-1)
+            angle_p50 = float(
+                torch.quantile(angles_flat, 0.5).detach().cpu() * (180.0 / math.pi)
+            )
+            angle_p90 = float(
+                torch.quantile(angles_flat, 0.9).detach().cpu() * (180.0 / math.pi)
+            )
+        else:
+            angle_p50 = angle_p90 = 0.0
+        flip_rate = (
+            float((cos_steps < 0).float().mean().detach().cpu())
+            if cos_steps.numel() > 0
+            else 0.0
+        )
+        if cos_steps.numel() > 0:
+            cos_flat = cos_steps.detach().reshape(-1).float()
+            direction_mean = float(cos_flat.mean().cpu())
+            direction_std = float(cos_flat.std(unbiased=False).cpu())
+            direction_p10 = float(torch.quantile(cos_flat, 0.1).cpu())
+            direction_p90 = float(torch.quantile(cos_flat, 0.9).cpu())
+        else:
+            direction_mean = 0.0
+            direction_std = 0.0
+            direction_p10 = 0.0
+            direction_p90 = 0.0
+        proj_vector = torch.ones(normed.shape[-1], device=device, dtype=normed.dtype)
+        proj_vector = proj_vector / (proj_vector.norm() + 1e-12)
+        proj_vals = torch.matmul(weight, proj_vector)
+        ks = _ks_uniform_metric(proj_vals.reshape(-1))
+        metrics = {
+            "lut_align": float(align_term.detach().cpu()),
+            "lut_step": float(step_term.detach().cpu()),
+            "lut_curvature": float(curvature_term.detach().cpu()),
+            "lut_flip_rate": flip_rate,
+            "lut_angle_p50_deg": angle_p50,
+            "lut_angle_p90_deg": angle_p90,
+            "lut_ks_uniform": ks,
+            "lut_step_cos_mean": direction_mean,
+            "lut_step_cos_std": direction_std,
+            "lut_step_cos_p10": direction_p10,
+            "lut_step_cos_p90": direction_p90,
+        }
+    return penalty, metrics
 
 
 # Compatibility autocast wrapper: prefer torch.amp.autocast('cuda', ...) if available,
@@ -391,6 +545,18 @@ def train_one_epoch(
     epoch_loss = MeanMetric().to(device, non_blocking=True)
     entropy_metric = MeanMetric().to(device, non_blocking=True)
     cosine_scale_ratio_metric = MeanMetric().to(device, non_blocking=True)
+    geodesic_penalty_metric = MeanMetric().to(device, non_blocking=True)
+    geodesic_penalty_updated = False
+    lut_reg_align = float(getattr(args, "mi_lut_reg_align", 0.0))
+    lut_reg_step = float(getattr(args, "mi_lut_reg_step", 0.0))
+    lut_reg_curvature = float(getattr(args, "mi_lut_reg_curvature", 0.0))
+    lut_geometry_log = bool(getattr(args, "mi_lut_geometry_log", False))
+    geometry_reg_enabled = any(w > 0.0 for w in (lut_reg_align, lut_reg_step, lut_reg_curvature))
+    geometry_enabled = getattr(args, "mi_learnable_lut", False) and (geometry_reg_enabled or lut_geometry_log)
+    geometry_accum = defaultdict(float)
+    geometry_count = 0
+    last_geometry_metrics: dict[str, float] = {}
+
     cosine_effective_neighbor_metric = MeanMetric().to(device, non_blocking=True)
     cosine_metrics_updated = False
     entropy_samples: list[torch.Tensor] = []
@@ -564,6 +730,7 @@ def train_one_epoch(
         samples = samples.to(device, non_blocking=True)
         labels = labels.to(device, non_blocking=True)
 
+        geom_metrics_step: dict[str, float] = {}
         if torch.rand(1) < args.class_drop_prob:
             conditioning = {}
         else:
@@ -856,6 +1023,24 @@ def train_one_epoch(
 
             if logbeta_reg_penalty is not None:
                 loss = loss + logbeta_reg_penalty
+            if geometry_enabled:
+                penalty, geom_metrics = _compute_lut_regularizer_and_metrics(
+                    path=path,
+                    device=device,
+                    reg_align=lut_reg_align,
+                    reg_step=lut_reg_step,
+                    reg_curv=lut_reg_curvature,
+                    compute_metrics=lut_geometry_log or geometry_reg_enabled,
+                )
+                if geometry_reg_enabled:
+                    loss = loss + penalty
+                if geom_metrics:
+                    geom_metrics_step = geom_metrics
+                    geometry_count += 1
+                    last_geometry_metrics = geom_metrics
+                    for k, v in geom_metrics.items():
+                        geometry_accum[k] += v
+
 
             beta_t_values, _ = path.beta(t)
             if cosine_monitor_enabled:
@@ -997,10 +1182,13 @@ def train_one_epoch(
                             
                             # Add to total loss
                             loss = loss + geo_penalty
-                            
+
                             # Store for logging (detach to avoid gradients)
                             geodesic_energy_val = geo_energy.detach()
-                            
+                            geodesic_penalty = geo_penalty.detach()
+                            geodesic_penalty_metric.update(geodesic_penalty)
+                            geodesic_penalty_updated = True
+
                             # Announce once per training
                             if not getattr(args, "_geodesic_energy_announced", False):
                                 logger.info(
@@ -1009,14 +1197,7 @@ def train_one_epoch(
                                 )
                                 setattr(args, "_geodesic_energy_announced", True)
 
-            wandb_logger = None
-            if getattr(args, "wandb", False) and distributed_mode.is_main_process():
-                try:
-                    import swanlab as wandb  # type: ignore
-                    wandb_logger = wandb
-                except ImportError:
-                    wandb_logger = None
-
+            wandb_logger = _resolve_wandb_module(args)
             if wandb_logger is not None:
                 weighted_entropy = _importance_weighted_mean(target_entropy, logbeta_weights)
                 wandb_log_data = {
@@ -1053,6 +1234,9 @@ def train_one_epoch(
                                 ),
                             }
                         )
+                if geom_metrics_step:
+                    for key, value in geom_metrics_step.items():
+                        wandb_log_data[key.replace("lut_", "lut/")] = float(value)
                 
                 # Log geodesic energy regularization
                 if geodesic_energy_val is not None:
@@ -1061,7 +1245,7 @@ def train_one_epoch(
                     )
                 if geodesic_penalty is not None:
                     wandb_log_data["train/geodesic_penalty"] = float(
-                        geodesic_penalty.detach().cpu().item()
+                        geodesic_penalty.cpu().item()
                     )
 
                 # Log bounded residual scale parameters and penalty
@@ -1343,22 +1527,18 @@ def train_one_epoch(
             logger.info(log_msg)
 
             # Optional Weights & Biases step-level logging (main process only)
-            if getattr(args, "wandb", False) and distributed_mode.is_main_process():
+            wandb_logger = _resolve_wandb_module(args)
+            if wandb_logger is not None:
                 try:
-                    import swanlab as wandb  # type: ignore
-                    if _dl_len is not None:
-                        global_step = epoch * _dl_len + data_iter_step
-                    else:
-                        global_step = None
-                    
-                    # Compute metric diagnostics for logging
+                    global_step = epoch * _dl_len + data_iter_step if _dl_len is not None else None
+
                     metric_diagnostics = {}
                     if hasattr(path, "learnable_metric") and path.learnable_metric is not None:
                         with torch.no_grad():
                             Z = path.learnable_metric.transformed_codes(
                                 device=device, dtype=torch.float32
                             )
-                            fro_norm = torch.linalg.norm(Z, ord='fro')
+                            fro_norm = torch.linalg.norm(Z, ord="fro")
                             dist_table = path.learnable_metric.pairwise_distance_table(
                                 device=device, dtype=torch.float32
                             )
@@ -1369,32 +1549,28 @@ def train_one_epoch(
                                 "metric/distance_max": float(dist_table.max().cpu()),
                                 "metric/distance_min": float(dist_table.min().cpu()),
                             }
-                            # Log learned scale (in reparameterization mode)
-                            if hasattr(path.learnable_metric, 'log_scale'):
+                            if hasattr(path.learnable_metric, "log_scale"):
                                 metric_diagnostics["metric/learned_scale"] = float(
                                     torch.exp(path.learnable_metric.log_scale).cpu()
                                 )
                             if metric_grad_norm_value is not None:
                                 metric_diagnostics["metric/grad_norm"] = float(
-                                    metric_grad_norm_value.cpu() if isinstance(metric_grad_norm_value, torch.Tensor) 
+                                    metric_grad_norm_value.cpu()
+                                    if isinstance(metric_grad_norm_value, torch.Tensor)
                                     else metric_grad_norm_value
                                 )
-                    
-                    # Add LUT diagnostics
+
                     lut_diagnostics = {}
                     if hasattr(path, "learnable_lut") and path.learnable_lut is not None:
                         with torch.no_grad():
-                            # Use forward() to get renormalized weights if enabled
                             lut_weight = path.learnable_lut()
                             lut_diagnostics["lut/weight_mean"] = float(lut_weight.mean().cpu())
                             lut_diagnostics["lut/weight_std"] = float(lut_weight.std().cpu())
                             lut_diagnostics["lut/weight_min"] = float(lut_weight.min().cpu())
                             lut_diagnostics["lut/weight_max"] = float(lut_weight.max().cpu())
                             lut_diagnostics["lut/weight_abs_max"] = float(lut_weight.abs().max().cpu())
-                            # Per-channel std
                             for ch_idx in range(lut_weight.shape[0]):
                                 lut_diagnostics[f"lut/ch{ch_idx}_std"] = float(lut_weight[ch_idx].std().cpu())
-                            # Per-channel Frobenius norms
                             lut_flat = lut_weight.view(lut_weight.shape[0], -1)
                             channel_fro = torch.linalg.vector_norm(lut_flat, ord=2, dim=1)
                             lut_diagnostics["lut/fro_norm_mean"] = float(channel_fro.mean().cpu())
@@ -1419,119 +1595,95 @@ def train_one_epoch(
                             )
                         if lut_param_delta is not None:
                             lut_diagnostics["lut/param_delta"] = float(lut_param_delta)
-                    
-                    wandb.log(  # type: ignore[attr-defined]
-                        {
-                            "train/step_loss": float(batch_loss.compute().detach().cpu()),
-                            "train/inst_loss": float(loss_value),
-                            "train/uw_loss": float(uw_loss) if 'uw_loss' in locals() else float(loss_value),
-                            "train/lr": float(lr),
-                            "epoch": int(epoch),
-                            **(
+
+                    wandb_payload = {
+                        "train/step_loss": float(batch_loss.compute().detach().cpu()),
+                        "train/inst_loss": float(loss_value),
+                        "train/uw_loss": float(uw_loss) if "uw_loss" in locals() else float(loss_value),
+                        "train/lr": float(lr),
+                        "epoch": int(epoch),
+                    }
+                    if step_scale_ratio is not None and step_effective_neighbor is not None:
+                        wandb_payload.update(
+                            {
+                                "train/cosine_scale_ratio": float(step_scale_ratio),
+                                "train/cosine_effective_neighbor": float(step_effective_neighbor),
+                            }
+                        )
+                    wandb_payload.update(metric_diagnostics)
+                    wandb_payload.update(lut_diagnostics)
+                    if grad_norm is not None and not grad_step_skipped:
+                        wandb_payload["train/model_grad_norm"] = float(
+                            grad_norm.cpu() if isinstance(grad_norm, torch.Tensor) else grad_norm
+                        )
+                    if use_path_trust_region and schedule_kl_value is not None:
+                        wandb_payload["train/schedule_kl"] = float(schedule_kl_value.detach().cpu())
+                        if schedule_kl_penalty is not None:
+                            wandb_payload["train/schedule_kl_penalty"] = float(
+                                schedule_kl_penalty.detach().cpu()
+                            )
+                        wandb_payload["train/schedule_kl_weight"] = float(kl_controller.current_weight())
+                        if kl_avg_for_logging is not None:
+                            wandb_payload["train/schedule_kl_avg"] = float(kl_avg_for_logging)
+                    if gumbel_schedule_active and current_gumbel_tau is not None:
+                        wandb_payload["train/gumbel_tau"] = float(current_gumbel_tau)
+                    if tau_progress is not None:
+                        wandb_payload["train/gumbel_tau_progress"] = float(tau_progress)
+                    if step_entropy_mean is not None:
+                        wandb_payload["train/entropy_mean"] = float(step_entropy_mean)
+                    if step_entropy_median is not None:
+                        wandb_payload["train/entropy_median"] = float(step_entropy_median)
+                    if step_entropy_p90 is not None:
+                        wandb_payload["train/entropy_p90"] = float(step_entropy_p90)
+                    if metric_interp_active and current_metric_interp is not None:
+                        wandb_payload["train/metric_interp_lambda"] = float(current_metric_interp)
+                    if logbeta_reg_penalty is not None:
+                        wandb_payload["train/logbeta_reg_penalty"] = float(logbeta_reg_penalty.detach().cpu())
+                        if logbeta_reg_terms is not None:
+                            wandb_payload.update(
                                 {
-                                    "train/cosine_scale_ratio": float(step_scale_ratio),
-                                    "train/cosine_effective_neighbor": float(step_effective_neighbor),
-                                }
-                                if step_scale_ratio is not None and step_effective_neighbor is not None
-                                else {}
-                            ),
-                            **metric_diagnostics,
-                            **lut_diagnostics,
-                            **({
-                                "train/model_grad_norm": float(
-                                    grad_norm.cpu() if isinstance(grad_norm, torch.Tensor) else grad_norm
-                                )
-                            } if grad_norm is not None and not grad_step_skipped else {}),
-                            **(
-                                {
-                                    "train/schedule_kl": float(
-                                        schedule_kl_value.detach().cpu()
-                                    ),
-                                    "train/schedule_kl_penalty": float(
-                                        schedule_kl_penalty.detach().cpu()
-                                    ),
-                                    "train/schedule_kl_weight": float(
-                                        kl_controller.current_weight()
-                                    ),
-                                    **(
-                                        {
-                                            "train/schedule_kl_avg": float(
-                                                kl_avg_for_logging
-                                            )
-                                        }
-                                        if kl_avg_for_logging is not None
-                                        else {}
-                                    ),
-                                }
-                                if use_path_trust_region and schedule_kl_value is not None
-                                else {}
-                            ),
-                            **(
-                                {
-                                    "train/gumbel_tau": float(current_gumbel_tau)
-                                }
-                                if gumbel_schedule_active and current_gumbel_tau is not None
-                                else {}
-                            ),
-                            **(
-                                {
-                                    "train/gumbel_tau_progress": float(tau_progress)
-                                }
-                                if tau_progress is not None
-                                else {}
-                            ),
-                            **(
-                                {
-                                    "train/entropy_mean": float(step_entropy_mean),
-                                    "train/entropy_median": float(step_entropy_median),
-                                    "train/entropy_p90": float(step_entropy_p90),
-                                }
-                                if step_entropy_mean is not None
-                                else {}
-                            ),
-                            **(
-                                {
-                                    "train/metric_interp_lambda": float(
-                                        current_metric_interp
-                                    )
-                                }
-                                if metric_interp_active
-                                and current_metric_interp is not None
-                                else {}
-                            ),
-                            **(
-                                {
-                                    "train/logbeta_reg_penalty": float(
-                                        logbeta_reg_penalty.detach().cpu()
-                                    ),
-                                    **(
-                                        {
-                                            "train/logbeta_reg_delta": float(
-                                                logbeta_reg_terms["delta"].detach().cpu()
-                                            ),
-                                            "train/logbeta_reg_delta2": float(
-                                                logbeta_reg_terms["delta2"].detach().cpu()
-                                            ),
-                                            "train/logbeta_reg_endpoint": float(
-                                                logbeta_reg_terms["endpoint"].detach().cpu()
-                                            ),
-                                        }
-                                        if logbeta_reg_terms is not None
-                                        else {}
+                                    "train/logbeta_reg_delta": float(logbeta_reg_terms["delta"].detach().cpu()),
+                                    "train/logbeta_reg_delta2": float(logbeta_reg_terms["delta2"].detach().cpu()),
+                                    "train/logbeta_reg_endpoint": float(
+                                        logbeta_reg_terms["endpoint"].detach().cpu()
                                     ),
                                 }
-                                if logbeta_reg_penalty is not None
-                                else {}
-                            ),
-                        },
-                        step=global_step,
-                    )
-                except Exception:
-                    pass
+                            )
+                    if geom_metrics_step:
+                        for key, value in geom_metrics_step.items():
+                            wandb_payload[key.replace("lut_", "train/lut_")] = value
+                    if geodesic_energy_val is not None:
+                        wandb_payload["train/geodesic_energy"] = float(geodesic_energy_val.cpu().item())
+                    if geodesic_penalty is not None:
+                        wandb_payload["train/geodesic_penalty"] = float(geodesic_penalty.cpu().item())
+
+                    wandb_logger.log(wandb_payload, step=global_step)
+                except Exception as exc:
+                    logger.warning(f"WandB logging failed at step {data_iter_step}: {exc}")
 
     setattr(args, "_mi_logbeta_reg_step", logbeta_reg_update_step)
     lr_schedule.step()
     stats = {"loss": float(epoch_loss.compute().detach().cpu())}
+    if geodesic_penalty_updated:
+        try:
+            stats["train/geodesic_penalty"] = float(
+                geodesic_penalty_metric.compute().detach().cpu().item()
+            )
+        except Exception:
+            pass
+    if geometry_count > 0:
+        try:
+            avg_metrics = {
+                key: value / float(geometry_count) for key, value in geometry_accum.items()
+            }
+            for key, value in avg_metrics.items():
+                stats[f"{key.replace('lut_', 'lut/')}_mean"] = float(value)
+            stats["lut/geometry_updates"] = float(geometry_count)
+            if last_geometry_metrics:
+                for key, value in last_geometry_metrics.items():
+                    stats[f"{key.replace('lut_', 'lut/')}_last"] = float(value)
+        except Exception:
+            logger.exception("Failed to aggregate LUT geometry metrics")
     if entropy_samples:
         try:
             entropy_epoch_tensor = torch.cat(entropy_samples)
@@ -1849,17 +2001,16 @@ def _log_lut_diagnostics(path: MetricInducedGibbsProbPath, epoch: int, logger: l
         logger.info(f"LUT diagnostics visualization saved to {save_path}")
         
         # Log to wandb if available
-        if getattr(args, 'wandb', False):
+        wandb_logger = _resolve_wandb_module(args)
+        if wandb_logger is not None:
             try:
-                import wandb
-                # Only log if wandb is actually initialized
-                if wandb.run is not None:
-                    wandb.log({"lut/diagnostics": wandb.Image(save_path)}, step=epoch)
-                    logger.info(f"✓ LUT diagnostics uploaded to wandb (run: {wandb.run.name})")
+                run = getattr(wandb_logger, "run", None)
+                if run is not None:
+                    wandb_logger.log({"lut/diagnostics": wandb_logger.Image(save_path)}, step=epoch)
+                    run_name = getattr(run, "name", "unknown")
+                    logger.info(f"LUT diagnostics uploaded to wandb (run: {run_name})")
                 else:
                     logger.info("wandb not initialized, image saved locally only")
-            except ImportError:
-                logger.info("wandb not installed, image saved locally only")
             except Exception as e:
                 logger.info(f"wandb upload skipped ({type(e).__name__}), image saved locally")
         

--- a/examples/image/training/train_loop.py
+++ b/examples/image/training/train_loop.py
@@ -343,6 +343,23 @@ def train_one_epoch(
         if metric_interp_update_step < epoch_offset_interp:
             metric_interp_update_step = epoch_offset_interp
 
+    logbeta_delta_weight = float(getattr(args, "mi_logbeta_reg_delta_weight", 0.0))
+    logbeta_delta2_weight = float(getattr(args, "mi_logbeta_reg_delta2_weight", 0.0))
+    logbeta_endpoint_weight = float(getattr(args, "mi_logbeta_endpoint_weight", 0.0))
+    logbeta_reg_power = float(getattr(args, "mi_logbeta_reg_power", 0.0))
+    logbeta_reg_steps = int(getattr(args, "mi_logbeta_reg_anneal_steps", 0) or 0)
+    logbeta_reg_update_step = int(getattr(args, "_mi_logbeta_reg_step", 0))
+
+    def _logbeta_annealed_weight(base: float) -> float:
+        if base <= 0.0:
+            return 0.0
+        if logbeta_reg_steps <= 0:
+            return base
+        progress = min(
+            max(logbeta_reg_update_step / float(logbeta_reg_steps), 0.0), 1.0
+        )
+        return base * (1.0 - progress)
+
     for data_iter_step, (samples, labels) in enumerate(data_loader):
         if data_iter_step % accum_iter == 0:
             optimizer.zero_grad(set_to_none=True)
@@ -367,45 +384,174 @@ def train_one_epoch(
             logbeta_weights: Optional[torch.Tensor] = None
             mis_uniform_frac: Optional[float] = None
             schedule = getattr(path, "beta_schedule", None)
-            lmin = getattr(args, "mi_logbeta_min", None)
-            lmax = getattr(args, "mi_logbeta_max", None)
-            use_logbeta_sampling = (
-                isinstance(schedule, ExpMonotoneRQSSchedule)
-                and hasattr(schedule, "sample_t_uniform_logbeta")
-                and lmin is not None
-                and lmax is not None
-            )
-            if use_logbeta_sampling and lmax <= lmin:
-                if not getattr(args, "_mi_logbeta_interval_warned", False):
+            schedule_is_exp = isinstance(schedule, ExpMonotoneRQSSchedule)
+            lmin_cfg = getattr(args, "mi_logbeta_min", None)
+            lmax_cfg = getattr(args, "mi_logbeta_max", None)
+            band_lo_cfg = getattr(args, "mi_logbeta_band_t_lo", None)
+            band_hi_cfg = getattr(args, "mi_logbeta_band_t_hi", None)
+            trunc_t_cfg = getattr(args, "mi_logbeta_trunc_t", None)
+
+            lmin_val = float(lmin_cfg) if lmin_cfg is not None else None
+            lmax_val = float(lmax_cfg) if lmax_cfg is not None else None
+            band_lo: Optional[float] = None
+            band_hi: Optional[float] = None
+
+            if schedule_is_exp:
+                cfg_t_eps = float(schedule.config.t_eps)
+                default_lo = cfg_t_eps
+                default_hi = 1.0 - cfg_t_eps
+                band_lo = max(
+                    default_lo,
+                    float(band_lo_cfg) if band_lo_cfg is not None else default_lo,
+                )
+                band_hi = min(
+                    default_hi,
+                    float(band_hi_cfg) if band_hi_cfg is not None else default_hi,
+                )
+                if band_hi <= band_lo:
+                    if not getattr(args, "_mi_logbeta_band_warned", False):
+                        logger.warning(
+                            "Adjusted log-β t-band to maintain ordering (received %.4f, %.4f)",
+                            float(band_lo),
+                            float(band_hi),
+                        )
+                        setattr(args, "_mi_logbeta_band_warned", True)
+                    band_hi = min(default_hi, band_lo + 1e-6)
+
+            uniform_lo = 0.0
+            uniform_hi = 1.0
+            if band_lo is not None and band_hi is not None:
+                uniform_lo = band_lo
+                uniform_hi = band_hi
+
+            trunc_t: Optional[float] = None
+            if trunc_t_cfg is not None:
+                trunc_t = float(trunc_t_cfg)
+                min_trunc = max(
+                    0.0,
+                    float(schedule.config.t_eps) if schedule_is_exp else float(getattr(args, "mi_t_eps", 0.0)),
+                )
+                if trunc_t <= min_trunc:
+                    if not getattr(args, "_mi_logbeta_trunc_warned", False):
+                        logger.warning(
+                            "mi_logbeta_trunc_t=%.4f must exceed %.4f; ignoring truncation.",
+                            trunc_t,
+                            min_trunc,
+                        )
+                        setattr(args, "_mi_logbeta_trunc_warned", True)
+                    trunc_t = None
+                elif trunc_t >= 0.5:
+                    if not getattr(args, "_mi_logbeta_trunc_clip_warned", False):
+                        logger.warning(
+                            "mi_logbeta_trunc_t=%.4f is too close to 0.5; clipping to 0.499.",
+                            trunc_t,
+                        )
+                        setattr(args, "_mi_logbeta_trunc_clip_warned", True)
+                    trunc_t = 0.499
+            if trunc_t is not None:
+                uniform_lo = max(uniform_lo, trunc_t)
+                uniform_hi = min(uniform_hi, 1.0 - trunc_t)
+
+            if uniform_hi <= uniform_lo:
+                if not getattr(args, "_mi_logbeta_uniform_warned", False):
                     logger.warning(
-                        "Ignoring log-β sampling interval with l_min >= l_max (%.4f, %.4f)",
-                        lmin,
-                        lmax,
+                        "Falling back to full [0,1] uniform support because bounds collapsed (%.4f, %.4f).",
+                        uniform_lo,
+                        uniform_hi,
                     )
-                    setattr(args, "_mi_logbeta_interval_warned", True)
-                use_logbeta_sampling = False
+                    setattr(args, "_mi_logbeta_uniform_warned", True)
+                uniform_lo = 0.0
+                uniform_hi = 1.0
+
+            if (uniform_lo > 0.0 or uniform_hi < 1.0) and not getattr(
+                args, "_mi_logbeta_uniform_announced", False
+            ):
+                logger.info(
+                    "MIS uniform support set to [%.4f, %.4f]",
+                    uniform_lo,
+                    uniform_hi,
+                )
+                setattr(args, "_mi_logbeta_uniform_announced", True)
+
+            if schedule_is_exp and band_lo is not None and band_hi is not None:
+                effective_band_lo = max(band_lo, uniform_lo)
+                effective_band_hi = min(band_hi, uniform_hi)
+                if effective_band_hi <= effective_band_lo:
+                    if not getattr(args, "_mi_logbeta_effective_band_warned", False):
+                        logger.warning(
+                            "Uniform truncation [%.4f, %.4f] conflicts with log-β band [%.4f, %.4f];"
+                            " keeping schedule band for log-β proposals.",
+                            uniform_lo,
+                            uniform_hi,
+                            band_lo,
+                            band_hi,
+                        )
+                        setattr(args, "_mi_logbeta_effective_band_warned", True)
+                    effective_band_lo = band_lo
+                    effective_band_hi = band_hi
+                else:
+                    band_lo = effective_band_lo
+                    band_hi = effective_band_hi
+
+                with torch.no_grad():
+                    t_bounds = torch.tensor(
+                        [band_lo, band_hi],
+                        dtype=schedule.y0.dtype,
+                        device=schedule.y0.device,
+                    )
+                    ell_bounds = schedule.ell_from_t(t_bounds)
+                derived_lmin = float(torch.min(ell_bounds).item())
+                derived_lmax = float(torch.max(ell_bounds).item())
+                if lmin_val is None:
+                    lmin_val = derived_lmin
+                else:
+                    lmin_val = max(lmin_val, derived_lmin)
+                if lmax_val is None:
+                    lmax_val = derived_lmax
+                else:
+                    lmax_val = min(lmax_val, derived_lmax)
+
+            use_logbeta_sampling = (
+                schedule_is_exp
+                and hasattr(schedule, "sample_t_uniform_logbeta")
+                and lmin_val is not None
+                and lmax_val is not None
+            )
+            if use_logbeta_sampling:
+                assert lmin_val is not None and lmax_val is not None
+                if lmax_val <= lmin_val:
+                    if not getattr(args, "_mi_logbeta_interval_warned", False):
+                        logger.warning(
+                            "Ignoring log-β sampling interval with l_min >= l_max (%.4f, %.4f)",
+                            lmin_val,
+                            lmax_val,
+                        )
+                        setattr(args, "_mi_logbeta_interval_warned", True)
+                    use_logbeta_sampling = False
 
             mix_alpha_raw = float(getattr(args, "mi_logbeta_mis_alpha", 0.0))
             mix_alpha = float(min(max(mix_alpha_raw, 0.0), 1.0))
 
+            batch_size = samples.shape[0]
+            uniform_span = max(uniform_hi - uniform_lo, 1e-6)
+            t_uniform = uniform_lo + torch.rand(batch_size, device=device) * uniform_span
+
             if use_logbeta_sampling:
-                batch_size = samples.shape[0]
-                # Draw proposals from both distributions (log-β and uniform) and mix via MIS.
+                assert lmin_val is not None and lmax_val is not None
                 t_logbeta, _ = schedule.sample_t_uniform_logbeta(
                     batch_shape=(batch_size,),
-                    lmin=float(lmin),
-                    lmax=float(lmax),
+                    lmin=float(lmin_val),
+                    lmax=float(lmax_val),
                 )
                 t_logbeta = t_logbeta.to(device=device)
-                t_uniform = torch.rand(batch_size, device=device)
                 selector = torch.rand(batch_size, device=device) < mix_alpha
                 t = torch.where(selector, t_uniform, t_logbeta)
 
                 if not getattr(args, "_mi_logbeta_sampling_announced", False):
                     logger.info(
                         "Using uniform log-β sampling with interval [%.4f, %.4f]",
-                        float(lmin),
-                        float(lmax),
+                        float(lmin_val),
+                        float(lmax_val),
                     )
                     setattr(args, "_mi_logbeta_sampling_announced", True)
                 if 0.0 < mix_alpha < 1.0 and not getattr(args, "_mi_logbeta_mis_announced", False):
@@ -416,17 +562,50 @@ def train_one_epoch(
                     )
                     setattr(args, "_mi_logbeta_mis_announced", True)
 
-                interval = max(float(lmax) - float(lmin), 1e-6)
+                interval = max(float(lmax_val) - float(lmin_val), 1e-6)
                 t_for_schedule = t.to(device=t_logbeta.device, dtype=t_logbeta.dtype)
                 beta_vals, beta_deriv = schedule.beta_and_derivative(t_for_schedule)
                 beta_vals = beta_vals.clamp_min(1e-12)
                 q_logbeta = (beta_deriv / beta_vals).clamp_min(1e-12) / interval
                 q_logbeta = q_logbeta.to(device=device, dtype=torch.float32)
-                q_mix = mix_alpha + (1.0 - mix_alpha) * q_logbeta
+                one_over_span = torch.tensor(
+                    1.0 / uniform_span,
+                    device=device,
+                    dtype=q_logbeta.dtype,
+                )
+                q_uniform = torch.zeros_like(q_logbeta)
+                within_uniform = (t >= uniform_lo) & (t <= uniform_hi)
+                q_uniform = torch.where(within_uniform, one_over_span, q_uniform)
+                q_mix = mix_alpha * q_uniform + (1.0 - mix_alpha) * q_logbeta
                 logbeta_weights = (1.0 / q_mix.clamp_min(1e-12)).to(device=device)
                 mis_uniform_frac = float(selector.float().mean().detach().cpu().item())
             else:
-                t = torch.rand(samples.shape[0], device=device)
+                t = t_uniform
+
+            logbeta_reg_penalty: Optional[torch.Tensor] = None
+            logbeta_reg_terms: Optional[dict[str, torch.Tensor]] = None
+            if schedule_is_exp and isinstance(schedule, ExpMonotoneRQSSchedule):
+                reg_terms = schedule.logbeta_regularization(
+                    t_lo=band_lo,
+                    t_hi=band_hi,
+                    power=logbeta_reg_power,
+                )
+                logbeta_reg_terms = reg_terms
+                penalty_components: Optional[torch.Tensor] = None
+                delta_weight_curr = _logbeta_annealed_weight(logbeta_delta_weight)
+                delta2_weight_curr = _logbeta_annealed_weight(logbeta_delta2_weight)
+                endpoint_weight_curr = _logbeta_annealed_weight(logbeta_endpoint_weight)
+                if delta_weight_curr > 0.0:
+                    penalty = reg_terms["delta"] * delta_weight_curr
+                    penalty_components = penalty if penalty_components is None else penalty_components + penalty
+                if delta2_weight_curr > 0.0:
+                    penalty = reg_terms["delta2"] * delta2_weight_curr
+                    penalty_components = penalty if penalty_components is None else penalty_components + penalty
+                if endpoint_weight_curr > 0.0:
+                    penalty = reg_terms["endpoint"] * endpoint_weight_curr
+                    penalty_components = penalty if penalty_components is None else penalty_components + penalty
+                if penalty_components is not None:
+                    logbeta_reg_penalty = penalty_components
 
             # Provide dummy x_0 for signature compatibility (not used by metric-induced path)
             x_0 = torch.zeros_like(samples)
@@ -446,24 +625,18 @@ def train_one_epoch(
             token_loss = torch.nn.functional.cross_entropy(
                 logits_flat, targets_flat, reduction="none"
             )
-            target_tokens = samples.view(samples.shape[0], -1)
-            token_counts = torch.zeros(
-                target_tokens.shape[0],
-                vocab_size,
-                device=target_tokens.device,
-                dtype=torch.float32,
-            )
-            token_counts.scatter_add_(
-                1,
-                target_tokens,
-                torch.ones_like(target_tokens, dtype=torch.float32),
-            )
-            token_probs = token_counts / token_counts.sum(dim=1, keepdim=True).clamp_min(1e-12)
-            token_probs = token_probs.clamp_min(1e-12)
-            target_entropy = -(token_probs * token_probs.log()).sum(dim=1)
+            with torch.no_grad():
+                x1_flat = samples.view(samples.shape[0], -1)
+                path_probs = path.get_prob_distribution_from_tokens(x1_flat, t)
+                path_probs = path_probs.clamp_min(1e-12)
+                per_site_entropy = -(path_probs * path_probs.log()).sum(dim=-1)
+                target_entropy = per_site_entropy.mean(dim=1)
             per_sample_loss = token_loss.view(samples.shape[0], -1).mean(dim=1)
             uw_loss = per_sample_loss.mean().item()
             loss = _importance_weighted_mean(per_sample_loss, logbeta_weights)
+
+            if logbeta_reg_penalty is not None:
+                loss = loss + logbeta_reg_penalty
 
             if use_path_trust_region:
                 x1_flat = samples.view(samples.shape[0], -1)
@@ -508,8 +681,9 @@ def train_one_epoch(
                     wandb_logger = None
 
             if wandb_logger is not None:
+                weighted_entropy = _importance_weighted_mean(target_entropy, logbeta_weights)
                 wandb_log_data = {
-                    "diag/target_entropy_mean": float(target_entropy.mean().detach().cpu().item()),
+                    "diag/target_entropy_mean": float(weighted_entropy.detach().cpu().item()),
                 }
                 if logbeta_weights is not None:
                     w = logbeta_weights.detach()
@@ -517,6 +691,24 @@ def train_one_epoch(
                     wandb_log_data["diag/ess_frac"] = float((ess_num / (w.numel() + 1e-12)).item())
                 if mis_uniform_frac is not None:
                     wandb_log_data["diag/mis_uniform_frac"] = mis_uniform_frac
+                if logbeta_reg_penalty is not None:
+                    wandb_log_data["loss/logbeta_reg_penalty"] = float(
+                        logbeta_reg_penalty.detach().cpu().item()
+                    )
+                    if logbeta_reg_terms is not None:
+                        wandb_log_data.update(
+                            {
+                                "loss/logbeta_reg_delta": float(
+                                    logbeta_reg_terms["delta"].detach().cpu().item()
+                                ),
+                                "loss/logbeta_reg_delta2": float(
+                                    logbeta_reg_terms["delta2"].detach().cpu().item()
+                                ),
+                                "loss/logbeta_reg_endpoint": float(
+                                    logbeta_reg_terms["endpoint"].detach().cpu().item()
+                                ),
+                            }
+                        )
 
                 if data_iter_step % (PRINT_FREQUENCY * 10) == 0:
                     max_points = int(getattr(args, "wandb_entropy_max_points", 4096) or 4096)
@@ -758,6 +950,8 @@ def train_one_epoch(
             and path.learnable_metric is not None
         ):
             metric_ema.update(path.learnable_metric)
+        if apply_update and not grad_step_skipped:
+            logbeta_reg_update_step += 1
         if apply_update:
             if use_path_trust_region:
                 if grad_step_skipped:
@@ -896,12 +1090,37 @@ def train_one_epoch(
                                 and current_metric_interp is not None
                                 else {}
                             ),
+                            **(
+                                {
+                                    "train/logbeta_reg_penalty": float(
+                                        logbeta_reg_penalty.detach().cpu()
+                                    ),
+                                    **(
+                                        {
+                                            "train/logbeta_reg_delta": float(
+                                                logbeta_reg_terms["delta"].detach().cpu()
+                                            ),
+                                            "train/logbeta_reg_delta2": float(
+                                                logbeta_reg_terms["delta2"].detach().cpu()
+                                            ),
+                                            "train/logbeta_reg_endpoint": float(
+                                                logbeta_reg_terms["endpoint"].detach().cpu()
+                                            ),
+                                        }
+                                        if logbeta_reg_terms is not None
+                                        else {}
+                                    ),
+                                }
+                                if logbeta_reg_penalty is not None
+                                else {}
+                            ),
                         },
                         step=global_step,
                     )
                 except Exception:
                     pass
 
+    setattr(args, "_mi_logbeta_reg_step", logbeta_reg_update_step)
     lr_schedule.step()
     stats = {"loss": float(epoch_loss.compute().detach().cpu())}
     if use_path_trust_region and kl_updates_total > 0 and kl_metric and kl_penalty_metric:
@@ -929,3 +1148,4 @@ def train_one_epoch(
             if hasattr(args, attr):
                 delattr(args, attr)
     return stats
+

--- a/examples/image/training/train_loop.py
+++ b/examples/image/training/train_loop.py
@@ -389,6 +389,8 @@ def train_one_epoch(
 
     batch_loss = MeanMetric().to(device, non_blocking=True)
     epoch_loss = MeanMetric().to(device, non_blocking=True)
+    entropy_metric = MeanMetric().to(device, non_blocking=True)
+    entropy_samples: list[torch.Tensor] = []
 
     accum_iter = args.accum_iter
     # Select path according to args. For KO CIFAR-10 metric-induced path, set
@@ -556,6 +558,9 @@ def train_one_epoch(
 
         schedule_kl_value = None
         schedule_kl_penalty = None
+        step_entropy_mean: Optional[float] = None
+        step_entropy_median: Optional[float] = None
+        step_entropy_p90: Optional[float] = None
 
         if getattr(args, "ko_metric_induced", False):
             # KO: 256-way classification; no mask token
@@ -822,12 +827,63 @@ def train_one_epoch(
                 path_probs = path_probs.clamp_min(1e-12)
                 per_site_entropy = -(path_probs * path_probs.log()).sum(dim=-1)
                 target_entropy = per_site_entropy.mean(dim=1)
+                entropy_metric.update(target_entropy.mean())
+                entropy_detached = target_entropy.detach()
+                if entropy_detached.numel() > 0:
+                    entropy_cpu = entropy_detached.to(device="cpu")
+                    entropy_samples.append(entropy_cpu)
+                    step_entropy_mean = float(entropy_cpu.mean().item())
+                    step_entropy_median = float(torch.quantile(entropy_cpu, 0.5).item())
+                    step_entropy_p90 = float(torch.quantile(entropy_cpu, 0.9).item())
             per_sample_loss = token_loss.view(samples.shape[0], -1).mean(dim=1)
             uw_loss = per_sample_loss.mean().item()
             loss = _importance_weighted_mean(per_sample_loss, logbeta_weights)
 
             if logbeta_reg_penalty is not None:
                 loss = loss + logbeta_reg_penalty
+
+            # KL trust region to baseline geometry for LUT (teacher = baseline distances)
+            lut_kl_weight = float(getattr(args, "mi_lut_kl_weight", 0.0) or 0.0)
+            if (
+                lut_kl_weight > 0.0
+                and isinstance(path, MetricInducedGibbsProbPath)
+                and getattr(path, "learnable_lut", None) is not None
+            ):
+                # Optionally restrict to a t-band
+                t_lo = getattr(args, "mi_lut_kl_t_lo", None)
+                t_hi = getattr(args, "mi_lut_kl_t_hi", None)
+                apply_mask = None
+                if t_lo is not None and t_hi is not None:
+                    t_lo_f = float(t_lo)
+                    t_hi_f = float(t_hi)
+                    apply_mask = (t >= t_lo_f) & (t <= t_hi_f)
+
+                # Build baseline table once per step and gather rows for x1
+                base_table = path._get_base_distance_table(
+                    device=path.embedding.weight.device,
+                    dtype=path.embedding.weight.dtype,
+                )
+                # Gather baseline distances rows for tokens
+                B = x1_flat.shape[0]
+                S = x1_flat.shape[1]
+                K = path.vocab_size
+                base_rows = base_table.index_select(0, x1_flat.view(-1)).view(B, S, K)
+                # Compute teacher probs from baseline with the same beta(t)
+                beta_t, _ = path.beta(t)
+                beta_t = beta_t.view(B, 1, 1).to(device=base_rows.device, dtype=base_rows.dtype)
+                logits_base = -beta_t * base_rows
+                logits_base = logits_base - logits_base.max(dim=-1, keepdim=True).values
+                teacher_probs = torch.softmax(logits_base, dim=-1).to(device=path_probs.device, dtype=path_probs.dtype)
+
+                # Student probs are current path_probs (already clamped)
+                student_probs = path_probs.clamp_min(1e-12)
+                teacher_probs = teacher_probs.clamp_min(1e-12).detach()  # no grad through teacher
+                kl_tensor = (teacher_probs * (torch.log(teacher_probs) - torch.log(student_probs))).sum(dim=-1)
+                if apply_mask is not None:
+                    # Zero out KL where mask is false
+                    kl_tensor = torch.where(apply_mask.view(-1, 1), kl_tensor, torch.zeros_like(kl_tensor))
+                lut_kl_value = _importance_weighted_mean(kl_tensor, logbeta_weights)
+                loss = loss + lut_kl_weight * lut_kl_value
 
             # Bounded residual scale penalty (L2 on scale parameter c)
             scale_penalty: Optional[torch.Tensor] = None
@@ -1050,6 +1106,10 @@ def train_one_epoch(
         # Loss scaler applies the optimizer when update_grad is set to true.
         # Otherwise just updates the internal gradient scales
         apply_update = (data_iter_step + 1) % accum_iter == 0
+        metric_grad_norm_value = None
+        lut_grad_norm_value = None
+        lut_param_delta = None
+
         grad_norm = loss_scaler(
             loss,
             optimizer,
@@ -1068,7 +1128,6 @@ def train_one_epoch(
                 grad_step_skipped = not math.isfinite(float(grad_norm))
             
             # Compute gradient norms before clipping for logging
-            metric_grad_norm_value = None
             if hasattr(path, "learnable_metric") and path.learnable_metric is not None:
                 # Compute metric gradient norm BEFORE clipping
                 metric_params = list(path.learnable_metric.parameters())
@@ -1080,8 +1139,6 @@ def train_one_epoch(
                     torch.nn.utils.clip_grad_norm_(metric_params, max_norm=1.0)
             
             # LUT gradient diagnostics
-            lut_grad_norm_value = None
-            lut_param_delta = None
             if hasattr(path, "learnable_lut") and path.learnable_lut is not None:
                 lut_params = list(path.learnable_lut.parameters())
                 if lut_params and lut_params[0].grad is not None:
@@ -1210,6 +1267,9 @@ def train_one_epoch(
         if data_iter_step % PRINT_FREQUENCY == 0:
             # Console log
             dl_len_str = str(_dl_len) if _dl_len is not None else "?"
+            tau_progress = None
+            if gumbel_schedule_active and gumbel_tau_steps > 0:
+                tau_progress = min(gumbel_update_step, gumbel_tau_steps) / float(gumbel_tau_steps)
             log_msg = (
                 f"Epoch {epoch} [{data_iter_step}/{dl_len_str}]: loss = {batch_loss.compute()}, lr = {lr}"
             )
@@ -1222,8 +1282,14 @@ def train_one_epoch(
                     log_msg += f", kl_avg = {float(kl_avg_for_logging):.4g}"
             if gumbel_schedule_active and current_gumbel_tau is not None:
                 log_msg += f", tau = {float(current_gumbel_tau):.4g}"
+                if tau_progress is not None:
+                    log_msg += f" (prog={tau_progress:.2%})"
             if metric_interp_active and current_metric_interp is not None:
                 log_msg += f", lambda = {float(current_metric_interp):.4g}"
+            if step_entropy_mean is not None:
+                log_msg += f", H={step_entropy_mean:.3f}"
+                if step_entropy_median is not None:
+                    log_msg += f" (p50={step_entropy_median:.3f})"
             
             # Add LUT diagnostics to log message
             if lut_grad_norm_value is not None:
@@ -1281,13 +1347,32 @@ def train_one_epoch(
                             lut_diagnostics["lut/weight_std"] = float(lut_weight.std().cpu())
                             lut_diagnostics["lut/weight_min"] = float(lut_weight.min().cpu())
                             lut_diagnostics["lut/weight_max"] = float(lut_weight.max().cpu())
+                            lut_diagnostics["lut/weight_abs_max"] = float(lut_weight.abs().max().cpu())
                             # Per-channel std
                             for ch_idx in range(lut_weight.shape[0]):
                                 lut_diagnostics[f"lut/ch{ch_idx}_std"] = float(lut_weight[ch_idx].std().cpu())
+                            # Per-channel Frobenius norms
+                            lut_flat = lut_weight.view(lut_weight.shape[0], -1)
+                            channel_fro = torch.linalg.vector_norm(lut_flat, ord=2, dim=1)
+                            lut_diagnostics["lut/fro_norm_mean"] = float(channel_fro.mean().cpu())
+                            for ch_idx, fro_val in enumerate(channel_fro):
+                                lut_diagnostics[f"lut/ch{ch_idx}_fro_norm"] = float(fro_val.cpu())
+                            base_norm = getattr(path.learnable_lut, "_base_fro_norm_per_channel", None)
+                            if base_norm is not None:
+                                base_norm = base_norm.to(device=lut_weight.device, dtype=lut_weight.dtype)
+                                ratio = channel_fro / base_norm.clamp_min(1e-12)
+                                lut_diagnostics["lut/fro_ratio_mean"] = float(ratio.mean().cpu())
+                                for ch_idx, ratio_val in enumerate(ratio):
+                                    lut_diagnostics[f"lut/ch{ch_idx}_fro_ratio"] = float(ratio_val.cpu())
+                        if hasattr(path.learnable_lut, "scale_c") and path.learnable_lut.scale_c is not None:
+                            scale_c_cpu = path.learnable_lut.scale_c.detach().cpu()
+                            lut_diagnostics["lut/scale_c_mean"] = float(scale_c_cpu.mean().item())
+                            lut_diagnostics["lut/scale_c_std"] = float(scale_c_cpu.std().item())
                         if lut_grad_norm_value is not None:
                             lut_diagnostics["lut/grad_norm"] = float(
-                                lut_grad_norm_value.cpu() if isinstance(lut_grad_norm_value, torch.Tensor) 
-                                else lut_grad_norm_value
+                                lut_grad_norm_value.detach().cpu().item()
+                                if isinstance(lut_grad_norm_value, torch.Tensor)
+                                else float(lut_grad_norm_value)
                             )
                         if lut_param_delta is not None:
                             lut_diagnostics["lut/param_delta"] = float(lut_param_delta)
@@ -1339,6 +1424,22 @@ def train_one_epoch(
                             ),
                             **(
                                 {
+                                    "train/gumbel_tau_progress": float(tau_progress)
+                                }
+                                if tau_progress is not None
+                                else {}
+                            ),
+                            **(
+                                {
+                                    "train/entropy_mean": float(step_entropy_mean),
+                                    "train/entropy_median": float(step_entropy_median),
+                                    "train/entropy_p90": float(step_entropy_p90),
+                                }
+                                if step_entropy_mean is not None
+                                else {}
+                            ),
+                            **(
+                                {
                                     "train/metric_interp_lambda": float(
                                         current_metric_interp
                                     )
@@ -1380,6 +1481,21 @@ def train_one_epoch(
     setattr(args, "_mi_logbeta_reg_step", logbeta_reg_update_step)
     lr_schedule.step()
     stats = {"loss": float(epoch_loss.compute().detach().cpu())}
+    if entropy_samples:
+        try:
+            entropy_epoch_tensor = torch.cat(entropy_samples)
+            stats.update(
+                {
+                    "entropy/mean": float(entropy_epoch_tensor.mean().item()),
+                    "entropy/std": float(entropy_epoch_tensor.std(unbiased=False).item()),
+                    "entropy/p25": float(torch.quantile(entropy_epoch_tensor, 0.25).item()),
+                    "entropy/p50": float(torch.quantile(entropy_epoch_tensor, 0.5).item()),
+                    "entropy/p90": float(torch.quantile(entropy_epoch_tensor, 0.9).item()),
+                    "entropy/batch_mean": float(entropy_metric.compute().detach().cpu()),
+                }
+            )
+        except Exception:
+            pass
     if use_path_trust_region and kl_updates_total > 0 and kl_metric and kl_penalty_metric:
         stats.update(
             {
@@ -1394,6 +1510,10 @@ def train_one_epoch(
         setattr(args, "_gumbel_update_step", gumbel_update_step)
         if current_gumbel_tau is not None:
             stats["gumbel_tau"] = float(current_gumbel_tau)
+        if gumbel_tau_steps > 0:
+            stats["gumbel_tau_progress"] = float(
+                min(gumbel_update_step, gumbel_tau_steps) / float(gumbel_tau_steps)
+            )
     if metric_interp_active:
         setattr(args, "_metric_interp_update_step", metric_interp_update_step)
         if current_metric_interp is not None:

--- a/examples/image/training/train_loop.py
+++ b/examples/image/training/train_loop.py
@@ -333,6 +333,7 @@ def train_one_epoch(
             # KO: 256-way classification; no mask token
             samples = (samples * 255.0).to(torch.long)
             logbeta_weights: Optional[torch.Tensor] = None
+            mis_uniform_frac: Optional[float] = None
             schedule = getattr(path, "beta_schedule", None)
             lmin = getattr(args, "mi_logbeta_min", None)
             lmax = getattr(args, "mi_logbeta_max", None)
@@ -352,14 +353,22 @@ def train_one_epoch(
                     setattr(args, "_mi_logbeta_interval_warned", True)
                 use_logbeta_sampling = False
 
+            mix_alpha_raw = float(getattr(args, "mi_logbeta_mis_alpha", 0.0))
+            mix_alpha = float(min(max(mix_alpha_raw, 0.0), 1.0))
+
             if use_logbeta_sampling:
-                t_samples, weights = schedule.sample_t_uniform_logbeta(
-                    batch_shape=(samples.shape[0],),
+                batch_size = samples.shape[0]
+                # Draw proposals from both distributions (log-β and uniform) and mix via MIS.
+                t_logbeta, _ = schedule.sample_t_uniform_logbeta(
+                    batch_shape=(batch_size,),
                     lmin=float(lmin),
                     lmax=float(lmax),
                 )
-                t = t_samples.to(device=device)
-                logbeta_weights = weights.to(device=device, dtype=torch.float32)
+                t_logbeta = t_logbeta.to(device=device)
+                t_uniform = torch.rand(batch_size, device=device)
+                selector = torch.rand(batch_size, device=device) < mix_alpha
+                t = torch.where(selector, t_uniform, t_logbeta)
+
                 if not getattr(args, "_mi_logbeta_sampling_announced", False):
                     logger.info(
                         "Using uniform log-β sampling with interval [%.4f, %.4f]",
@@ -367,6 +376,23 @@ def train_one_epoch(
                         float(lmax),
                     )
                     setattr(args, "_mi_logbeta_sampling_announced", True)
+                if 0.0 < mix_alpha < 1.0 and not getattr(args, "_mi_logbeta_mis_announced", False):
+                    logger.info(
+                        "Using MIS with α=%.3f (uniform-t) and %.3f (log-β proposal)",
+                        mix_alpha,
+                        1.0 - mix_alpha,
+                    )
+                    setattr(args, "_mi_logbeta_mis_announced", True)
+
+                interval = max(float(lmax) - float(lmin), 1e-6)
+                t_for_schedule = t.to(device=t_logbeta.device, dtype=t_logbeta.dtype)
+                beta_vals, beta_deriv = schedule.beta_and_derivative(t_for_schedule)
+                beta_vals = beta_vals.clamp_min(1e-12)
+                q_logbeta = (beta_deriv / beta_vals).clamp_min(1e-12) / interval
+                q_logbeta = q_logbeta.to(device=device, dtype=torch.float32)
+                q_mix = mix_alpha + (1.0 - mix_alpha) * q_logbeta
+                logbeta_weights = (1.0 / q_mix.clamp_min(1e-12)).to(device=device)
+                mis_uniform_frac = float(selector.float().mean().detach().cpu().item())
             else:
                 t = torch.rand(samples.shape[0], device=device)
 
@@ -457,6 +483,8 @@ def train_one_epoch(
                     w = logbeta_weights.detach()
                     ess_num = (w.sum() ** 2) / (w.square().sum() + 1e-12)
                     wandb_log_data["diag/ess_frac"] = float((ess_num / (w.numel() + 1e-12)).item())
+                if mis_uniform_frac is not None:
+                    wandb_log_data["diag/mis_uniform_frac"] = mis_uniform_frac
 
                 if data_iter_step % (PRINT_FREQUENCY * 2) == 0:
                     max_points = int(getattr(args, "wandb_entropy_max_points", 4096) or 4096)

--- a/examples/image/training/train_loop.py
+++ b/examples/image/training/train_loop.py
@@ -53,6 +53,20 @@ def _autocast(dtype: Optional[torch.dtype] = None):  # type: ignore[name-defined
         return torch.cuda.amp.autocast(dtype=dtype)
 
 
+def _importance_weighted_mean(
+    values: torch.Tensor, weights: Optional[torch.Tensor]
+) -> torch.Tensor:
+    """Return the mean of ``values`` with optional importance weights."""
+
+    if weights is None:
+        return values.mean()
+
+    weight_tensor = weights.to(device=values.device, dtype=values.dtype)
+    while weight_tensor.dim() < values.dim():
+        weight_tensor = weight_tensor.unsqueeze(-1)
+    return (values * weight_tensor).mean()
+
+
 def skewed_timestep_sample(num_samples: int, device: torch.device) -> torch.Tensor:
     P_mean = -1.2
     P_std = 1.2
@@ -375,14 +389,7 @@ def train_one_epoch(
                 logits_flat, targets_flat, reduction="none"
             )
             per_sample_loss = token_loss.view(samples.shape[0], -1).mean(dim=1)
-            if logbeta_weights is None:
-                weighted_loss = per_sample_loss
-            else:
-                logbeta_weights = logbeta_weights.to(
-                    device=per_sample_loss.device, dtype=per_sample_loss.dtype
-                )
-                weighted_loss = per_sample_loss * logbeta_weights
-            loss = weighted_loss.mean()
+            loss = _importance_weighted_mean(per_sample_loss, logbeta_weights)
 
             if use_path_trust_region:
                 x1_flat = samples.view(samples.shape[0], -1)
@@ -407,10 +414,9 @@ def train_one_epoch(
                     teacher_probs
                     * (torch.log(teacher_probs) - torch.log(student_probs))
                 ).sum(dim=-1)
-                if logbeta_weights is not None:
-                    schedule_kl_value = (kl_tensor * logbeta_weights).mean()
-                else:
-                    schedule_kl_value = kl_tensor.mean()
+                schedule_kl_value = _importance_weighted_mean(
+                    kl_tensor, logbeta_weights
+                )
                 schedule_kl_penalty = kl_controller.compute_penalty(schedule_kl_value)
                 loss = loss + schedule_kl_penalty
                 kl_metric.update(schedule_kl_value.detach())

--- a/flow_matching/path/beta_schedules.py
+++ b/flow_matching/path/beta_schedules.py
@@ -52,7 +52,7 @@ def _rational_quadratic_spline(
     outputs_flat = torch.empty_like(inputs_flat)
 
     cumwidths = torch.cumsum(widths, dim=-1)
-    cumheights = torch.cumsum(heights, dim=-1)
+    cumheights = torch
 
     cumwidths = F.pad(cumwidths, (1, 0), value=0.0)
     cumheights = F.pad(cumheights, (1, 0), value=0.0)
@@ -400,6 +400,39 @@ class ExpMonotoneRQSSchedule(BetaSchedule):
             _inv_softplus(torch.tensor(float(a), dtype=dtype, device=device))
         )
 
+    def _ell_and_derivative(self, t: Tensor) -> Tuple[Tensor, Tensor]:
+        cfg = self.config
+        t_clamped = t.clamp(min=cfg.t_eps, max=1.0 - cfg.t_eps)
+        s = torch.logit(t_clamped, eps=cfg.logit_eps)
+        r_s, dr_ds = self.rqs(s)
+        a = self.a
+        ell = self.y0 + a * r_s
+        denom = (t_clamped * (1.0 - t_clamped)).clamp_min(1e-8)
+        dell_dt = (a * dr_ds) / denom
+        return ell.view_as(t_clamped), dell_dt.view_as(t_clamped)
+
+    def ell_from_t(self, t: Tensor) -> Tensor:
+        ell, _ = self._ell_and_derivative(t)
+        return ell
+
+    def dtdell(self, t: Tensor) -> Tensor:
+        _, dell_dt = self._ell_and_derivative(t)
+        return dell_dt.reciprocal()
+
+    @torch.no_grad()
+    def t_from_ell(self, ell: Tensor) -> Tuple[Tensor, Tensor]:
+        dtype = self.y0.dtype
+        device = self.y0.device
+        ell = ell.to(device=device, dtype=dtype)
+        a = self.a
+        y = (ell - self.y0) / a
+        s, dr_ds = self.rqs.inverse(y)
+        t = torch.sigmoid(s)
+        t = t.clamp_(self.config.t_eps, 1.0 - self.config.t_eps)
+        denom = (a * dr_ds).clamp_min(1e-8)
+        dt_dell = (t * (1.0 - t)) / denom
+        return t, dt_dell
+
     @torch.no_grad()
     def sample_t_uniform_logbeta(
         self, batch_shape, lmin: float, lmax: float
@@ -423,17 +456,9 @@ class ExpMonotoneRQSSchedule(BetaSchedule):
         dtype = self.y0.dtype
         device = self.y0.device
         ell = torch.empty(batch_shape, dtype=dtype, device=device).uniform_(lmin, lmax)
-
         interval = max(lmax - lmin, float(torch.finfo(dtype).eps))
-
-        a = self.a
-        y = (ell - self.y0) / a
-        s, dr_ds = self.rqs.inverse(y)
-        t = torch.sigmoid(s)
-        t = t.clamp_(self.config.t_eps, 1.0 - self.config.t_eps)
-
-        denom = (a * dr_ds).clamp_min(1e-6)
-        weight = interval * (t * (1.0 - t)) / denom
+        t, dt_dell = self.t_from_ell(ell)
+        weight = interval * dt_dell
         return t, weight
 
     def beta_and_derivative(self, t: Tensor) -> Tuple[Tensor, Tensor]:

--- a/flow_matching/path/beta_schedules.py
+++ b/flow_matching/path/beta_schedules.py
@@ -400,6 +400,40 @@ class ExpMonotoneRQSSchedule(BetaSchedule):
             _inv_softplus(torch.tensor(float(a), dtype=dtype, device=device))
         )
 
+    @torch.no_grad()
+    def sample_t_uniform_logbeta(
+        self, batch_shape, lmin: float, lmax: float
+    ) -> Tuple[Tensor, Tensor]:
+        """Sample ``log beta`` uniformly, invert to ``t``, and return ``(t, dt/dℓ)``.
+
+        Args:
+            batch_shape: Shape of the samples to draw (same semantics as ``torch.empty``).
+            lmin: Lower bound of the uniform distribution over ``log beta``.
+            lmax: Upper bound of the uniform distribution over ``log beta``.
+
+        Returns:
+            A tuple ``(t, weight)`` where ``t`` are the recovered time values and
+            ``weight`` is the Jacobian ``dt/dℓ`` that preserves expectations when
+            importance-sampling with uniform ``log beta`` draws.
+        """
+
+        if lmax < lmin:
+            raise ValueError("lmax must be >= lmin")
+
+        dtype = self.y0.dtype
+        device = self.y0.device
+        ell = torch.empty(batch_shape, dtype=dtype, device=device).uniform_(lmin, lmax)
+
+        a = self.a
+        y = (ell - self.y0) / a
+        s, dr_ds = self.rqs.inverse(y)
+        t = torch.sigmoid(s)
+        t = t.clamp_(self.config.t_eps, 1.0 - self.config.t_eps)
+
+        denom = (a * dr_ds).clamp_min(1e-6)
+        weight = (t * (1.0 - t)) / denom
+        return t, weight
+
     def beta_and_derivative(self, t: Tensor) -> Tuple[Tensor, Tensor]:
         cfg = self.config
         t_clamped = t.clamp(min=cfg.t_eps, max=1.0 - cfg.t_eps)

--- a/flow_matching/path/beta_schedules.py
+++ b/flow_matching/path/beta_schedules.py
@@ -270,17 +270,29 @@ class _ExpRQS1D(nn.Module):
             t2 = slope + (d1 + d0 - 2.0 * slope) * xi * (1.0 - xi)
             outputs_mid = y0 + h * (t1 / (t2 + eps_val))
 
-            numerator = (
-                d1 * xi * xi
-                + 2.0 * slope * xi * (1.0 - xi)
-                + d0 * (1.0 - xi) * (1.0 - xi)
-            )
-            derivatives_mid = (h / (w + eps_val)) * (slope * slope) * numerator / (
-                (t2 + eps_val) ** 2
+            # Analytical derivative of the monotone RQS (matches finite differences)
+            delta_val = slope
+            coeff = d0 + d1 - 2.0 * delta_val
+            B_val = delta_val + coeff * xi * (1.0 - xi)
+            A_val = delta_val * xi * xi + d0 * xi * (1.0 - xi)
+            dA_dxi = 2.0 * delta_val * xi + d0 * (1.0 - 2.0 * xi)
+            dB_dxi = coeff * (1.0 - 2.0 * xi)
+            derivatives_mid = delta_val * (dA_dxi * B_val - A_val * dB_dxi) / (
+                (B_val + eps_val) ** 2
             )
 
             outputs[center_mask] = outputs_mid
             derivatives[center_mask] = derivatives_mid
+
+        if left_mask.any():
+            slope = delta[0]
+            outputs[left_mask] = -B + (flat_inputs[left_mask] + B) * slope
+            derivatives[left_mask] = slope
+
+        if right_mask.any():
+            slope = delta[-1]
+            outputs[right_mask] = B + (flat_inputs[right_mask] - B) * slope
+            derivatives[right_mask] = slope
 
         return outputs.view_as(inputs), derivatives.view_as(inputs)
 
@@ -457,9 +469,29 @@ class ExpMonotoneRQSSchedule(BetaSchedule):
         t_hi: float | None = None,
         power: float = 0.0,
     ) -> dict[str, Tensor]:
+        """Compute smoothness penalties using ANALYTICAL derivatives from RQS.
+        
+        Key features:
+        1. Uses exact dℓ/ds = a * dr/ds from RQS.forward() (not finite differences)
+        2. NORMALIZED penalties using Coefficient of Variation (CV = std/mean)
+        3. Second derivative: finite difference of exact first derivatives
+        
+        Normalization strategy (CV-based):
+        - delta: CV² of first derivatives → penalizes relative variability
+        - delta2: CV² of second derivatives → penalizes relative curvature changes
+        - endpoint: normalized by interior scale → detects boundary anomalies
+        
+        Why CV is scale-invariant:
+        - CV = std/mean is dimensionless (scale-free)
+        - β(t) ×10 → std ×10, mean ×10 → CV unchanged
+        - Penalties ∈ [0, ∞) with typical values ~ 0.01-1.0
+        - Automatically adapts to any β magnitude
+        """
         dtype = self.y0.dtype
         device = self.y0.device
         zero = torch.zeros((), dtype=dtype, device=device)
+        eps = 1e-8  # Numerical stability
+        cv_min_abs_mean = 1e-3  # Huber-like saturation: clamp |mean| to prevent CV² explosion
 
         xk, yk, _ = self.rqs._knot_tensors(dtype=dtype, device=device)
         if xk.numel() < 2:
@@ -475,34 +507,60 @@ class ExpMonotoneRQSSchedule(BetaSchedule):
         t_lo_tensor = torch.tensor(lo_val, dtype=dtype, device=device)
         t_hi_tensor = torch.tensor(hi_val, dtype=dtype, device=device)
 
+        # Map knot positions to t-space for masking
         t_knots = torch.sigmoid(xk)
         t_knots = t_knots.clamp(cfg.t_eps, 1.0 - cfg.t_eps)
-        ell_knots = self.y0 + self.a * yk
+        
+        # ========== ANALYTICAL DERIVATIVE COMPUTATION ==========
+        # Evaluate RQS at knot positions to get exact dr/ds
+        r_knots, dr_ds_knots = self.rqs(xk)  # Analytical derivatives!
+        a = self.a
+        ell_knots = self.y0 + a * r_knots
+        dell_ds_knots = a * dr_ds_knots  # Exact dℓ/ds = a * dr/ds
+        # ========================================================
 
-        delta_s = xk[1:] - xk[:-1]
-        delta_s = delta_s.clamp_min(1e-6)
-        delta_ell = ell_knots[1:] - ell_knots[:-1]
-        first_slopes = delta_ell / delta_s
+        # ========== FIRST-ORDER PENALTY (NORMALIZED) ==========
+        # Use midpoints between knots for interval masking
         centers = 0.5 * (t_knots[1:] + t_knots[:-1])
         interval_mask = (centers >= t_lo_tensor) & (centers <= t_hi_tensor)
         weights = torch.ones_like(centers)
         if power != 0.0:
             weights = torch.pow((centers * (1.0 - centers)).clamp_min(1e-6), power)
 
+        # Average first derivatives at interval endpoints
+        first_slopes = 0.5 * (dell_ds_knots[1:] + dell_ds_knots[:-1])
+        
         if interval_mask.any():
             weighted = weights[interval_mask]
             slopes = first_slopes[interval_mask]
-            denom = weighted.sum().clamp_min(1.0)
-            first_penalty = (weighted * slopes.square()).sum() / denom
+            
+            # NORMALIZED: Coefficient of Variation (CV) penalty
+            # CV = std/mean measures relative variability (scale-invariant)
+            # Penalizing CV² encourages smoothness regardless of magnitude
+            # Huber-like saturation: clamp |mean| to prevent explosion when mean ≈ 0
+            if slopes.numel() > 1:
+                slopes_mean_raw = slopes.mean().detach()
+                slopes_mean = torch.clamp(torch.abs(slopes_mean_raw), min=cv_min_abs_mean)  # Saturate denominator
+                slopes_std = torch.std(slopes, unbiased=False).detach() + eps
+                cv = slopes_std / slopes_mean  # Coefficient of variation with bounded denominator
+                first_penalty = cv.square()  # Penalize relative variability
+            else:
+                # Single sample: no variability to penalize
+                first_penalty = zero
         else:
             first_penalty = zero
 
-        if first_slopes.numel() >= 2:
-            h_prev = delta_s[:-1]
-            h_next = delta_s[1:]
-            diff_slopes = first_slopes[1:] - first_slopes[:-1]
-            denom = (h_prev + h_next).clamp_min(1e-6)
-            second_est = 2.0 * diff_slopes / denom
+        # ========== SECOND-ORDER PENALTY (NORMALIZED) ==========
+        # Finite difference of EXACT first derivatives
+        if dell_ds_knots.numel() >= 2:
+            delta_s = xk[1:] - xk[:-1]
+            delta_s = delta_s.clamp_min(1e-6)
+            
+            # Finite difference on analytical first derivatives
+            delta_dell_ds = dell_ds_knots[1:] - dell_ds_knots[:-1]
+            second_est = delta_dell_ds / delta_s  # Approximate d²ℓ/ds²
+            
+            # Mask to interior knots
             interior_t = t_knots[1:-1]
             interior_mask = (interior_t >= t_lo_tensor) & (interior_t <= t_hi_tensor)
             interior_weights = torch.ones_like(interior_t)
@@ -510,20 +568,55 @@ class ExpMonotoneRQSSchedule(BetaSchedule):
                 interior_weights = torch.pow(
                     (interior_t * (1.0 - interior_t)).clamp_min(1e-6), power
                 )
-            if interior_mask.any():
+            
+            # Trim second_est to match interior knots (exclude boundaries)
+            if second_est.numel() > interior_t.numel():
+                start_idx = 0
+                end_idx = interior_t.numel()
+                second_est_interior = second_est[start_idx:end_idx]
+            else:
+                second_est_interior = second_est
+                
+            if interior_mask.any() and second_est_interior.numel() == interior_mask.numel():
                 w2 = interior_weights[interior_mask]
-                s2 = second_est[interior_mask]
-                denom2 = w2.sum().clamp_min(1.0)
-                second_penalty = (w2 * s2.square()).sum() / denom2
+                s2 = second_est_interior[interior_mask]
+                
+                # NORMALIZED: Coefficient of Variation (CV) penalty
+                # CV = std/mean measures relative variability (scale-invariant)
+                # Huber-like saturation: clamp |mean| to prevent explosion when mean ≈ 0
+                if s2.numel() > 1:
+                    s2_mean_raw = s2.mean().detach()
+                    s2_mean = torch.clamp(torch.abs(s2_mean_raw), min=cv_min_abs_mean)  # Saturate denominator
+                    s2_std = torch.std(s2, unbiased=False).detach() + eps
+                    cv2 = s2_std / s2_mean  # Coefficient of variation with bounded denominator
+                    second_penalty = cv2.square()  # Penalize relative variability
+                else:
+                    # Single sample: no variability to penalize
+                    second_penalty = zero
             else:
                 second_penalty = zero
         else:
             second_penalty = zero
 
-        if first_slopes.numel() >= 1:
-            endpoint_penalty = 0.5 * (
-                first_slopes[0].square() + first_slopes[-1].square()
-            )
+        # ========== ENDPOINT PENALTY (NORMALIZED) ==========
+        # Penalize steep slopes at boundaries, normalized by interior scale
+        if dell_ds_knots.numel() >= 3:
+            # Use interior slopes (exclude endpoints) for scale reference
+            interior_slopes = dell_ds_knots[1:-1]
+            interior_scale = torch.abs(interior_slopes.mean()).detach() + eps
+            
+            # Normalized endpoint slopes (relative to interior)
+            endpoint_left = dell_ds_knots[0] / interior_scale
+            endpoint_right = dell_ds_knots[-1] / interior_scale
+            
+            # Penalize if endpoints deviate from interior scale
+            endpoint_penalty = 0.5 * (endpoint_left.square() + endpoint_right.square())
+        elif dell_ds_knots.numel() >= 1:
+            # Too few knots: use absolute value normalization
+            all_scale = torch.abs(dell_ds_knots.mean()).detach() + eps
+            endpoint_left = dell_ds_knots[0] / all_scale
+            endpoint_right = dell_ds_knots[-1] / all_scale
+            endpoint_penalty = 0.5 * (endpoint_left.square() + endpoint_right.square())
         else:
             endpoint_penalty = zero
 

--- a/flow_matching/path/beta_schedules.py
+++ b/flow_matching/path/beta_schedules.py
@@ -52,7 +52,7 @@ def _rational_quadratic_spline(
     outputs_flat = torch.empty_like(inputs_flat)
 
     cumwidths = torch.cumsum(widths, dim=-1)
-    cumheights = torch
+    cumheights = torch.cumsum(heights, dim=-1)
 
     cumwidths = F.pad(cumwidths, (1, 0), value=0.0)
     cumheights = F.pad(cumheights, (1, 0), value=0.0)
@@ -208,15 +208,13 @@ class _ExpRQS1D(nn.Module):
                 target = torch.tensor(1.0)
                 self.theta_d.copy_(_inv_softplus(target).expand_as(self.theta_d))
 
-    def forward(self, inputs: Tensor) -> Tuple[Tensor, Tensor]:
-        device = inputs.device
-        dtype = inputs.dtype
+    def _knot_tensors(
+        self, *, dtype: torch.dtype, device: torch.device
+    ) -> tuple[Tensor, Tensor, Tensor]:
         B = self.tail_bound
-
         widths = F.softmax(self.theta_w, dim=0) * (2.0 * B)
         heights = F.softmax(self.theta_h, dim=0) * (2.0 * B)
         eps = torch.finfo(widths.dtype).eps
-        eps_val = torch.finfo(dtype).eps
         internal = F.softplus(self.theta_d) + eps
 
         cumsum_widths = torch.cumsum(widths, dim=0)
@@ -233,6 +231,15 @@ class _ExpRQS1D(nn.Module):
             delta = torch.cat((delta_left, delta_mid, delta_right))
         else:
             delta = torch.cat((delta_left, delta_right))
+        return xk, yk, delta
+
+    def forward(self, inputs: Tensor) -> Tuple[Tensor, Tensor]:
+        device = inputs.device
+        dtype = inputs.dtype
+        B = self.tail_bound
+        eps_val = torch.finfo(dtype).eps
+
+        xk, yk, delta = self._knot_tensors(dtype=dtype, device=device)
 
         flat_inputs = inputs.reshape(-1)
         outputs = flat_inputs.clone()
@@ -282,27 +289,9 @@ class _ExpRQS1D(nn.Module):
         device = outputs.device
         dtype = outputs.dtype
         B = self.tail_bound
-
-        widths = F.softmax(self.theta_w, dim=0) * (2.0 * B)
-        heights = F.softmax(self.theta_h, dim=0) * (2.0 * B)
-        eps = torch.finfo(widths.dtype).eps
         eps_val = torch.finfo(dtype).eps
-        internal = F.softplus(self.theta_d) + eps
 
-        cumsum_widths = torch.cumsum(widths, dim=0)
-        cumsum_heights = torch.cumsum(heights, dim=0)
-
-        left = torch.tensor([-B], device=device, dtype=dtype)
-        xk = torch.cat((left, (left + cumsum_widths).to(device=device, dtype=dtype)))
-        yk = torch.cat((left, (left + cumsum_heights).to(device=device, dtype=dtype)))
-
-        delta_left = torch.ones(1, device=device, dtype=dtype)
-        delta_right = torch.ones(1, device=device, dtype=dtype)
-        if self.num_bins > 1:
-            delta_mid = internal.to(device=device, dtype=dtype)
-            delta = torch.cat((delta_left, delta_mid, delta_right))
-        else:
-            delta = torch.cat((delta_left, delta_right))
+        xk, yk, delta = self._knot_tensors(dtype=dtype, device=device)
 
         flat_outputs = outputs.reshape(-1)
         s_flat = flat_outputs.clone()
@@ -460,6 +449,89 @@ class ExpMonotoneRQSSchedule(BetaSchedule):
         t, dt_dell = self.t_from_ell(ell)
         weight = interval * dt_dell
         return t, weight
+
+    def logbeta_regularization(
+        self,
+        *,
+        t_lo: float | None = None,
+        t_hi: float | None = None,
+        power: float = 0.0,
+    ) -> dict[str, Tensor]:
+        dtype = self.y0.dtype
+        device = self.y0.device
+        zero = torch.zeros((), dtype=dtype, device=device)
+
+        xk, yk, _ = self.rqs._knot_tensors(dtype=dtype, device=device)
+        if xk.numel() < 2:
+            return {"delta": zero, "delta2": zero, "endpoint": zero}
+
+        cfg = self.config
+        default_lo = float(cfg.t_eps)
+        default_hi = float(1.0 - cfg.t_eps)
+        lo_val = max(default_lo, float(t_lo) if t_lo is not None else default_lo)
+        hi_val = min(default_hi, float(t_hi) if t_hi is not None else default_hi)
+        if hi_val <= lo_val:
+            hi_val = lo_val + 1e-6
+        t_lo_tensor = torch.tensor(lo_val, dtype=dtype, device=device)
+        t_hi_tensor = torch.tensor(hi_val, dtype=dtype, device=device)
+
+        t_knots = torch.sigmoid(xk)
+        t_knots = t_knots.clamp(cfg.t_eps, 1.0 - cfg.t_eps)
+        ell_knots = self.y0 + self.a * yk
+
+        delta_s = xk[1:] - xk[:-1]
+        delta_s = delta_s.clamp_min(1e-6)
+        delta_ell = ell_knots[1:] - ell_knots[:-1]
+        first_slopes = delta_ell / delta_s
+        centers = 0.5 * (t_knots[1:] + t_knots[:-1])
+        interval_mask = (centers >= t_lo_tensor) & (centers <= t_hi_tensor)
+        weights = torch.ones_like(centers)
+        if power != 0.0:
+            weights = torch.pow((centers * (1.0 - centers)).clamp_min(1e-6), power)
+
+        if interval_mask.any():
+            weighted = weights[interval_mask]
+            slopes = first_slopes[interval_mask]
+            denom = weighted.sum().clamp_min(1.0)
+            first_penalty = (weighted * slopes.square()).sum() / denom
+        else:
+            first_penalty = zero
+
+        if first_slopes.numel() >= 2:
+            h_prev = delta_s[:-1]
+            h_next = delta_s[1:]
+            diff_slopes = first_slopes[1:] - first_slopes[:-1]
+            denom = (h_prev + h_next).clamp_min(1e-6)
+            second_est = 2.0 * diff_slopes / denom
+            interior_t = t_knots[1:-1]
+            interior_mask = (interior_t >= t_lo_tensor) & (interior_t <= t_hi_tensor)
+            interior_weights = torch.ones_like(interior_t)
+            if power != 0.0:
+                interior_weights = torch.pow(
+                    (interior_t * (1.0 - interior_t)).clamp_min(1e-6), power
+                )
+            if interior_mask.any():
+                w2 = interior_weights[interior_mask]
+                s2 = second_est[interior_mask]
+                denom2 = w2.sum().clamp_min(1.0)
+                second_penalty = (w2 * s2.square()).sum() / denom2
+            else:
+                second_penalty = zero
+        else:
+            second_penalty = zero
+
+        if first_slopes.numel() >= 1:
+            endpoint_penalty = 0.5 * (
+                first_slopes[0].square() + first_slopes[-1].square()
+            )
+        else:
+            endpoint_penalty = zero
+
+        return {
+            "delta": first_penalty,
+            "delta2": second_penalty,
+            "endpoint": endpoint_penalty,
+        }
 
     def beta_and_derivative(self, t: Tensor) -> Tuple[Tensor, Tensor]:
         cfg = self.config

--- a/flow_matching/path/beta_schedules.py
+++ b/flow_matching/path/beta_schedules.py
@@ -216,6 +216,7 @@ class _ExpRQS1D(nn.Module):
         widths = F.softmax(self.theta_w, dim=0) * (2.0 * B)
         heights = F.softmax(self.theta_h, dim=0) * (2.0 * B)
         eps = torch.finfo(widths.dtype).eps
+        eps_val = torch.finfo(dtype).eps
         internal = F.softplus(self.theta_d) + eps
 
         cumsum_widths = torch.cumsum(widths, dim=0)
@@ -275,6 +276,91 @@ class _ExpRQS1D(nn.Module):
             derivatives[center_mask] = derivatives_mid
 
         return outputs.view_as(inputs), derivatives.view_as(inputs)
+
+    @torch.no_grad()
+    def inverse(self, outputs: Tensor) -> Tuple[Tensor, Tensor]:
+        device = outputs.device
+        dtype = outputs.dtype
+        B = self.tail_bound
+
+        widths = F.softmax(self.theta_w, dim=0) * (2.0 * B)
+        heights = F.softmax(self.theta_h, dim=0) * (2.0 * B)
+        eps = torch.finfo(widths.dtype).eps
+        eps_val = torch.finfo(dtype).eps
+        internal = F.softplus(self.theta_d) + eps
+
+        cumsum_widths = torch.cumsum(widths, dim=0)
+        cumsum_heights = torch.cumsum(heights, dim=0)
+
+        left = torch.tensor([-B], device=device, dtype=dtype)
+        xk = torch.cat((left, (left + cumsum_widths).to(device=device, dtype=dtype)))
+        yk = torch.cat((left, (left + cumsum_heights).to(device=device, dtype=dtype)))
+
+        delta_left = torch.ones(1, device=device, dtype=dtype)
+        delta_right = torch.ones(1, device=device, dtype=dtype)
+        if self.num_bins > 1:
+            delta_mid = internal.to(device=device, dtype=dtype)
+            delta = torch.cat((delta_left, delta_mid, delta_right))
+        else:
+            delta = torch.cat((delta_left, delta_right))
+
+        flat_outputs = outputs.reshape(-1)
+        s_flat = flat_outputs.clone()
+
+        left_mask = flat_outputs <= -B
+        right_mask = flat_outputs >= B
+        center_mask = (~left_mask) & (~right_mask)
+
+        if center_mask.any():
+            y = flat_outputs[center_mask]
+            bin_idx = torch.bucketize(y, yk[1:])
+            bin_idx = bin_idx.clamp(min=0, max=self.num_bins - 1)
+
+            x0 = xk[bin_idx]
+            x1 = xk[bin_idx + 1]
+            y0 = yk[bin_idx]
+            y1 = yk[bin_idx + 1]
+            d0 = delta[bin_idx]
+            d1 = delta[bin_idx + 1]
+
+            w = x1 - x0
+            h = y1 - y0
+            slope = h / w
+            z = (y - y0) / h
+
+            coeff = d0 + d1 - 2.0 * slope
+            a = slope - d0 + z * coeff
+            b = d0 - z * coeff
+            c = -z * slope
+
+            discriminant = torch.clamp(b * b - 4.0 * a * c, min=0.0)
+            sqrt_disc = torch.sqrt(discriminant)
+
+            denom = 2.0 * a
+            # Handle near-linear bins by falling back to linear solution
+            linear_mask = torch.isclose(
+                denom, torch.zeros_like(denom), atol=1e-12, rtol=0.0
+            )
+
+            eps_denom = torch.full_like(denom, eps_val)
+            denom_safe = denom + torch.where(denom >= 0, eps_denom, -eps_denom)
+            xi_quad1 = (-b - sqrt_disc) / denom_safe
+            xi_quad2 = (-b + sqrt_disc) / denom_safe
+            xi_quad = torch.where(
+                (xi_quad1 >= 0.0) & (xi_quad1 <= 1.0), xi_quad1, xi_quad2
+            )
+            eps_b = torch.full_like(b, eps_val)
+            b_safe = b + torch.where(b >= 0, eps_b, -eps_b)
+            xi_linear = (-c) / b_safe
+            xi = torch.where(linear_mask, xi_linear, xi_quad)
+            xi = xi.clamp(0.0, 1.0)
+
+            s_center = x0 + w * xi
+            s_flat[center_mask] = s_center
+
+        s = s_flat.view_as(outputs)
+        _, derivatives = self.forward(s)
+        return s, derivatives
 
 
 class ExpMonotoneRQSSchedule(BetaSchedule):

--- a/flow_matching/path/beta_schedules.py
+++ b/flow_matching/path/beta_schedules.py
@@ -424,6 +424,8 @@ class ExpMonotoneRQSSchedule(BetaSchedule):
         device = self.y0.device
         ell = torch.empty(batch_shape, dtype=dtype, device=device).uniform_(lmin, lmax)
 
+        interval = max(lmax - lmin, float(torch.finfo(dtype).eps))
+
         a = self.a
         y = (ell - self.y0) / a
         s, dr_ds = self.rqs.inverse(y)
@@ -431,7 +433,7 @@ class ExpMonotoneRQSSchedule(BetaSchedule):
         t = t.clamp_(self.config.t_eps, 1.0 - self.config.t_eps)
 
         denom = (a * dr_ds).clamp_min(1e-6)
-        weight = (t * (1.0 - t)) / denom
+        weight = interval * (t * (1.0 - t)) / denom
         return t, weight
 
     def beta_and_derivative(self, t: Tensor) -> Tuple[Tensor, Tensor]:

--- a/flow_matching/path/lut_diagnostics.py
+++ b/flow_matching/path/lut_diagnostics.py
@@ -1,0 +1,699 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the CC-by-NC license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Diagnostic metrics for learnable per-channel LUT in metric-induced path.
+
+Implements the "lean-but-thorough" monitoring checklist:
+  1) LUT geometry (range, scale, monotonicity, drift)
+  2) Distance statistics (pairwise, β-scaled)
+  3) Path quality (entropy, support)
+  4) Sampling displacement (token space movement)
+  5) Training dynamics (grad norms, update sizes)
+  6) Cross-channel sanity (scale ratios, entropy gaps)
+  7) Snapshots for plotting
+  8) Alert thresholds
+
+Design: minimal overhead, no regularization, just observation.
+"""
+
+import logging
+from typing import Dict, List, Optional, Tuple
+
+import torch
+import torch.nn.functional as F
+from torch import Tensor
+from scipy.stats import spearmanr
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+
+class LUTDiagnostics:
+    """Diagnostic metrics for learnable scalar LUT.
+    
+    Tracks geometry, distances, path quality, and cross-channel behavior.
+    Designed for 1-D per-channel LUTs with linear initialization.
+    """
+
+    def __init__(
+        self,
+        num_channels: int = 3,
+        vocab_size: int = 256,
+        probe_times: Optional[List[float]] = None,
+        alert_thresholds: Optional[Dict[str, float]] = None,
+    ):
+        """Initialize diagnostics tracker.
+        
+        Args:
+            num_channels: Number of channels (e.g., 3 for RGB)
+            vocab_size: Vocabulary size (e.g., 256 for images)
+            probe_times: Times to compute path metrics (default: [0.2, 0.5, 0.8])
+            alert_thresholds: Custom alert thresholds (default: safe values)
+        """
+        self.num_channels = num_channels
+        self.vocab_size = vocab_size
+        self.probe_times = probe_times or [0.2, 0.5, 0.8]
+        
+        # Alert thresholds (conservative defaults)
+        self.alert_thresholds = alert_thresholds or {
+            "entropy_collapse": 1.0,      # H_0.5 < 1.0
+            "entropy_overflat": 5.3,      # H_0.5 > 5.3 (close to log(256))
+            "scale_blowup": 3.0,          # std > 3x init
+            "scale_collapse": 0.33,       # std < 1/3x init
+            "inversion_ratio": 0.06,      # > 6% positions inverted
+            "kl_drift": 0.5,              # KL > 0.5 at t=0.5
+        }
+        
+        # Storage for baseline (linear init) reference
+        self.baseline_embeddings: Optional[Tensor] = None
+        self.init_embeddings: Optional[Tensor] = None
+        self.init_std: Optional[Tensor] = None
+        
+        # Alert state tracking
+        self.alert_counts: Dict[str, int] = {k: 0 for k in self.alert_thresholds}
+
+    def register_baseline(self, embeddings: Tensor) -> None:
+        """Register initial/baseline embeddings for comparison.
+        
+        Args:
+            embeddings: [num_channels, vocab_size] tensor
+        """
+        self.baseline_embeddings = embeddings.detach().clone()
+        self.init_embeddings = embeddings.detach().clone()
+        self.init_std = embeddings.std(dim=1)  # [num_channels]
+        logger.info(
+            f"Registered baseline LUT: std_per_channel={self.init_std.cpu().numpy()}"
+        )
+
+    # =========================================================================
+    # 1) LUT Geometry
+    # =========================================================================
+
+    def compute_lut_geometry(
+        self, embeddings: Tensor, channel_names: Optional[List[str]] = None
+    ) -> Dict[str, Tensor]:
+        """Compute LUT geometry metrics per channel.
+        
+        Args:
+            embeddings: [num_channels, vocab_size] current LUT weights
+            channel_names: Optional names (e.g., ['R', 'G', 'B'])
+        
+        Returns:
+            Dictionary of metrics (all tensors on same device as embeddings)
+        """
+        C, V = embeddings.shape
+        if channel_names is None:
+            channel_names = [f"ch{c}" for c in range(C)]
+        
+        metrics = {}
+        
+        # Range & endpoints
+        metrics["min"] = embeddings.min(dim=1).values  # [C]
+        metrics["max"] = embeddings.max(dim=1).values
+        metrics["endpoint_0"] = embeddings[:, 0]       # [C]
+        metrics["endpoint_255"] = embeddings[:, -1]
+        
+        # Scale
+        metrics["std"] = embeddings.std(dim=1)         # [C]
+        diffs = embeddings[:, 1:] - embeddings[:, :-1]  # [C, V-1]
+        metrics["mean_abs_diff"] = diffs.abs().mean(dim=1)  # [C]
+        
+        # Monotonicity (inversion count)
+        inversions = (diffs < 0).sum(dim=1).float()    # [C]
+        metrics["inversion_count"] = inversions
+        metrics["inversion_ratio"] = inversions / (V - 1)
+        
+        # Smoothness (total variation, curvature)
+        metrics["total_variation"] = diffs.abs().sum(dim=1)  # [C]
+        if V >= 3:
+            second_diff = diffs[:, 1:] - diffs[:, :-1]   # [C, V-2]
+            metrics["curvature"] = second_diff.abs().sum(dim=1)
+        
+        # Drift from init (if registered)
+        if self.init_embeddings is not None:
+            delta = embeddings - self.init_embeddings
+            metrics["drift_from_init_l2"] = delta.norm(p=2, dim=1)  # [C]
+        
+        # Rank preservation (Spearman correlation)
+        spearman_corrs = []
+        for c in range(C):
+            emb_c = embeddings[c].detach().cpu().numpy()
+            vocab_idx = np.arange(V)
+            rho, _ = spearmanr(vocab_idx, emb_c)
+            spearman_corrs.append(rho)
+        metrics["spearman_rho"] = torch.tensor(
+            spearman_corrs, device=embeddings.device
+        )
+        
+        # Saturation (duplicate count)
+        duplicates = (diffs == 0).sum(dim=1).float()
+        metrics["duplicate_count"] = duplicates
+        
+        # NaN/Inf checks
+        metrics["has_nan"] = embeddings.isnan().any(dim=1)
+        metrics["has_inf"] = embeddings.isinf().any(dim=1)
+        
+        return metrics
+
+    # =========================================================================
+    # 2) Distance Statistics
+    # =========================================================================
+
+    def compute_distance_stats(
+        self,
+        embeddings: Tensor,
+        probe_batch: Tensor,
+        beta_values: Optional[Tensor] = None,
+    ) -> Dict[str, Tensor]:
+        """Compute pairwise distance statistics for probe batch.
+        
+        Args:
+            embeddings: [num_channels, vocab_size] LUT weights
+            probe_batch: [B, C, H, W] probe images (int64, values in [0, vocab_size))
+            beta_values: Optional [len(probe_times)] β(t) values to scale distances
+        
+        Returns:
+            Dictionary with distance stats per channel and time
+        """
+        C, V = embeddings.shape
+        B, C_img, H, W = probe_batch.shape
+        assert C == C_img, f"Channel mismatch: {C} vs {C_img}"
+        
+        metrics = {}
+        
+        # Compute all pairwise distances: |E[v] - E[x_1]| for all v, x_1
+        # [C, V, 1] - [C, 1, V] -> [C, V, V]
+        emb_i = embeddings.unsqueeze(2)  # [C, V, 1]
+        emb_j = embeddings.unsqueeze(1)  # [C, 1, V]
+        all_dists = (emb_i - emb_j).abs()  # [C, V, V]
+        
+        # For each pixel in probe_batch, get distances to all other tokens
+        probe_flat = probe_batch.view(B, C, -1)  # [B, C, HW]
+        N_pixels = probe_flat.shape[-1]
+        
+        # Sample subset to avoid memory blow-up
+        max_pixels = 1024
+        if N_pixels > max_pixels:
+            indices = torch.randperm(N_pixels, device=probe_flat.device)[:max_pixels]
+            probe_flat = probe_flat[:, :, indices]
+            N_pixels = max_pixels
+        
+        # Gather distances: for each (x_1), get distances to all vocab
+        # probe_flat: [B, C, N] with values in [0, V)
+        # all_dists: [C, V, V]
+        # Want: [B, C, N, V]
+        probe_expanded = probe_flat.unsqueeze(-1).expand(-1, -1, -1, V)  # [B, C, N, V]
+        
+        # Gather from all_dists using probe_flat as index
+        # For channel c, pixel with value x_1, get all_dists[c, x_1, :]
+        dists_per_pixel = []
+        for c in range(C):
+            # all_dists[c]: [V, V]
+            # probe_flat[:, c, :]: [B, N]
+            # Gather: [B, N, V]
+            d_c = all_dists[c][probe_flat[:, c, :].long()]  # [B, N, V]
+            dists_per_pixel.append(d_c)
+        
+        dists_per_pixel = torch.stack(dists_per_pixel, dim=1)  # [B, C, N, V]
+        
+        # Flatten to [B*C*N, V]
+        dists_flat = dists_per_pixel.reshape(-1, V)  # [B*C*N, V]
+        
+        # Compute statistics per channel
+        for c in range(C):
+            start_idx = c * B * N_pixels
+            end_idx = (c + 1) * B * N_pixels
+            d_c = dists_flat[start_idx:end_idx, :]  # [B*N, V]
+            
+            metrics[f"ch{c}_dist_min"] = d_c.min()
+            metrics[f"ch{c}_dist_mean"] = d_c.mean()
+            metrics[f"ch{c}_dist_std"] = d_c.std()
+            metrics[f"ch{c}_dist_max"] = d_c.max()
+            
+            # Quantiles (10%, 50%, 90%, 99%)
+            quantiles = torch.quantile(d_c.flatten(), torch.tensor(
+                [0.1, 0.5, 0.9, 0.99], device=d_c.device
+            ))
+            metrics[f"ch{c}_dist_q10"] = quantiles[0]
+            metrics[f"ch{c}_dist_median"] = quantiles[1]
+            metrics[f"ch{c}_dist_q90"] = quantiles[2]
+            metrics[f"ch{c}_dist_q99"] = quantiles[3]
+        
+        # β-scaled distances (if provided)
+        if beta_values is not None:
+            for t_idx, beta_t in enumerate(beta_values):
+                for c in range(C):
+                    median_key = f"ch{c}_dist_median"
+                    if median_key in metrics:
+                        scaled = beta_t * metrics[median_key]
+                        metrics[f"ch{c}_beta_scaled_median_t{t_idx}"] = scaled
+        
+        return metrics
+
+    # =========================================================================
+    # 3) Path Quality: Entropy & Support
+    # =========================================================================
+
+    def compute_path_quality(
+        self,
+        embeddings: Tensor,
+        probe_batch: Tensor,
+        beta_fn,  # Callable: t -> β(t)
+    ) -> Dict[str, Tensor]:
+        """Compute entropy and support size at probe times.
+        
+        Args:
+            embeddings: [num_channels, vocab_size] LUT weights
+            probe_batch: [B, C, H, W] probe images
+            beta_fn: Function mapping t -> β(t) (scalar or [C] tensor)
+        
+        Returns:
+            Dictionary with entropy/support metrics per channel and time
+        """
+        C, V = embeddings.shape
+        B, C_img, H, W = probe_batch.shape
+        assert C == C_img
+        
+        metrics = {}
+        
+        probe_flat = probe_batch.view(B, C, -1)  # [B, C, HW]
+        N_pixels = probe_flat.shape[-1]
+        
+        # Sample subset
+        max_pixels = 512
+        if N_pixels > max_pixels:
+            indices = torch.randperm(N_pixels, device=probe_flat.device)[:max_pixels]
+            probe_flat = probe_flat[:, :, indices]
+            N_pixels = max_pixels
+        
+        for t in self.probe_times:
+            beta_t = beta_fn(torch.tensor(t, device=embeddings.device))
+            
+            # Compute Gibbs probabilities for each channel
+            for c in range(C):
+                # Get x_1 values for this channel: [B, N]
+                x1_c = probe_flat[:, c, :].long()  # [B, N]
+                
+                # Embedding for x_1: [B, N]
+                emb_x1 = embeddings[c, x1_c]  # [B, N]
+                
+                # All embeddings for channel c: [V]
+                emb_all = embeddings[c, :]  # [V]
+                
+                # Distances: |E[v] - E[x_1]| for all v
+                # emb_x1: [B, N] -> [B, N, 1]
+                # emb_all: [V] -> [1, 1, V]
+                # dists: [B, N, V]
+                dists = (emb_x1.unsqueeze(-1) - emb_all.unsqueeze(0).unsqueeze(0)).abs()
+                
+                # Gibbs logits: -β * d
+                if isinstance(beta_t, Tensor) and beta_t.numel() > 1:
+                    beta_c = beta_t[c]
+                else:
+                    beta_c = beta_t
+                
+                logits = -beta_c * dists  # [B, N, V]
+                probs = F.softmax(logits, dim=-1)  # [B, N, V]
+                
+                # Entropy: -sum(p log p)
+                entropy = -(probs * (probs + 1e-10).log()).sum(dim=-1)  # [B, N]
+                avg_entropy = entropy.mean()
+                metrics[f"ch{c}_entropy_t{t:.1f}"] = avg_entropy
+                
+                # Effective support size (top-k for 90% mass)
+                sorted_probs, _ = probs.sort(dim=-1, descending=True)
+                cumsum = sorted_probs.cumsum(dim=-1)  # [B, N, V]
+                support_sizes = (cumsum < 0.9).sum(dim=-1).float() + 1  # [B, N]
+                avg_support = support_sizes.mean()
+                metrics[f"ch{c}_support90_t{t:.1f}"] = avg_support
+                
+                # Top-1, top-3, top-5 mass
+                metrics[f"ch{c}_top1_prob_t{t:.1f}"] = sorted_probs[:, :, 0].mean()
+                metrics[f"ch{c}_top3_mass_t{t:.1f}"] = sorted_probs[:, :, :3].sum(dim=-1).mean()
+                metrics[f"ch{c}_top5_mass_t{t:.1f}"] = sorted_probs[:, :, :5].sum(dim=-1).mean()
+                
+                # KL divergence vs baseline (if registered)
+                if self.baseline_embeddings is not None:
+                    emb_base = self.baseline_embeddings[c, :]
+                    dists_base = (emb_x1.unsqueeze(-1) - emb_base.unsqueeze(0).unsqueeze(0)).abs()
+                    logits_base = -beta_c * dists_base
+                    probs_base = F.softmax(logits_base, dim=-1)
+                    
+                    # KL(p_lut || p_base)
+                    kl = (probs * ((probs + 1e-10) / (probs_base + 1e-10)).log()).sum(dim=-1)
+                    metrics[f"ch{c}_kl_vs_baseline_t{t:.1f}"] = kl.mean()
+        
+        return metrics
+
+    # =========================================================================
+    # 4) Sampling Displacement
+    # =========================================================================
+
+    def compute_sampling_displacement(
+        self,
+        embeddings: Tensor,
+        probe_batch: Tensor,
+        beta_fn,
+        num_samples: int = 256,
+    ) -> Dict[str, Tensor]:
+        """Compute token displacement statistics from sampling.
+        
+        Args:
+            embeddings: [num_channels, vocab_size] LUT weights
+            probe_batch: [B, C, H, W] probe images
+            beta_fn: Function mapping t -> β(t)
+            num_samples: Number of pixels to sample per channel
+        
+        Returns:
+            Dictionary with displacement metrics
+        """
+        C, V = embeddings.shape
+        B, C_img, H, W = probe_batch.shape
+        
+        metrics = {}
+        
+        probe_flat = probe_batch.view(B, C, -1)  # [B, C, HW]
+        N_pixels = probe_flat.shape[-1]
+        
+        # Sample pixels
+        n_sample = min(num_samples, N_pixels)
+        indices = torch.randperm(N_pixels, device=probe_flat.device)[:n_sample]
+        sampled_pixels = probe_flat[:, :, indices]  # [B, C, n_sample]
+        
+        for t in self.probe_times:
+            beta_t = beta_fn(torch.tensor(t, device=embeddings.device))
+            
+            for c in range(C):
+                x1_c = sampled_pixels[:, c, :].long()  # [B, n_sample]
+                
+                # Compute Gibbs distribution and sample
+                emb_x1 = embeddings[c, x1_c]  # [B, n_sample]
+                emb_all = embeddings[c, :]  # [V]
+                
+                dists = (emb_x1.unsqueeze(-1) - emb_all.unsqueeze(0).unsqueeze(0)).abs()
+                
+                if isinstance(beta_t, Tensor) and beta_t.numel() > 1:
+                    beta_c = beta_t[c]
+                else:
+                    beta_c = beta_t
+                
+                logits = -beta_c * dists  # [B, n_sample, V]
+                probs = F.softmax(logits, dim=-1)
+                
+                # Sample x_t
+                x_t = torch.multinomial(
+                    probs.view(-1, V), num_samples=1
+                ).view(B, n_sample)  # [B, n_sample]
+                
+                # Displacement: x_t - x_1
+                displacement = (x_t - x1_c).float()  # [B, n_sample]
+                
+                metrics[f"ch{c}_mean_abs_disp_t{t:.1f}"] = displacement.abs().mean()
+                metrics[f"ch{c}_mean_sq_disp_t{t:.1f}"] = (displacement ** 2).mean()
+                
+                # Signed symmetry: fraction moving up
+                frac_up = (displacement > 0).float().mean()
+                metrics[f"ch{c}_frac_move_up_t{t:.1f}"] = frac_up
+        
+        return metrics
+
+    # =========================================================================
+    # 5) Training Dynamics
+    # =========================================================================
+
+    def compute_training_dynamics(
+        self,
+        embeddings: Tensor,
+        embeddings_prev: Optional[Tensor],
+        grad: Optional[Tensor],
+        lr: float,
+    ) -> Dict[str, Tensor]:
+        """Compute LUT training dynamics.
+        
+        Args:
+            embeddings: [num_channels, vocab_size] current LUT
+            embeddings_prev: Previous epoch's LUT (for delta computation)
+            grad: [num_channels, vocab_size] gradient (if available)
+            lr: Learning rate for LUT
+        
+        Returns:
+            Dictionary with dynamics metrics
+        """
+        metrics = {}
+        
+        # Gradient norms (per channel)
+        if grad is not None:
+            grad_norms = grad.norm(p=2, dim=1)  # [C]
+            for c in range(self.num_channels):
+                metrics[f"ch{c}_grad_norm"] = grad_norms[c]
+            metrics["grad_norm_avg"] = grad_norms.mean()
+            metrics["grad_norm_max"] = grad_norms.max()
+            
+            # Step size estimate: lr * ||grad||
+            step_sizes = lr * grad_norms
+            metrics["step_size_avg"] = step_sizes.mean()
+            metrics["step_size_max"] = step_sizes.max()
+        
+        # Actual parameter delta (if prev available)
+        if embeddings_prev is not None:
+            delta = embeddings - embeddings_prev  # [C, V]
+            delta_norms = delta.norm(p=2, dim=1)  # [C]
+            
+            for c in range(self.num_channels):
+                metrics[f"ch{c}_param_delta"] = delta_norms[c]
+            metrics["param_delta_avg"] = delta_norms.mean()
+            metrics["param_delta_max"] = delta_norms.max()
+            
+            # Max per-token update
+            max_updates = delta.abs().max(dim=1).values  # [C]
+            metrics["max_token_update_avg"] = max_updates.mean()
+        
+        return metrics
+
+    # =========================================================================
+    # 6) Cross-Channel Sanity
+    # =========================================================================
+
+    def compute_cross_channel_sanity(
+        self,
+        embeddings: Tensor,
+        entropy_dict: Optional[Dict[str, Tensor]] = None,
+    ) -> Dict[str, Tensor]:
+        """Compute cross-channel consistency metrics.
+        
+        Args:
+            embeddings: [num_channels, vocab_size] LUT weights
+            entropy_dict: Optional dict from compute_path_quality (for gaps)
+        
+        Returns:
+            Dictionary with cross-channel metrics
+        """
+        metrics = {}
+        
+        # Scale (std) per channel
+        stds = embeddings.std(dim=1)  # [C]
+        for c in range(self.num_channels):
+            metrics[f"ch{c}_std"] = stds[c]
+        
+        # Scale ratios (if 3 channels, compute R:G:B ratios)
+        if self.num_channels == 3:
+            metrics["std_ratio_RG"] = stds[0] / (stds[1] + 1e-8)
+            metrics["std_ratio_RB"] = stds[0] / (stds[2] + 1e-8)
+            metrics["std_ratio_GB"] = stds[1] / (stds[2] + 1e-8)
+        
+        # Entropy gaps (if provided)
+        if entropy_dict is not None and self.num_channels == 3:
+            # Find entropy at t=0.5 (middle probe time)
+            mid_t = self.probe_times[len(self.probe_times) // 2]
+            h0 = entropy_dict.get(f"ch0_entropy_t{mid_t:.1f}")
+            h1 = entropy_dict.get(f"ch1_entropy_t{mid_t:.1f}")
+            h2 = entropy_dict.get(f"ch2_entropy_t{mid_t:.1f}")
+            
+            if h0 is not None and h1 is not None and h2 is not None:
+                metrics["entropy_gap_RG"] = h0 - h1
+                metrics["entropy_gap_RB"] = h0 - h2
+                metrics["entropy_gap_GB"] = h1 - h2
+        
+        return metrics
+
+    # =========================================================================
+    # 8) Alert Thresholds
+    # =========================================================================
+
+    def check_alerts(
+        self,
+        geometry: Dict[str, Tensor],
+        path_quality: Dict[str, Tensor],
+    ) -> Dict[str, bool]:
+        """Check if any alert thresholds are triggered.
+        
+        Args:
+            geometry: Output from compute_lut_geometry
+            path_quality: Output from compute_path_quality
+        
+        Returns:
+            Dictionary of alert flags
+        """
+        alerts = {}
+        
+        # Entropy collapse/overflat (check at t=0.5)
+        mid_t = self.probe_times[len(self.probe_times) // 2]
+        for c in range(self.num_channels):
+            entropy_key = f"ch{c}_entropy_t{mid_t:.1f}"
+            if entropy_key in path_quality:
+                H = path_quality[entropy_key].item()
+                
+                if H < self.alert_thresholds["entropy_collapse"]:
+                    alerts[f"ch{c}_entropy_collapse"] = True
+                    self.alert_counts["entropy_collapse"] += 1
+                
+                if H > self.alert_thresholds["entropy_overflat"]:
+                    alerts[f"ch{c}_entropy_overflat"] = True
+                    self.alert_counts["entropy_overflat"] += 1
+        
+        # Scale blow-up/collapse (if init_std registered)
+        if self.init_std is not None and "std" in geometry:
+            current_std = geometry["std"]
+            for c in range(self.num_channels):
+                ratio = current_std[c] / self.init_std[c]
+                
+                if ratio > self.alert_thresholds["scale_blowup"]:
+                    alerts[f"ch{c}_scale_blowup"] = True
+                    self.alert_counts["scale_blowup"] += 1
+                
+                if ratio < self.alert_thresholds["scale_collapse"]:
+                    alerts[f"ch{c}_scale_collapse"] = True
+                    self.alert_counts["scale_collapse"] += 1
+        
+        # Inversion ratio
+        if "inversion_ratio" in geometry:
+            inv_ratio = geometry["inversion_ratio"]
+            for c in range(self.num_channels):
+                if inv_ratio[c] > self.alert_thresholds["inversion_ratio"]:
+                    alerts[f"ch{c}_inversion_spike"] = True
+                    self.alert_counts["inversion_ratio"] += 1
+        
+        # KL drift (if baseline registered)
+        if self.baseline_embeddings is not None:
+            kl_key = f"ch0_kl_vs_baseline_t{mid_t:.1f}"
+            if kl_key in path_quality:
+                kl = path_quality[kl_key].item()
+                if kl > self.alert_thresholds["kl_drift"]:
+                    alerts["kl_drift"] = True
+                    self.alert_counts["kl_drift"] += 1
+        
+        return alerts
+
+    # =========================================================================
+    # Convenience: Compute All Metrics
+    # =========================================================================
+
+    def compute_all_metrics(
+        self,
+        embeddings: Tensor,
+        probe_batch: Tensor,
+        beta_fn,
+        embeddings_prev: Optional[Tensor] = None,
+        grad: Optional[Tensor] = None,
+        lr: Optional[float] = None,
+        beta_values: Optional[Tensor] = None,
+    ) -> Dict[str, Tensor]:
+        """Compute all diagnostic metrics in one call.
+        
+        Args:
+            embeddings: [num_channels, vocab_size] current LUT
+            probe_batch: [B, C, H, W] probe images
+            beta_fn: Callable mapping t -> β(t)
+            embeddings_prev: Previous LUT (for dynamics)
+            grad: Gradient tensor (for dynamics)
+            lr: Learning rate (for dynamics)
+            beta_values: Optional [len(probe_times)] β values for distance scaling
+        
+        Returns:
+            Combined dictionary of all metrics
+        """
+        all_metrics = {}
+        
+        # 1) Geometry
+        geometry = self.compute_lut_geometry(embeddings)
+        all_metrics.update({f"geom/{k}": v for k, v in geometry.items()})
+        
+        # 2) Distance stats
+        dist_stats = self.compute_distance_stats(embeddings, probe_batch, beta_values)
+        all_metrics.update({f"dist/{k}": v for k, v in dist_stats.items()})
+        
+        # 3) Path quality
+        path_quality = self.compute_path_quality(embeddings, probe_batch, beta_fn)
+        all_metrics.update({f"path/{k}": v for k, v in path_quality.items()})
+        
+        # 4) Sampling displacement
+        displacement = self.compute_sampling_displacement(embeddings, probe_batch, beta_fn)
+        all_metrics.update({f"sample/{k}": v for k, v in displacement.items()})
+        
+        # 5) Training dynamics (if data available)
+        if embeddings_prev is not None or grad is not None:
+            lr_val = lr if lr is not None else 0.0
+            dynamics = self.compute_training_dynamics(
+                embeddings, embeddings_prev, grad, lr_val
+            )
+            all_metrics.update({f"dynamics/{k}": v for k, v in dynamics.items()})
+        
+        # 6) Cross-channel sanity
+        cross_channel = self.compute_cross_channel_sanity(embeddings, path_quality)
+        all_metrics.update({f"cross/{k}": v for k, v in cross_channel.items()})
+        
+        # 8) Alerts
+        alerts = self.check_alerts(geometry, path_quality)
+        all_metrics.update({f"alert/{k}": v for k, v in alerts.items()})
+        
+        return all_metrics
+
+    def log_metrics_summary(
+        self, metrics: Dict[str, Tensor], epoch: int, logger_obj=None
+    ) -> None:
+        """Log a human-readable summary of key metrics.
+        
+        Args:
+            metrics: Dictionary from compute_all_metrics
+            epoch: Current epoch number
+            logger_obj: Logger to use (defaults to module logger)
+        """
+        log = logger_obj or logger
+        
+        # Header
+        log.info(f"=== LUT Diagnostics Epoch {epoch} ===")
+        
+        # Geometry summary (per channel)
+        log.info("Geometry:")
+        for c in range(self.num_channels):
+            if f"geom/std" in metrics:
+                std = metrics[f"geom/std"][c].item()
+                inv_count = metrics.get(f"geom/inversion_count", torch.zeros(self.num_channels))[c].item()
+                spearman = metrics.get(f"geom/spearman_rho", torch.zeros(self.num_channels))[c].item()
+                log.info(f"  ch{c}: std={std:.4f}, inversions={inv_count:.0f}, ρ={spearman:.3f}")
+        
+        # Path quality at t=0.5
+        mid_t = self.probe_times[len(self.probe_times) // 2]
+        log.info(f"Path Quality (t={mid_t}):")
+        for c in range(self.num_channels):
+            H_key = f"path/ch{c}_entropy_t{mid_t:.1f}"
+            sup_key = f"path/ch{c}_support90_t{mid_t:.1f}"
+            if H_key in metrics:
+                H = metrics[H_key].item()
+                sup = metrics.get(sup_key, torch.tensor(0.0)).item()
+                log.info(f"  ch{c}: H={H:.3f}, support90={sup:.1f}")
+        
+        # Alerts
+        alert_triggered = any("alert/" in k for k in metrics.keys())
+        if alert_triggered:
+            log.warning("⚠️  Alerts triggered:")
+            for k, v in metrics.items():
+                if k.startswith("alert/") and v:
+                    log.warning(f"  {k}")
+        else:
+            log.info("✓ No alerts")
+        
+        log.info("=" * 50)

--- a/flow_matching/path/mds_init.py
+++ b/flow_matching/path/mds_init.py
@@ -1,0 +1,374 @@
+"""
+MDS-based initialization for learnable Mahalanobis metric.
+
+This module provides initialization methods that warm-start the learnable metric
+from the baseline Lp metric using Multi-Dimensional Scaling (MDS).
+"""
+
+import torch
+from torch import Tensor
+from typing import Optional
+
+
+def classical_mds(
+    distance_matrix: Tensor,
+    metric_dim: int,
+    device: Optional[torch.device] = None,
+    dtype: Optional[torch.dtype] = None,
+) -> Tensor:
+    """
+    Classical Multi-Dimensional Scaling (Torgerson 1952).
+    
+    Given a distance matrix D, find coordinates Z such that ||z_i - z_j||_2 ≈ D_ij.
+    Uses eigendecomposition of the double-centered Gram matrix.
+    
+    Args:
+        distance_matrix: [K, K] pairwise distance matrix
+        metric_dim: Target embedding dimension
+        device: Device for computation
+        dtype: Data type for computation
+    
+    Returns:
+        codes: [K, metric_dim] embedded coordinates
+    
+    Algorithm:
+        1. Double-centering: B = -1/2 * H * D² * H  where H = I - 11ᵀ/K
+        2. Eigendecomposition: B = V Λ Vᵀ
+        3. Extract top-d components: Z = V[:,:d] * sqrt(Λ[:d,:d])
+    """
+    K = distance_matrix.shape[0]
+    if device is None:
+        device = distance_matrix.device
+    if dtype is None:
+        dtype = distance_matrix.dtype
+    
+    # Double-centering to get Gram matrix
+    D_sq = distance_matrix ** 2
+    row_means = D_sq.mean(dim=1, keepdim=True)
+    col_means = D_sq.mean(dim=0, keepdim=True)
+    grand_mean = D_sq.mean()
+    
+    B = -0.5 * (D_sq - row_means - col_means + grand_mean)
+    
+    # Eigendecomposition (ascending order by default)
+    eigenvalues, eigenvectors = torch.linalg.eigh(B)
+    
+    # Take top-d eigenvalues/vectors (flip to descending order)
+    eigenvalues = eigenvalues.flip(0)[:metric_dim]
+    eigenvectors = eigenvectors.flip(1)[:, :metric_dim]
+    
+    # Clamp negative eigenvalues to zero (numerical artifacts or non-Euclidean)
+    eigenvalues = eigenvalues.clamp(min=0.0)
+    
+    # Construct embedding: Z = V * sqrt(Λ)
+    codes = eigenvectors @ torch.diag(torch.sqrt(eigenvalues))
+    
+    return codes.to(device=device, dtype=dtype)
+
+
+def classical_mds_full_spectrum(
+    distance_matrix: Tensor,
+    metric_dim: int,
+    device: Optional[torch.device] = None,
+    dtype: Optional[torch.dtype] = None,
+) -> Tensor:
+    """
+    Classical MDS using ALL eigenvalues (including negatives).
+    
+    This is equivalent to standard classical MDS but we compute it by:
+    1. Using all eigenvalues (not clamping negatives)
+    2. Taking top-d by absolute value
+    3. Preserving sign when taking sqrt
+    
+    For non-Euclidean distances, this can sometimes give better stress
+    by allowing "imaginary" dimensions.
+    
+    Args:
+        distance_matrix: [K, K] pairwise distance matrix
+        metric_dim: Target embedding dimension
+        device: Device for computation
+        dtype: Data type for computation
+    
+    Returns:
+        codes: [K, metric_dim] embedded coordinates
+    """
+    K = distance_matrix.shape[0]
+    if device is None:
+        device = distance_matrix.device
+    if dtype is None:
+        dtype = distance_matrix.dtype
+    
+    # Double-centering
+    D_sq = distance_matrix ** 2
+    row_means = D_sq.mean(dim=1, keepdim=True)
+    col_means = D_sq.mean(dim=0, keepdim=True)
+    grand_mean = D_sq.mean()
+    
+    B = -0.5 * (D_sq - row_means - col_means + grand_mean)
+    
+    # Full eigendecomposition
+    eigenvalues, eigenvectors = torch.linalg.eigh(B)
+    
+    # Sort by absolute value (descending)
+    abs_eigenvalues = eigenvalues.abs()
+    sorted_indices = abs_eigenvalues.argsort(descending=True)[:metric_dim]
+    
+    selected_eigenvalues = eigenvalues[sorted_indices]
+    selected_eigenvectors = eigenvectors[:, sorted_indices]
+    
+    # Use sign-preserving sqrt: sqrt(|λ|) * sign(λ)
+    sqrt_eigenvalues = torch.sqrt(selected_eigenvalues.abs()) * selected_eigenvalues.sign()
+    
+    # Construct embedding
+    codes = selected_eigenvectors @ torch.diag(sqrt_eigenvalues)
+    
+    return codes.to(device=device, dtype=dtype)
+
+
+def initialize_metric_from_lp(
+    vocab_size: int,
+    metric_dim: int,
+    lp_order: float = 3.0,
+    embed_range: str = "pm1",
+    device: torch.device = torch.device("cpu"),
+    dtype: torch.dtype = torch.float32,
+) -> Tensor:
+    """
+    Initialize metric codes using MDS on the baseline Lp distance.
+    
+    Args:
+        vocab_size: Number of discrete tokens (e.g., 256 for CIFAR-10 pixels)
+        metric_dim: Dimension of the learnable embedding
+        lp_order: Lp norm order (e.g., 3.0 for L3)
+        embed_range: "pm1" for [-1,1] or "unit" for [0,1]
+        device: Target device
+        dtype: Target dtype
+    
+    Returns:
+        init_codes: [vocab_size, metric_dim] initialized codes
+    
+    Process:
+        1. Build 1D baseline embedding (linspace)
+        2. Compute Lp distance matrix
+        3. Run MDS to get d-dimensional embedding
+        4. Result: codes that preserve Lp geometry
+    """
+    # Step 1: Build baseline 1D embedding
+    if embed_range == "pm1":
+        baseline = torch.linspace(-1.0, 1.0, steps=vocab_size, device=device, dtype=dtype)
+    else:  # "unit"
+        baseline = torch.linspace(0.0, 1.0, steps=vocab_size, device=device, dtype=dtype)
+    
+    baseline = baseline.unsqueeze(1)  # [K, 1]
+    
+    # Step 2: Compute Lp distance matrix
+    # For 1D: d(i,j) = |baseline[i] - baseline[j]|^p
+    pairwise_diff = baseline - baseline.T  # [K, K]
+    lp_distances = torch.abs(pairwise_diff) ** lp_order  # [K, K]
+    
+    # Step 3: MDS embedding
+    init_codes = classical_mds(lp_distances, metric_dim)  # [K, metric_dim]
+    
+    return init_codes.to(device=device, dtype=dtype)
+
+
+def verify_mds_quality(
+    init_codes: Tensor,
+    target_distances: Tensor,
+    metric_dim: int,
+) -> dict:
+    """
+    Verify the quality of MDS initialization using standard metrics.
+    
+    Args:
+        init_codes: [K, d] MDS embedding
+        target_distances: [K, K] target distance matrix
+        metric_dim: Dimension used
+    
+    Returns:
+        metrics: Dictionary with quality metrics
+            - reconstruction_error: ||D_target - D_mds||_F / ||D_target||_F
+            - spearman_correlation: Rank correlation between distances
+            - num_negative_eigenvalues: Count of negative eigenvalues (non-Euclidean indicator)
+            - gof_eigenvalue: Goodness-of-fit via eigenvalues (Σλ⁺ / Σ|λ|)
+            - gof_stress1: Kruskal's stress-1 metric
+            - explained_variance_positive: Variance explained by positive eigenvalues only
+    """
+    K = init_codes.shape[0]
+    device = init_codes.device
+    
+    # Compute MDS distances
+    mds_distances = torch.cdist(init_codes, init_codes, p=2.0)  # [K, K]
+    
+    # 1. Frobenius reconstruction error
+    diff = target_distances - mds_distances
+    reconstruction_error = torch.linalg.norm(diff, ord='fro') / torch.linalg.norm(target_distances, ord='fro')
+    
+    # 2. Spearman correlation (on flattened upper triangle)
+    mask = torch.triu(torch.ones(K, K, dtype=torch.bool, device=device), diagonal=1)
+    target_flat = target_distances[mask]
+    mds_flat = mds_distances[mask]
+    
+    target_ranks = target_flat.argsort().argsort().float()
+    mds_ranks = mds_flat.argsort().argsort().float()
+    spearman_corr = torch.corrcoef(torch.stack([target_ranks, mds_ranks]))[0, 1]
+    
+    # 3. Double-centered Gram matrix and eigenvalues
+    D_sq = target_distances ** 2
+    row_means = D_sq.mean(dim=1, keepdim=True)
+    col_means = D_sq.mean(dim=0, keepdim=True)
+    grand_mean = D_sq.mean()
+    B = -0.5 * (D_sq - row_means - col_means + grand_mean)
+    
+    # Full eigendecomposition (don't clamp yet - we need to count negatives)
+    eigenvalues_raw = torch.linalg.eigvalsh(B)  # Ascending order
+    eigenvalues_sorted = eigenvalues_raw.flip(0)  # Descending order
+    
+    # 4. Count negative eigenvalues (indicator of non-Euclidean geometry)
+    num_negative = (eigenvalues_sorted < -1e-10).sum().item()
+    
+    # 5. GOF (Goodness-of-Fit) - Method 1: Eigenvalue-based
+    # Uses absolute sum so negatives don't vanish
+    # GOF = (Σ λ⁺ for top d) / (Σ |λ| for all)
+    positive_eigenvalues = eigenvalues_sorted.clamp(min=0.0)
+    abs_eigenvalues = eigenvalues_sorted.abs()
+    
+    top_d_positive = positive_eigenvalues[:metric_dim].sum()
+    total_abs = abs_eigenvalues.sum()
+    gof_eigenvalue = top_d_positive / (total_abs + 1e-10)
+    
+    # 6. GOF (Goodness-of-Fit) - Method 2: Kruskal's Stress-1
+    # Stress-1 = sqrt(Σ(D_target - D_mds)² / Σ D_target²)
+    # Lower is better; 0 = perfect fit
+    numerator = ((target_distances - mds_distances) ** 2).sum()
+    denominator = (target_distances ** 2).sum()
+    stress1 = torch.sqrt(numerator / (denominator + 1e-10))
+    
+    # 7. Explained variance (using only positive eigenvalues)
+    total_positive_var = positive_eigenvalues.sum()
+    top_d_var = positive_eigenvalues[:metric_dim].sum()
+    explained_variance_positive = top_d_var / (total_positive_var + 1e-10)
+    
+    return {
+        "reconstruction_error": reconstruction_error.item(),
+        "spearman_correlation": spearman_corr.item(),
+        "num_negative_eigenvalues": num_negative,
+        "gof_eigenvalue": gof_eigenvalue.item(),
+        "gof_stress1": stress1.item(),
+        "explained_variance_positive": explained_variance_positive.item(),
+    }
+
+
+if __name__ == "__main__":
+    """Test MDS initialization with comparison between classical and full-spectrum methods."""
+    print("="*70)
+    print("MDS INITIALIZATION COMPARISON (K=256, d=8)")
+    print("="*70)
+    
+    # Test parameters
+    K, d = 256, 8
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    
+    # Compute target L₃ distances
+    baseline = torch.linspace(-1.0, 1.0, steps=K, device=device).unsqueeze(1)
+    lp_distances = torch.abs(baseline - baseline.T) ** 3.0
+    
+    print(f"\nTarget: L₃ distance matrix from linearly spaced {K} tokens")
+    print(f"Device: {device}")
+    
+    # Method 1: Classical MDS (positive eigenvalues only)
+    print("\n" + "─"*70)
+    print("METHOD 1: Classical MDS (positive eigenvalues only)")
+    print("─"*70)
+    
+    init_codes_classical = classical_mds(lp_distances, d, device, torch.float32)
+    
+    print(f"Shape: {init_codes_classical.shape}")
+    print(f"Mean:  {init_codes_classical.mean():.4f}")
+    print(f"Std:   {init_codes_classical.std():.4f}")
+    print(f"Rank:  {torch.linalg.matrix_rank(init_codes_classical).item()}")
+    
+    metrics_classical = verify_mds_quality(init_codes_classical, lp_distances, d)
+    
+    print(f"\nQuality Metrics:")
+    print(f"  Reconstruction error:           {metrics_classical['reconstruction_error']:.4f}")
+    print(f"  Spearman correlation:           {metrics_classical['spearman_correlation']:.4f}")
+    print(f"  Num negative eigenvalues:       {metrics_classical['num_negative_eigenvalues']}")
+    print(f"  GOF (eigenvalue-based):         {metrics_classical['gof_eigenvalue']:.4f}")
+    print(f"  Kruskal's Stress-1:             {metrics_classical['gof_stress1']:.4f}")
+    print(f"  Explained variance (positive):  {metrics_classical['explained_variance_positive']:.4f}")
+    
+    # Method 2: Full-spectrum MDS (including negative eigenvalues by |λ|)
+    print("\n" + "─"*70)
+    print("METHOD 2: Full-Spectrum MDS (top-d by |λ|, preserving sign)")
+    print("─"*70)
+    
+    init_codes_full = classical_mds_full_spectrum(lp_distances, d, device, torch.float32)
+    
+    print(f"Shape: {init_codes_full.shape}")
+    print(f"Mean:  {init_codes_full.mean():.4f}")
+    print(f"Std:   {init_codes_full.std():.4f}")
+    print(f"Rank:  {torch.linalg.matrix_rank(init_codes_full).item()}")
+    
+    metrics_full = verify_mds_quality(init_codes_full, lp_distances, d)
+    
+    print(f"\nQuality Metrics:")
+    print(f"  Reconstruction error:           {metrics_full['reconstruction_error']:.4f}")
+    print(f"  Spearman correlation:           {metrics_full['spearman_correlation']:.4f}")
+    print(f"  Num negative eigenvalues:       {metrics_full['num_negative_eigenvalues']}")
+    print(f"  GOF (eigenvalue-based):         {metrics_full['gof_eigenvalue']:.4f}")
+    print(f"  Kruskal's Stress-1:             {metrics_full['gof_stress1']:.4f}")
+    print(f"  Explained variance (positive):  {metrics_full['explained_variance_positive']:.4f}")
+    
+    # Comparison
+    print("\n" + "="*70)
+    print("COMPARISON")
+    print("="*70)
+    
+    stress_diff = metrics_classical['gof_stress1'] - metrics_full['gof_stress1']
+    recon_diff = metrics_classical['reconstruction_error'] - metrics_full['reconstruction_error']
+    gof_diff = metrics_full['gof_eigenvalue'] - metrics_classical['gof_eigenvalue']
+    
+    print(f"\nStress-1 difference (Classical - Full): {stress_diff:+.4f}")
+    if abs(stress_diff) < 1e-6:
+        print("  → Identical fit quality")
+    elif stress_diff > 0:
+        print(f"  → Full-spectrum is BETTER by {abs(stress_diff):.4f}")
+    else:
+        print(f"  → Classical is BETTER by {abs(stress_diff):.4f}")
+    
+    print(f"\nReconstruction error difference (Classical - Full): {recon_diff:+.4f}")
+    if abs(recon_diff) < 1e-6:
+        print("  → Identical reconstruction")
+    elif recon_diff > 0:
+        print(f"  → Full-spectrum is BETTER by {abs(recon_diff):.4f}")
+    else:
+        print(f"  → Classical is BETTER by {abs(recon_diff):.4f}")
+    
+    print(f"\nGOF difference (Full - Classical): {gof_diff:+.4f}")
+    if abs(gof_diff) < 1e-6:
+        print("  → Identical eigenvalue coverage")
+    elif gof_diff > 0:
+        print(f"  → Full-spectrum captures {abs(gof_diff)*100:.2f}% more variance")
+    else:
+        print(f"  → Classical captures {abs(gof_diff)*100:.2f}% more variance")
+    
+    # Final recommendation
+    print("\n" + "="*70)
+    print("RECOMMENDATION")
+    print("="*70)
+    
+    if metrics_full['gof_stress1'] < metrics_classical['gof_stress1'] - 0.01:
+        print("✅ Use FULL-SPECTRUM MDS (significantly better stress)")
+        recommended_method = "classical_mds_full_spectrum"
+    elif metrics_full['gof_stress1'] > metrics_classical['gof_stress1'] + 0.01:
+        print("✅ Use CLASSICAL MDS (better stress with positive eigenvalues only)")
+        recommended_method = "classical_mds"
+    else:
+        print("✅ Use CLASSICAL MDS (standard method, equivalent quality)")
+        print("   (Full-spectrum gains negligible improvement for this case)")
+        recommended_method = "classical_mds"
+    
+    print(f"\nRecommended function: {recommended_method}()")
+    print(f"Recommended dimension: d={d}")
+    print("\n" + "="*70)

--- a/flow_matching/path/metric_analysis.py
+++ b/flow_matching/path/metric_analysis.py
@@ -1,0 +1,361 @@
+"""
+Metric Analysis Utilities
+
+Provides comprehensive analysis of learned Mahalanobis metrics during training.
+Automatically generates visualizations (t-SNE/UMAP), statistics, and diagnostics.
+
+Author: Based on Linus's philosophy of "glass box engineering"
+Date: October 2025
+"""
+
+import torch
+import numpy as np
+import matplotlib
+matplotlib.use('Agg')  # Non-interactive backend
+import matplotlib.pyplot as plt
+import seaborn as sns
+from pathlib import Path
+from typing import Optional, Dict, Any, Tuple
+import warnings
+
+try:
+    from sklearn.manifold import TSNE
+    HAS_TSNE = True
+except ImportError:
+    HAS_TSNE = False
+    warnings.warn("scikit-learn not installed, t-SNE visualization will be unavailable")
+
+try:
+    import umap
+    HAS_UMAP = True
+except ImportError:
+    HAS_UMAP = False
+
+
+def analyze_metric(
+    metric: "MahalanobisTokenMetric",
+    output_dir: str,
+    device: str = "cuda",
+    use_umap: bool = True,
+    use_tsne: bool = True,
+    verbose: bool = True,
+    save_plots: bool = True,
+) -> Dict[str, Any]:
+    """
+    Comprehensive analysis of a learned Mahalanobis metric.
+    
+    Args:
+        metric: The MahalanobisTokenMetric instance to analyze
+        output_dir: Directory to save analysis outputs
+        device: Device for computation
+        use_umap: Whether to generate UMAP visualization (if available)
+        use_tsne: Whether to generate t-SNE visualization (if available)
+        verbose: Whether to print analysis results
+        save_plots: Whether to save visualization plots
+        
+    Returns:
+        Dictionary containing all computed statistics and metrics
+    """
+    output_path = Path(output_dir)
+    output_path.mkdir(parents=True, exist_ok=True)
+    
+    results = {}
+    
+    if verbose:
+        print("\n" + "=" * 80)
+        print("METRIC ANALYSIS")
+        print("=" * 80)
+    
+    # Move metric to device and set to eval mode
+    metric = metric.to(device)
+    metric.eval()
+    
+    with torch.no_grad():
+        # ========================================================================
+        # 1. Basic Statistics
+        # ========================================================================
+        
+        codes = metric.codes  # [vocab_size, metric_dim]
+        lower = metric.cholesky_factor()  # [metric_dim, metric_dim]
+        Z = codes @ lower.T  # [vocab_size, metric_dim]
+        
+        # Frobenius norms (raw and normalized)
+        fro_norm_raw = torch.linalg.norm(Z, ord='fro').item()
+        results['frobenius_norm_raw'] = fro_norm_raw
+        
+        # Normalized version (as used in distance computation)
+        Z_normalized = Z / (fro_norm_raw + 1e-6)
+        fro_norm_normalized = torch.linalg.norm(Z_normalized, ord='fro').item()
+        results['frobenius_norm_normalized'] = fro_norm_normalized
+        
+        if verbose:
+            print(f"\nFrobenius norm (raw):        {fro_norm_raw:.6f}")
+            print(f"Frobenius norm (normalized): {fro_norm_normalized:.6f}  [constrained to 1.0]")
+        
+        # codes_raw norm (if available)
+        if hasattr(metric, 'codes_raw'):
+            codes_raw_norm = torch.linalg.norm(metric.codes_raw, ord='fro').item()
+            results['codes_raw_norm'] = codes_raw_norm
+            if verbose:
+                print(f"codes_raw norm: {codes_raw_norm:.6f}")
+        
+        # Pairwise distances (using normalized Z, consistent with training)
+        distances = torch.cdist(Z_normalized, Z_normalized, p=2.0)  # [vocab_size, vocab_size]
+        
+        # Distance statistics (exclude diagonal)
+        vocab_size = Z.shape[0]
+        mask = ~torch.eye(vocab_size, dtype=torch.bool, device=device)
+        dist_values = distances[mask]
+        
+        results['distance_mean'] = dist_values.mean().item()
+        results['distance_std'] = dist_values.std().item()
+        results['distance_min'] = dist_values.min().item()
+        results['distance_max'] = dist_values.max().item()
+        results['distance_median'] = dist_values.median().item()
+        
+        if verbose:
+            print(f"\nPairwise Distance Statistics:")
+            print(f"  Mean:   {results['distance_mean']:.6f}")
+            print(f"  Std:    {results['distance_std']:.6f}")
+            print(f"  Min:    {results['distance_min']:.6f}")
+            print(f"  Max:    {results['distance_max']:.6f}")
+            print(f"  Median: {results['distance_median']:.6f}")
+            
+            # Coefficient of variation
+            cv = results['distance_std'] / results['distance_mean']
+            results['coefficient_of_variation'] = cv
+            print(f"  CV:     {cv:.6f}")
+            
+            if results['distance_std'] > 0.03:
+                print(f"\n✅ Meaningful structure learned (std={results['distance_std']:.4f})")
+            else:
+                print(f"\n⚠️  Weak structure (std={results['distance_std']:.4f})")
+        
+        # ========================================================================
+        # 2. Nearest Neighbors Analysis
+        # ========================================================================
+        
+        if verbose:
+            print(f"\nNearest Neighbors (sample tokens):")
+        
+        # For grayscale tokens (0-255), check key anchors
+        if vocab_size == 256:
+            anchor_tokens = [(0, "Black"), (128, "Mid-Gray"), (255, "White")]
+        else:
+            # Generic anchors for other vocab sizes
+            anchor_tokens = [
+                (0, "Token-0"),
+                (vocab_size // 2, f"Token-{vocab_size//2}"),
+                (vocab_size - 1, f"Token-{vocab_size-1}")
+            ]
+        
+        neighbors_info = {}
+        for token_id, description in anchor_tokens:
+            if token_id >= vocab_size:
+                continue
+                
+            dists_from_anchor = distances[token_id]
+            nearest_indices = torch.argsort(dists_from_anchor)[:6]
+            nearest_dists = dists_from_anchor[nearest_indices]
+            
+            neighbors_info[token_id] = {
+                'description': description,
+                'neighbors': nearest_indices.cpu().tolist(),
+                'distances': nearest_dists.cpu().tolist()
+            }
+            
+            if verbose:
+                print(f"  {description} ({token_id}): " + 
+                      f"neighbors={nearest_indices[1:4].cpu().tolist()}")
+        
+        results['nearest_neighbors'] = neighbors_info
+        
+        # ========================================================================
+        # 3. Visualizations (if requested)
+        # ========================================================================
+        
+        if save_plots:
+            Z_np = Z.cpu().numpy()
+            
+            # 3.1 Distance Heatmap
+            if verbose:
+                print(f"\nGenerating distance heatmap...")
+            
+            plt.figure(figsize=(10, 8))
+            sns.heatmap(
+                distances.cpu().numpy(),
+                cmap='viridis',
+                square=True,
+                xticklabels=False,
+                yticklabels=False,
+                cbar_kws={'label': 'Distance'}
+            )
+            plt.title(f'Pairwise Token Distances ({vocab_size}×{vocab_size})')
+            heatmap_path = output_path / "distance_heatmap.png"
+            plt.savefig(heatmap_path, dpi=120, bbox_inches='tight')
+            plt.close()
+            results['heatmap_path'] = str(heatmap_path)
+            
+            # 3.2 Distance Distribution
+            if verbose:
+                print(f"Generating distance distribution...")
+            
+            plt.figure(figsize=(10, 6))
+            plt.hist(dist_values.cpu().numpy(), bins=50, edgecolor='black', alpha=0.7)
+            plt.axvline(results['distance_mean'], color='red', linestyle='--', 
+                       linewidth=2, label=f"Mean: {results['distance_mean']:.3f}")
+            plt.xlabel('Distance')
+            plt.ylabel('Frequency')
+            plt.title('Distribution of Pairwise Distances')
+            plt.legend()
+            plt.grid(alpha=0.3)
+            dist_hist_path = output_path / "distance_distribution.png"
+            plt.savefig(dist_hist_path, dpi=120, bbox_inches='tight')
+            plt.close()
+            results['distribution_path'] = str(dist_hist_path)
+            
+            # 3.3 Dimensionality Reduction Visualizations
+            viz_methods = []
+            if use_umap and HAS_UMAP:
+                viz_methods.append(('UMAP', _compute_umap))
+            if use_tsne and HAS_TSNE:
+                viz_methods.append(('t-SNE', _compute_tsne))
+            
+            if not viz_methods:
+                if verbose:
+                    print("\n⚠️  No dimensionality reduction available")
+                    print("   Install: pip install umap-learn scikit-learn")
+            
+            for method_name, compute_fn in viz_methods:
+                if verbose:
+                    print(f"Running {method_name}...")
+                
+                try:
+                    Z_2d = compute_fn(Z_np)
+                    
+                    # Create visualization
+                    fig, axes = plt.subplots(1, 2, figsize=(16, 7))
+                    
+                    # Plot 1: Simple scatter
+                    axes[0].scatter(Z_2d[:, 0], Z_2d[:, 1], s=20, alpha=0.6, c='blue')
+                    axes[0].set_title(f'{method_name}: Learned Metric Space → 2D')
+                    axes[0].set_xlabel(f'{method_name} Dim 1')
+                    axes[0].set_ylabel(f'{method_name} Dim 2')
+                    axes[0].grid(alpha=0.3)
+                    
+                    # Plot 2: Colored by token value (for grayscale tokens)
+                    if vocab_size == 256:
+                        grayscale_colors = np.array([[i/255, i/255, i/255] for i in range(256)])
+                        axes[1].scatter(Z_2d[:, 0], Z_2d[:, 1], s=20, alpha=0.8, 
+                                       c=grayscale_colors)
+                        axes[1].set_title(f'{method_name}: Colors=Token Values (0=Black→255=White)')
+                    else:
+                        # Use viridis colormap for non-grayscale
+                        axes[1].scatter(Z_2d[:, 0], Z_2d[:, 1], s=20, alpha=0.8,
+                                       c=np.arange(vocab_size), cmap='viridis')
+                        axes[1].set_title(f'{method_name}: Colored by Token ID')
+                    
+                    axes[1].set_xlabel(f'{method_name} Dim 1')
+                    axes[1].set_ylabel(f'{method_name} Dim 2')
+                    axes[1].grid(alpha=0.3)
+                    
+                    plt.tight_layout()
+                    
+                    viz_path = output_path / f"{method_name.lower().replace('-', '')}_visualization.png"
+                    plt.savefig(viz_path, dpi=120, bbox_inches='tight')
+                    plt.close()
+                    
+                    results[f'{method_name.lower()}_path'] = str(viz_path)
+                    
+                    if verbose:
+                        print(f"  ✓ Saved: {viz_path.name}")
+                
+                except Exception as e:
+                    if verbose:
+                        print(f"  ✗ Failed: {e}")
+            
+            # 3.4 Cholesky Factor Heatmap
+            if verbose:
+                print(f"Generating Cholesky factor heatmap...")
+            
+            L = lower.cpu().numpy()
+            plt.figure(figsize=(8, 6))
+            sns.heatmap(L, annot=False, cmap='coolwarm', center=0, square=True,
+                       cbar_kws={'label': 'Value'})
+            plt.title(f'Cholesky Factor L ({L.shape[0]}×{L.shape[1]})')
+            cholesky_path = output_path / "cholesky_factor.png"
+            plt.savefig(cholesky_path, dpi=120, bbox_inches='tight')
+            plt.close()
+            results['cholesky_path'] = str(cholesky_path)
+            
+            # Diagonal values
+            diag_values = np.diag(L)
+            results['cholesky_diag_min'] = float(diag_values.min())
+            results['cholesky_diag_max'] = float(diag_values.max())
+    
+    if verbose:
+        print("\n" + "=" * 80)
+        print("✅ ANALYSIS COMPLETE")
+        print("=" * 80)
+        if save_plots:
+            print(f"\nOutputs saved to: {output_dir}")
+    
+    return results
+
+
+def _compute_tsne(Z: np.ndarray) -> np.ndarray:
+    """Compute t-SNE dimensionality reduction."""
+    tsne = TSNE(
+        n_components=2,
+        perplexity=min(30, Z.shape[0] // 4),
+        learning_rate='auto',
+        init='pca',
+        random_state=42,
+        max_iter=1000
+    )
+    return tsne.fit_transform(Z)
+
+
+def _compute_umap(Z: np.ndarray) -> np.ndarray:
+    """Compute UMAP dimensionality reduction."""
+    reducer = umap.UMAP(
+        n_components=2,
+        n_neighbors=min(15, Z.shape[0] // 4),
+        min_dist=0.1,
+        metric='euclidean',
+        random_state=42,
+        n_jobs=1
+    )
+    return reducer.fit_transform(Z)
+
+
+def quick_metric_check(
+    metric: "MahalanobisTokenMetric",
+    device: str = "cuda",
+) -> Dict[str, float]:
+    """
+    Quick check of metric health without saving plots.
+    Returns key statistics only.
+    """
+    metric = metric.to(device)
+    metric.eval()
+    
+    with torch.no_grad():
+        codes = metric.codes
+        lower = metric.cholesky_factor()
+        Z = codes @ lower.T
+        
+        distances = torch.cdist(Z, Z, p=2.0)
+        vocab_size = Z.shape[0]
+        mask = ~torch.eye(vocab_size, dtype=torch.bool, device=device)
+        dist_values = distances[mask]
+        
+        fro_norm_raw = torch.linalg.norm(Z, ord='fro').item()
+        
+        return {
+            'distance_mean': dist_values.mean().item(),
+            'distance_std': dist_values.std().item(),
+            'distance_min': dist_values.min().item(),
+            'distance_max': dist_values.max().item(),
+            'frobenius_norm_raw': fro_norm_raw,
+        }

--- a/flow_matching/path/mixture.py
+++ b/flow_matching/path/mixture.py
@@ -4,12 +4,17 @@
 # This source code is licensed under the CC-by-NC license found in the
 # LICENSE file in the root directory of this source tree.
 
+import logging
+import math
+from typing import Iterable, Optional, Union
+
 import torch
 import torch.nn.functional as F
 import torch.nn as nn
-from typing import Iterable, Optional, Union
 
 from torch import Tensor
+
+logger = logging.getLogger(__name__)
 
 
 def _inv_softplus_tensor(x: Tensor) -> Tensor:
@@ -18,8 +23,275 @@ def _inv_softplus_tensor(x: Tensor) -> Tensor:
     return torch.log(torch.expm1(x))
 
 
+class LearnableScalarLUT(nn.Module):
+    """Per-channel learnable embedding lookup table.
+
+    This module stores C independent embedding lookup tables, each with vocab_size
+    entries of dimension emb_dim. It is designed for the metric-induced probability
+    path where the distance is defined by Lp norm between embeddings.
+    
+    Shape: weight [num_channels, vocab_size, emb_dim]
+    - When emb_dim=1: behaves as scalar LUT (backward compatible)
+    - When emb_dim>1: uses vector embeddings with Lp distance
+    """
+
+    def __init__(
+        self,
+        *,
+        num_channels: int,
+        vocab_size: int,
+        emb_dim: int = 1,
+        embed_range: str,
+        device: Optional[torch.device],
+        dtype: torch.dtype,
+        lp_order: float = 1.0,
+        renormalize_to_init_norm: bool = False,
+        renorm_eps: float = 1e-12,
+        bounded_residual_scale: bool = False,
+        scale_baseline: float = 1.0,
+        scale_epsilon: float = 0.25,
+        init_method: str = "linear",
+        init_noise_scale: float = 0.01,
+    ) -> None:
+        super().__init__()
+        if num_channels <= 0:
+            raise ValueError("num_channels must be positive")
+        if vocab_size <= 0:
+            raise ValueError("vocab_size must be positive")
+        if emb_dim <= 0:
+            raise ValueError("emb_dim must be positive")
+        if embed_range not in {"pm1", "unit"}:
+            raise ValueError("embed_range must be 'pm1' or 'unit'")
+
+        self.num_channels = int(num_channels)
+        self.vocab_size = int(vocab_size)
+        self.emb_dim = int(emb_dim)
+        self.embed_range = embed_range
+        self.lp_order = float(lp_order)
+
+        # Set initialization parameters before calling _init_weight
+        self.init_method = str(init_method)
+        self.init_noise_scale = float(init_noise_scale)
+
+        weight = self._init_weight()
+        if device is not None:
+            weight = weight.to(device=device)
+        weight = weight.to(dtype=dtype)
+        self.weight = nn.Parameter(weight)
+        
+        # Compute base norm (without noise) PER CHANNEL for renormalization target
+        # Shape: [num_channels] - each channel has its own target norm
+        base_weight = self._linear_init_base()
+        if device is not None:
+            base_weight = base_weight.to(device=device)
+        base_weight = base_weight.to(dtype=dtype)
+        # Compute norm per channel: norm over dims (vocab_size, emb_dim)
+        base_norm_per_channel = torch.linalg.vector_norm(base_weight, dim=(1, 2))  # [num_channels]
+        self.register_buffer("_base_fro_norm_per_channel", base_norm_per_channel, persistent=False)
+        
+        self.renormalize_to_init_norm = bool(renormalize_to_init_norm)
+        self.renorm_eps = float(renorm_eps)
+        
+        # Bounded residual scale parameterization
+        self.bounded_residual_scale = bool(bounded_residual_scale)
+        self.scale_baseline = float(scale_baseline)  # s_0
+        self.scale_epsilon = float(scale_epsilon)    # ε
+        
+        if self.bounded_residual_scale:
+            # Learnable scale parameter c per channel: [num_channels]
+            # Initialized to 0 (tanh(0) = 0, so s = s_0 initially)
+            self.scale_c = nn.Parameter(torch.zeros(num_channels, dtype=dtype))
+        else:
+            self.scale_c = None
+
+    def _init_weight(self) -> Tensor:
+        """Initialize LUT weights using the selected initialization method."""
+        if self.init_method == "linear":
+            return self._linear_init()
+        elif self.init_method == "small_noise_qr":
+            return self._small_noise_qr_init()
+        else:
+            raise ValueError(f"Unknown init_method: {self.init_method}")
+
+    def _linear_init(self) -> Tensor:
+        """Initialize LUT with linearly spaced values along each dimension.
+        
+        Returns:
+            Tensor of shape [num_channels, vocab_size, emb_dim]
+        """
+        # Initialize each dimension independently with linspace + small noise
+        weight = torch.zeros(self.num_channels, self.vocab_size, self.emb_dim)
+        
+        for d in range(self.emb_dim):
+            if self.embed_range == "pm1":
+                base = torch.linspace(-1.0, 1.0, steps=self.vocab_size)
+            else:
+                base = torch.linspace(0.0, 1.0, steps=self.vocab_size)
+            
+            # Repeat base pattern for all channels
+            base_repeated = base.repeat(self.num_channels, 1)  # [C, V]
+            
+            # Add small Gaussian noise to break channel symmetry
+            # σ = 1e-3 is ~7.8x smaller than linear step size (≈0.00784 for V=256)
+            # This preserves monotonicity (P(inversion) ≈ 0) while decorrelating RGB
+            noise = torch.randn_like(base_repeated) * 1e-3
+            
+            weight[:, :, d] = base_repeated + noise
+        
+        return weight
+    
+    def _linear_init_base(self) -> Tensor:
+        """Initialize base LUT (without noise) for renormalization target.
+        
+        Returns:
+            Tensor of shape [num_channels, vocab_size, emb_dim]
+        """
+        weight = torch.zeros(self.num_channels, self.vocab_size, self.emb_dim)
+        
+        for d in range(self.emb_dim):
+            if self.embed_range == "pm1":
+                base = torch.linspace(-1.0, 1.0, steps=self.vocab_size)
+            else:
+                base = torch.linspace(0.0, 1.0, steps=self.vocab_size)
+            
+            # Repeat base pattern for all channels (no noise)
+            base_repeated = base.repeat(self.num_channels, 1)  # [C, V]
+            weight[:, :, d] = base_repeated
+        
+        return weight
+
+    def _small_noise_qr_init(self) -> Tensor:
+        """Initialize LUT with small noise QR decomposition for orthogonal warm start.
+        
+        This method provides an orthogonal initialization that balances:
+        - Orthogonality: QR decomposition ensures dimension-wise independence
+        - Warm start: Small noise prevents exact orthogonality for gradient flow
+        - Stability: Maintains consistent norms across channels and dimensions
+        
+        Returns:
+            Tensor of shape [num_channels, vocab_size, emb_dim]
+        """
+        # Step 1: Compute baseline unit vector (linear spacing normalized)
+        if self.embed_range == "pm1":
+            base_values = torch.linspace(-1.0, 1.0, steps=self.vocab_size)
+        else:
+            base_values = torch.linspace(0.0, 1.0, steps=self.vocab_size)
+        
+        # Normalize to unit vector for each dimension
+        base_unit = base_values / torch.linalg.vector_norm(base_values, ord=2)
+        
+        # Step 2: Build matrix A with small noise for QR decomposition
+        # A will be [vocab_size, emb_dim] - we want orthogonal columns
+        A = torch.zeros(self.vocab_size, self.emb_dim)
+        
+        # First column: baseline unit vector
+        A[:, 0] = base_unit
+        
+        # Remaining columns: add small noise to break symmetry
+        if self.emb_dim > 1:
+            # Generate small orthogonal noise
+            noise_scale = self.init_noise_scale
+            for d in range(1, self.emb_dim):
+                # Start with small random perturbation of the baseline
+                noise = torch.randn(self.vocab_size) * noise_scale
+                A[:, d] = base_unit + noise
+        
+        # Step 3: Apply QR decomposition for orthogonality
+        Q, R = torch.linalg.qr(A)
+        
+        # Step 4: Scale to target norm (same as linear init for consistency)
+        # Target norm should match the linear initialization norm
+        target_norm = torch.linalg.vector_norm(base_values, ord=2)
+        current_norm = torch.linalg.vector_norm(Q, dim=0)  # norm per column
+        scale_factors = target_norm / (current_norm + 1e-8)
+        Q_scaled = Q * scale_factors.unsqueeze(0)  # broadcast to [vocab_size, emb_dim]
+        
+        # Step 5: Replicate across channels (with small channel-wise noise)
+        weight = torch.zeros(self.num_channels, self.vocab_size, self.emb_dim)
+        for c in range(self.num_channels):
+            if c == 0:
+                # First channel: use the QR result directly
+                weight[c] = Q_scaled
+            else:
+                # Other channels: add small channel-specific noise
+                channel_noise = torch.randn_like(Q_scaled) * (noise_scale * 0.1)
+                weight[c] = Q_scaled + channel_noise
+        
+        return weight
+
+    @torch.no_grad()
+    def reset_parameters(self) -> None:
+        init_weight = self._init_weight().to(device=self.weight.device, dtype=self.weight.dtype)
+        self.weight.copy_(init_weight)
+        
+        # Recompute base norm per channel (without noise)
+        base_weight = self._linear_init_base().to(device=self.weight.device, dtype=self.weight.dtype)
+        base_norm_per_channel = torch.linalg.vector_norm(base_weight, dim=(1, 2))  # [num_channels]
+        self._base_fro_norm_per_channel.copy_(base_norm_per_channel)
+        
+        # Reset scale parameter c to 0 if using bounded residual
+        if self.bounded_residual_scale and self.scale_c is not None:
+            self.scale_c.zero_()
+
+    def forward(self) -> Tensor:
+        """Return LUT weights, optionally renormalized to base norm PER CHANNEL.
+        
+        When renormalize_to_init_norm=True:
+            - Renormalizes EACH channel independently to match its base (no-noise) norm
+            - Each channel maintains its own geometry (single-channel norm ≈ 9.27)
+            - Preserves gradients (scaling is differentiable)
+            - Keeps noise injection benefits while maintaining consistent geometry
+        
+        When bounded_residual_scale=True:
+            - Uses bounded residual parameterization: s = s_0 * (1 + ε * tanh(c))
+            - c is learnable per channel, L2 penalty keeps it near 0
+            - s_0 is baseline scale, ε controls maximum deviation
+            - Trust region approach prevents extreme scale changes
+        
+        Returns:
+            Tensor of shape [num_channels, vocab_size, emb_dim]
+        """
+        if self.bounded_residual_scale and self.scale_c is not None:
+            # Bounded residual scale: s = s_0 * (1 + ε * tanh(c))
+            # c is per-channel learnable parameter initialized to 0
+            scale = self.scale_baseline * (1.0 + self.scale_epsilon * torch.tanh(self.scale_c))
+            # Apply per-channel scaling: scale.view(C, 1, 1) * weight[C, V, D]
+            return self.weight * scale.view(-1, 1, 1)
+        
+        if not self.renormalize_to_init_norm:
+            return self.weight
+        
+        # Renormalize each channel independently to its base norm
+        # target: [num_channels] - target norm for each channel
+        # current: [num_channels] - current norm for each channel
+        target = self._base_fro_norm_per_channel.to(device=self.weight.device, dtype=self.weight.dtype)
+        current = torch.linalg.vector_norm(self.weight, dim=(1, 2))  # [num_channels]
+        scale = target / (current + self.renorm_eps)  # [num_channels]
+        
+        # Apply per-channel scaling: scale.view(C, 1, 1) * weight[C, V, D]
+        # Broadcasting: [C, 1, 1] * [C, V, D] -> [C, V, D]
+        return self.weight * scale.view(-1, 1, 1)
+
+    def extra_repr(self) -> str:
+        return (
+            f"num_channels={self.num_channels}, vocab_size={self.vocab_size}, "
+            f"emb_dim={self.emb_dim}, embed_range='{self.embed_range}', "
+            f"lp_order={self.lp_order}, bounded_residual_scale={self.bounded_residual_scale}, "
+            f"init_method='{self.init_method}', init_noise_scale={self.init_noise_scale}"
+        )
+
+
 class MahalanobisTokenMetric(nn.Module):
-    """Learnable PSD metric defined via token codes and a lower-triangular map."""
+    """Learnable PSD metric with unit-Frobenius retraction constraint.
+    
+    Uses reparameterization to enforce unit Frobenius norm ||Z||_F = 1:
+    - codes_raw: learnable parameters [vocab_size, metric_dim]
+    - codes (property): per-row normalized codes = normalize(codes_raw, dim=-1)
+    - Z = codes @ L^T is normalized to ||Z||_F = 1 via stop-gradient retraction
+    
+    This removes scale ambiguity with β schedule (β controls all distance scaling).
+    Similar to weight normalization: separates direction (learnable) from magnitude (controlled by β).
+    """
 
     def __init__(
         self,
@@ -28,6 +300,8 @@ class MahalanobisTokenMetric(nn.Module):
         *,
         init_codes: Optional[Tensor] = None,
         diag_eps: float = 1e-4,
+        target_norm: float = 1.0,
+        use_reparameterization: bool = False,  # Disabled by default for backward compatibility
     ) -> None:
         super().__init__()
         if vocab_size <= 0:
@@ -40,8 +314,19 @@ class MahalanobisTokenMetric(nn.Module):
         self.vocab_size = int(vocab_size)
         self.metric_dim = int(metric_dim)
         self.diag_eps = float(diag_eps)
+        self.target_norm = float(target_norm)
+        self.use_reparameterization = bool(use_reparameterization)
 
-        self.codes = nn.Parameter(torch.zeros(self.vocab_size, self.metric_dim))
+        if self.use_reparameterization:
+            # Reparameterization mode: unit-Frobenius constraint by construction
+            # Only codes_raw is learnable; Frobenius norm enforced via retraction
+            self.codes_raw = nn.Parameter(torch.zeros(self.vocab_size, self.metric_dim))
+            # No log_scale: scale ambiguity removed (β schedule controls all scaling)
+        else:
+            # Legacy mode: direct parameter (requires post-update projection)
+            # Directly register parameter to avoid property getter trigger
+            self._parameters['codes'] = nn.Parameter(torch.zeros(self.vocab_size, self.metric_dim))
+        
         self._lower_params = nn.Parameter(torch.zeros(self.metric_dim, self.metric_dim))
 
         self.reset_parameters(init_codes=init_codes)
@@ -53,13 +338,88 @@ class MahalanobisTokenMetric(nn.Module):
                 raise ValueError(
                     "init_codes must have shape (vocab_size, metric_dim)"
                 )
-            self.codes.copy_(init_codes)
+            if self.use_reparameterization:
+                # Initialize codes_raw such that normalized version equals init_codes
+                # Compute current norm of init_codes
+                init_norm = torch.linalg.norm(init_codes, ord='fro')
+                if init_norm > 1e-8:
+                    # Simply normalize per-row (Frobenius constraint applied in distance computation)
+                    self.codes_raw.copy_(F.normalize(init_codes, dim=-1))
+                else:
+                    # Fallback: small random initialization
+                    std = 1.0 / math.sqrt(self.vocab_size * self.metric_dim)
+                    self.codes_raw.normal_(0, std)
+            else:
+                # Legacy mode: set parameter directly
+                param = self._parameters.get('codes')
+                if param is not None:
+                    param.copy_(init_codes)
         else:
-            self.codes.zero_()
+            # Default initialization: unit-Frobenius constraint
+            if self.use_reparameterization:
+                # Initialize so that E[||Z||_F] = 1 after Frobenius normalization
+                # E[||Z||²_F] = vocab_size × metric_dim × σ²
+                # Want E[||Z||_F] = 1 => σ = 1 / sqrt(vocab_size × metric_dim)
+                std = 1.0 / math.sqrt(self.vocab_size * self.metric_dim)
+                self.codes_raw.normal_(0, std)
+            else:
+                # Legacy mode: zero initialization
+                param = self._parameters.get('codes')
+                if param is not None:
+                    param.zero_()
 
         self._lower_params.zero_()
         inv_sp_one = _inv_softplus_tensor(torch.ones(self.metric_dim, dtype=self._lower_params.dtype))
         torch.diagonal(self._lower_params).copy_(inv_sp_one)
+    
+    @property
+    def codes(self) -> Tensor:
+        """Return codes (learnable per-token embeddings).
+        
+        In reparameterization mode:
+            codes = codes_raw (already normalized per-row during updates)
+            Frobenius normalization is applied later in distance computation.
+        
+        In legacy mode:
+            codes = self.codes (direct parameter)
+        
+        NOTE: In reparameterization mode, codes_raw is kept normalized after
+        each gradient update via projection. Direct modifications to codes
+        (via .mul_, .add_, etc.) will break normalization and should be avoided.
+        Use optimizer updates instead.
+        """
+        if self.use_reparameterization:
+            # Return codes_raw directly (already per-row normalized)
+            return self.codes_raw
+        else:
+            # Legacy mode: return parameter directly (fallback for old checkpoints)
+            param = self._parameters.get('codes')
+            if param is None:
+                raise RuntimeError("Legacy codes parameter not found")
+            return param
+    
+    @codes.setter
+    def codes(self, value: Tensor) -> None:
+        """Allow setting codes (mainly for checkpoint loading).
+        
+        In reparameterization mode:
+            Normalize and assign to codes_raw (Frobenius norm enforced at distance computation)
+        In legacy mode:
+            Sets codes parameter directly
+        """
+        if value.shape != (self.vocab_size, self.metric_dim):
+            raise ValueError(f"codes must have shape ({self.vocab_size}, {self.metric_dim})")
+        
+        if self.use_reparameterization:
+            with torch.no_grad():
+                # Simply normalize per-row and assign
+                # Frobenius normalization happens in pairwise_distance_table
+                self.codes_raw.copy_(F.normalize(value, dim=-1))
+        else:
+            # Legacy mode: set parameter directly (fallback for old checkpoints)
+            param = self._parameters.get('codes')
+            if param is not None:
+                param.copy_(value)
 
     def cholesky_factor(self) -> Tensor:
         lower = torch.tril(self._lower_params)
@@ -69,23 +429,59 @@ class MahalanobisTokenMetric(nn.Module):
         return lower
 
     def transformed_codes(self, *, device: Optional[torch.device] = None, dtype: Optional[torch.dtype] = None) -> Tensor:
-        codes = self.codes
+        """Return Z = C @ L^T (before Frobenius normalization).
+        
+        Note: Frobenius normalization ||Z||_F = 1 is applied in pairwise_distance_table()
+        with stop-gradient to enable manifold optimization.
+        
+        In reparameterization mode (if enabled):
+            - Per-row normalization enforced on-the-fly (to handle manual modifications)
+            - Frobenius normalization happens at distance computation
+        
+        In legacy mode (default):
+            - Direct parameter access (backward compatibility)
+        """
+        codes = self.codes  # In reparam mode (if enabled), this returns codes_raw
         if device is not None or dtype is not None:
             codes = codes.to(device=device or codes.device, dtype=dtype or codes.dtype)
+        
+        # In reparameterization mode, enforce per-row normalization on-the-fly
+        # This handles cases where codes may have been modified directly (e.g., in tests)
+        # Only apply if reparameterization is actually enabled
+        if self.use_reparameterization:
+            codes = F.normalize(codes, dim=-1)
+        
         lower = self.cholesky_factor().to(device=codes.device, dtype=codes.dtype)
-        return codes @ lower.T
+        Z = codes @ lower.T  # [K, d]
+        return Z
 
     def pairwise_distance_table(
         self, *, device: torch.device, dtype: torch.dtype
     ) -> Tensor:
+        """Compute pairwise distance table with unit-Frobenius normalization.
+        
+        Applies Frobenius normalization: Z = Z_raw / ||Z_raw||_F
+        Gradient flows through both the norm and the normalized matrix.
+        """
         transformed = self.transformed_codes(device=device, dtype=dtype)
+        
+        # Unit-Frobenius normalization (gradient flows through norm)
+        fro_norm = torch.linalg.norm(transformed, ord='fro')  # gradient enabled
+        transformed = transformed / (fro_norm + 1e-6)  # normalized to ||Z||_F = 1
+        
         return torch.cdist(transformed, transformed, p=2.0)
 
     def get_extra_state(self) -> dict:
-        return {"diag_eps": self.diag_eps}
+        return {
+            "diag_eps": self.diag_eps,
+            "target_norm": self.target_norm,
+            "use_reparameterization": self.use_reparameterization,
+        }
 
     def set_extra_state(self, state: dict) -> None:  # pragma: no cover - API requirement
         self.diag_eps = float(state.get("diag_eps", self.diag_eps))
+        self.target_norm = float(state.get("target_norm", getattr(self, "target_norm", 1.0)))
+        self.use_reparameterization = bool(state.get("use_reparameterization", getattr(self, "use_reparameterization", True)))
 
 from flow_matching.path.beta_schedules import BetaSchedule
 from flow_matching.path.path import ProbPath
@@ -231,6 +627,17 @@ class MetricInducedGibbsProbPath(ProbPath):
         learnable_metric_dim: int = 0,
         learnable_metric_diag_eps: float = 1e-4,
         metric_interp_lambda: float = 0.0,
+        learnable_lut: bool = False,
+        lut_num_channels: int = 3,
+        lut_emb_dim: int = 1,
+        lut_share_across_channels: bool = False,
+        lut_renorm_to_init_norm: bool = False,
+        lut_bounded_residual_scale: bool = False,
+        lut_scale_baseline: float = 1.0,
+        lut_scale_epsilon: float = 0.25,
+        lut_init_method: str = "linear",
+        lut_init_noise_scale: float = 0.01,
+        use_normalized_distance: bool = False,
     ):
         super().__init__()
         self.metric_name = metric
@@ -256,6 +663,46 @@ class MetricInducedGibbsProbPath(ProbPath):
             p.requires_grad_(False)
 
         self.learnable_metric: Optional[MahalanobisTokenMetric] = None
+        self.learnable_lut: Optional[LearnableScalarLUT] = None
+        self._lut_num_channels = int(max(1, lut_num_channels))
+        self._lut_share_across_channels = bool(lut_share_across_channels)
+        self._lut_renorm_to_init_norm = bool(lut_renorm_to_init_norm)
+        self._lut_bounded_residual_scale = bool(lut_bounded_residual_scale)
+        self._lut_scale_baseline = float(lut_scale_baseline)
+        self._lut_scale_epsilon = float(lut_scale_epsilon)
+        self._lut_init_method = str(lut_init_method)
+        self._lut_init_noise_scale = float(lut_init_noise_scale)
+        self._use_normalized_distance = bool(use_normalized_distance)
+
+        if learnable_lut:
+            if learnable_metric_dim > 0:
+                raise ValueError("Cannot enable both learnable_metric and learnable_lut")
+            if metric not in {"lp", "euclidean"}:
+                raise ValueError(
+                    "learnable_lut currently supports only 'lp' or 'euclidean' metrics (absolute difference)"
+                )
+            num_channels = 1 if self._lut_share_across_channels else self._lut_num_channels
+            lut_module = LearnableScalarLUT(
+                num_channels=num_channels,
+                vocab_size=vocab_size,
+                emb_dim=int(lut_emb_dim),
+                embed_range="pm1" if embed_range == "pm1" else "unit",
+                device=device,
+                dtype=dtype,
+                lp_order=float(lp_order),
+                renormalize_to_init_norm=self._lut_renorm_to_init_norm,
+                bounded_residual_scale=self._lut_bounded_residual_scale,
+                scale_baseline=self._lut_scale_baseline,
+                scale_epsilon=self._lut_scale_epsilon,
+                init_method=self._lut_init_method,
+                init_noise_scale=self._lut_init_noise_scale,
+            )
+            if device is not None:
+                lut_module = lut_module.to(device=device, dtype=dtype)
+            else:
+                lut_module = lut_module.to(dtype=dtype)
+            self.learnable_lut = lut_module
+
         if learnable_metric_dim > 0:
             init_codes = self._build_metric_init_codes(
                 metric_dim=int(learnable_metric_dim),
@@ -279,6 +726,8 @@ class MetricInducedGibbsProbPath(ProbPath):
         self._cached_emb_weight: Optional[Tensor] = None  # reference to detect invalidation
         self._cached_metric_name: Optional[str] = None
         self._cached_lp_order: Optional[float] = None
+        # Cache for learned metric during eval (parameters frozen)
+        self._cached_learned_dist_table: Optional[Tensor] = None  # [K,K]
 
         self.metric_interp_lambda = 0.0
         self.set_metric_interpolation_lambda(metric_interp_lambda)
@@ -326,12 +775,25 @@ class MetricInducedGibbsProbPath(ProbPath):
     def _build_metric_init_codes(
         self, *, metric_dim: int, device: torch.device, dtype: torch.dtype
     ) -> Tensor:
-        base = self.embedding.weight.detach().to(device=device, dtype=dtype)
-        codes = torch.zeros(base.size(0), metric_dim, device=device, dtype=dtype)
-        dims = min(base.size(1), metric_dim)
-        if dims > 0:
-            codes[:, :dims] = base[:, :dims]
-        return codes
+        """
+        Initialize metric codes using Classical MDS from L_p distance structure.
+        
+        This provides a rank-d initialization that captures the intrinsic geometry
+        of the L_p metric, enabling faster convergence compared to rank-1 baseline.
+        
+        For metric_dim=8: Spearman correlation ≈ 0.82 with L_p distances.
+        """
+        from flow_matching.path.mds_init import initialize_metric_from_lp
+        
+        init_codes = initialize_metric_from_lp(
+            vocab_size=self.vocab_size,
+            metric_dim=metric_dim,
+            lp_order=self.lp_order,
+            embed_range=self.embed_range,
+            device=device,
+            dtype=dtype
+        )
+        return init_codes
 
     def _embedding_to_tokens(self, emb: Tensor) -> Tensor:
         if emb.shape[-1] < 1:
@@ -359,6 +821,11 @@ class MetricInducedGibbsProbPath(ProbPath):
 
     def set_metric_interpolation_lambda(self, value: float) -> None:
         clamped = float(min(max(value, 0.0), 1.0))
+        if self.learnable_lut is not None and clamped > 0.0:
+            logger.warning(
+                "Interpolation lambda has no effect when learnable_lut is enabled; forcing to 0."
+            )
+            clamped = 0.0
         self.metric_interp_lambda = clamped
 
     def get_metric_interpolation_lambda(self) -> float:
@@ -390,6 +857,10 @@ class MetricInducedGibbsProbPath(ProbPath):
         if self.learnable_metric is not None:
             yield from self.learnable_metric.parameters()
 
+    def lut_parameters(self) -> Iterable[nn.Parameter]:
+        if self.learnable_lut is not None:
+            yield from self.learnable_lut.parameters()
+
     # ---------- Distance on the embedding space ----------
     def _pairwise_dist(self, z_flat: Tensor, E: Tensor) -> Tensor:
         """
@@ -420,6 +891,9 @@ class MetricInducedGibbsProbPath(ProbPath):
 
     # ---------- Precompute and use fast token-indexed distances ----------
     def _get_base_distance_table(self, device: torch.device, dtype: torch.dtype) -> Tensor:
+        if self.learnable_lut is not None:
+            return self._build_lut_distance_table(device=device, dtype=dtype)
+
         E = self.embedding.weight
         metric_changed = (
             self._cached_metric_name != self.metric_name
@@ -449,6 +923,131 @@ class MetricInducedGibbsProbPath(ProbPath):
             base = base.to(device=device, dtype=dtype)
         return base
 
+    def _build_lut_distance_table(self, *, device: torch.device, dtype: torch.dtype) -> Tensor:
+        """Build pairwise distance table for LUT embeddings.
+        
+        When use_normalized_distance=True:
+            Uses normalized distance: \tilde d = ||E[v] - E[x_1]||_2 / \sqrt{m}
+            where m is the embedding dimension (for vector embeddings) or 1 (for scalar)
+        
+        Returns:
+            Tensor of shape [num_channels, vocab_size, vocab_size] containing
+            pairwise Lp distances between all token embeddings.
+        """
+        assert self.learnable_lut is not None
+        weight = self.learnable_lut()
+        if weight.device != device or weight.dtype != dtype:
+            weight = weight.to(device=device, dtype=dtype)
+        channels, vocab_size, emb_dim = weight.shape
+        
+        # Compute pairwise differences: [C, V, V, D]
+        diff = weight[:, :, None, :] - weight[:, None, :, :]  # [C, V, 1, D] - [C, 1, V, D]
+        
+        if self._use_normalized_distance:
+            # Normalized distance: ||diff||_2 / sqrt(m)
+            # For scalar embeddings (emb_dim=1): m=1, so just ||diff||_2
+            # For vector embeddings (emb_dim>1): m=emb_dim
+            m = float(emb_dim)  # embedding dimension as normalization factor
+            dist = torch.linalg.vector_norm(diff, dim=-1) / math.sqrt(m)  # [C, V, V]
+        else:
+            # Original Lp norm distance
+            p = self.learnable_lut.lp_order
+            if emb_dim == 1:
+                # Scalar case: simple absolute difference (backward compatible)
+                dist = diff.abs().squeeze(-1)  # [C, V, V]
+            elif p == 1.0:
+                # L1 norm: sum of absolute differences
+                dist = diff.abs().sum(dim=-1)  # [C, V, V]
+            elif p == 2.0:
+                # L2 norm: Euclidean distance
+                dist = (diff ** 2).sum(dim=-1).sqrt()  # [C, V, V]
+            else:
+                # General Lp norm
+                dist = (diff.abs() ** p).sum(dim=-1) ** (1.0 / p)  # [C, V, V]
+        
+        return dist
+
+    def _lut_channel_assignments(self, tokens: Tensor) -> Tensor:
+        assert self.learnable_lut is not None
+        channels = self.learnable_lut.num_channels
+        B, S = tokens.shape
+        if channels == 1:
+            return torch.zeros((B, S), device=tokens.device, dtype=torch.long)
+        if S % channels != 0:
+            raise ValueError(
+                f"Token sequence length {S} is not divisible by lut channels {channels}."
+            )
+        per_channel = S // channels
+        base = torch.arange(S, device=tokens.device) // per_channel
+        return base.unsqueeze(0).expand(B, -1)
+
+    def _lut_rows(self, dist_table: Tensor, token_indices: Tensor) -> Tensor:
+        assert self.learnable_lut is not None
+        channels = dist_table.shape[0]
+        B, S = token_indices.shape
+        channel_ids = self._lut_channel_assignments(token_indices).reshape(-1)
+        flat_tokens = token_indices.reshape(-1)
+        lookup = dist_table.reshape(channels * self.vocab_size, self.vocab_size)
+        combined = channel_ids * self.vocab_size + flat_tokens
+        rows = lookup.index_select(0, combined)
+        return rows.view(B, S, self.vocab_size)
+
+    def _lut_pair_distance(self, dist_table: Tensor, x_tokens: Tensor, x1_tokens: Tensor) -> Tensor:
+        assert self.learnable_lut is not None
+        channels = dist_table.shape[0]
+        assignments = self._lut_channel_assignments(x_tokens).reshape(-1)
+        flat = x_tokens.reshape(-1)
+        flat1 = x1_tokens.reshape(-1)
+        lookup = dist_table.reshape(channels * self.vocab_size, self.vocab_size)
+        combined = assignments * self.vocab_size + flat
+        rows = lookup.index_select(0, combined)
+        dist = rows.gather(1, flat1.view(-1, 1))
+        return dist.view(x_tokens.shape + (1,))
+
+    def precompute_learned_metric_table(
+        self,
+        *,
+        device: torch.device,
+        dtype: torch.dtype,
+        metric_module: Optional[MahalanobisTokenMetric] = None,
+    ) -> None:
+        if self.learnable_lut is not None:
+            logger.warning("precompute_learned_metric_table is a no-op when learnable_lut is enabled")
+            return
+        """Precompute and cache learned metric distance table for evaluation.
+        
+        This should be called once at the start of evaluation to avoid recomputing
+        the distance table at every timestep when the metric parameters are frozen.
+        
+        Args:
+            device: Device to store the cached table on
+            dtype: Data type for the cached table
+            metric_module: Optional metric module to use (e.g., EMA teacher).
+                If None, uses self.learnable_metric.
+        """
+        learned_table = self._learned_distance_table(
+            device=device,
+            dtype=dtype,
+            metric_module=metric_module,
+        )
+        if learned_table is not None:
+            self._cached_learned_dist_table = learned_table
+            logger.info(
+                f"Precomputed learned metric distance table [{learned_table.shape}] "
+                f"on {device} with dtype {dtype}"
+            )
+        else:
+            logger.warning("No learned metric to precompute (learnable_metric is None)")
+
+    def clear_learned_metric_cache(self) -> None:
+        """Clear the cached learned metric distance table.
+        
+        This should be called at the end of evaluation to free memory.
+        """
+        if self._cached_learned_dist_table is not None:
+            logger.info("Clearing cached learned metric distance table")
+            self._cached_learned_dist_table = None
+
     def _learned_distance_table(
         self,
         *,
@@ -469,15 +1068,28 @@ class MetricInducedGibbsProbPath(ProbPath):
         *,
         metric_module: Optional[MahalanobisTokenMetric] = None,
         cache_result: bool = True,
+        use_cache: bool = False,
     ) -> Tensor:
+        if self.learnable_lut is not None:
+            table = self._build_lut_distance_table(device=device, dtype=dtype)
+            return table
+
         base = self._get_base_distance_table(device=device, dtype=dtype)
 
         lam = float(self.metric_interp_lambda)
         learned_table = None
         if lam > 0.0:
-            learned_table = self._learned_distance_table(
-                device=device, dtype=dtype, metric_module=metric_module
-            )
+            # Try to use cached table first (eval optimization)
+            if use_cache and self._cached_learned_dist_table is not None:
+                learned_table = self._cached_learned_dist_table
+                # Ensure device/dtype match
+                if learned_table.device != device or learned_table.dtype != dtype:
+                    learned_table = learned_table.to(device=device, dtype=dtype)
+            else:
+                # Recompute (training or cache miss)
+                learned_table = self._learned_distance_table(
+                    device=device, dtype=dtype, metric_module=metric_module
+                )
 
         if learned_table is None or lam <= 0.0:
             dist = base
@@ -486,8 +1098,11 @@ class MetricInducedGibbsProbPath(ProbPath):
         else:
             dist = (1.0 - lam) * base + lam * learned_table
 
-        if cache_result and metric_module is None:
-            self._cached_dist_table = dist
+        # NOTE: We do NOT cache the learned metric distance table during training
+        # because the metric parameters are constantly changing. Caching would
+        # use stale distances. Only cache the baseline Lp table (done in _get_base_distance_table).
+        # if cache_result and metric_module is None:
+        #     self._cached_dist_table = dist
         return dist
 
     def distances_from_tokens(self, token_indices: Tensor) -> Tensor:
@@ -501,7 +1116,16 @@ class MetricInducedGibbsProbPath(ProbPath):
         assert token_indices.dtype in (torch.int32, torch.int64)
         device = token_indices.device
         dtype = self.embedding.weight.dtype
-        dist_table = self._build_distance_table(device=device, dtype=dtype)
+        
+        # LUT path: [C, K, K] distance table requires channel-aware indexing
+        if self.learnable_lut is not None:
+            dist_table = self._build_lut_distance_table(device=device, dtype=dtype)
+            return self._lut_rows(dist_table, token_indices)
+        
+        # Standard path: [K, K] distance table
+        dist_table = self._build_distance_table(
+            device=device, dtype=dtype, use_cache=True
+        )
         # Gather rows for each token index
         K = self.vocab_size
         B, S = token_indices.shape[0], token_indices.view(token_indices.shape[0], -1).shape[1]
@@ -538,9 +1162,13 @@ class MetricInducedGibbsProbPath(ProbPath):
             dtype=dtype,
             metric_module=metric_module,
             cache_result=metric_module is None,
+            use_cache=True,  # Always try cache (no-op during training)
         )
         flat_indices = x1_tokens.view(-1)
-        d = dist_table.index_select(0, flat_indices).view(x1_tokens.shape + (self.vocab_size,))
+        if self.learnable_lut is not None:
+            d = self._lut_rows(dist_table, x1_tokens)
+        else:
+            d = dist_table.index_select(0, flat_indices).view(x1_tokens.shape + (self.vocab_size,))
         if beta_values is not None:
             beta_t = beta_values
         elif beta_schedule is not None:
@@ -548,7 +1176,10 @@ class MetricInducedGibbsProbPath(ProbPath):
         else:
             beta_t, _ = self.beta(t)
         beta_t = beta_t.view(B, 1, 1)
-        logits = -beta_t * d
+        logits = -beta_t * d  # [B, S, K]
+        # Numerically stable log-sum-exp softmax (no clamp, fully backward compatible)
+        max_logits = logits.max(dim=-1, keepdim=True).values  # [B, S, 1]
+        logits = logits - max_logits
         return torch.softmax(logits, dim=-1)
 
     def pair_distance_tokens(self, x_tokens: Tensor, x1_tokens: Tensor) -> Tensor:
@@ -563,7 +1194,13 @@ class MetricInducedGibbsProbPath(ProbPath):
         assert x_tokens.shape == x1_tokens.shape
         device = x_tokens.device
         dtype = self.embedding.weight.dtype
-        dist_table = self._build_distance_table(device=device, dtype=dtype)
+        dist_table = self._build_distance_table(
+            device=device, dtype=dtype, use_cache=True
+        )
+        if self.learnable_lut is not None:
+            dist = self._lut_pair_distance(dist_table, x_tokens, x1_tokens)
+            return dist
+
         flat = x_tokens.view(-1)             # [N]
         flat1 = x1_tokens.view(-1)           # [N]
         rows = dist_table.index_select(0, flat)  # [N,K]

--- a/flow_matching/path/mixture.py
+++ b/flow_matching/path/mixture.py
@@ -8,6 +8,7 @@ import logging
 import math
 from typing import Iterable, Optional, Union
 
+import numpy as np
 import torch
 import torch.nn.functional as F
 import torch.nn as nn
@@ -55,13 +56,13 @@ class LearnableScalarLUT(nn.Module):
     ) -> None:
         super().__init__()
         if num_channels <= 0:
-            raise ValueError("num_channels must be positive")
+          raise ValueError("num_channels must be positive")
         if vocab_size <= 0:
-            raise ValueError("vocab_size must be positive")
+          raise ValueError("vocab_size must be positive")
         if emb_dim <= 0:
-            raise ValueError("emb_dim must be positive")
+          raise ValueError("emb_dim must be positive")
         if embed_range not in {"pm1", "unit"}:
-            raise ValueError("embed_range must be 'pm1' or 'unit'")
+          raise ValueError("embed_range must be 'pm1' or 'unit'")
 
         self.num_channels = int(num_channels)
         self.vocab_size = int(vocab_size)
@@ -144,7 +145,335 @@ class LearnableScalarLUT(nn.Module):
             weight[:, :, d] = base_repeated + noise
         
         return weight
-    
+
+
+def _softplus_inverse(y: Tensor) -> Tensor:
+    """Stable inverse of softplus for positive ``y``."""
+    return torch.log(torch.expm1(y))
+
+
+def _pava_1d(values: Tensor) -> Tensor:
+    """Pool Adjacent Violators Algorithm for 1D isotonic regression."""
+    v = values.detach().cpu().double().numpy()
+    n = v.shape[0]
+    y = v.copy()
+    w = np.ones(n, dtype=np.double)
+    i = 0
+    while i < n - 1:
+        if y[i] > y[i + 1]:
+            s = y[i] * w[i] + y[i + 1] * w[i + 1]
+            w_new = w[i] + w[i + 1]
+            y[i] = y[i + 1] = s / w_new
+            w[i] = w[i + 1] = w_new
+            j = i
+            while j > 0 and y[j - 1] > y[j]:
+                s = y[j - 1] * w[j - 1] + y[j] * w[j]
+                w_new = w[j - 1] + w[j]
+                y[j - 1] = y[j] = s / w_new
+                w[j - 1] = w[j] = w_new
+                j -= 1
+            i = j
+        else:
+            i += 1
+    return torch.from_numpy(y).to(values)
+
+
+def _pava_projection(values: Tensor) -> Tensor:
+    """Apply PAVA independently along the last dimension."""
+    if values.dim() == 1:
+        return _pava_1d(values)
+    out = torch.empty_like(values)
+    for idx in range(values.shape[0]):
+        out[idx] = _pava_1d(values[idx])
+    return out
+
+
+class _Line2DLUTParam(nn.Module):
+    """1D monotone curve embedded along a single direction."""
+
+    def __init__(
+        self,
+        *,
+        num_channels: int,
+        vocab_size: int,
+        embed_dim: int,
+        monotone_mode: str = "softplus",
+        min_step: float = 1e-4,
+    ) -> None:
+        super().__init__()
+        if vocab_size < 2:
+            raise ValueError("vocab_size must be >= 2 for line2d parameterization")
+        if monotone_mode != "softplus":
+            raise ValueError(f"Unsupported monotone_mode '{monotone_mode}' for line2d")
+        self.num_channels = num_channels
+        self.vocab_size = vocab_size
+        self.embed_dim = embed_dim
+        self.monotone_mode = monotone_mode
+        self.min_step = float(min_step)
+
+        direction_init = torch.randn(num_channels, embed_dim)
+        delta_init = torch.full((num_channels, vocab_size - 1), 0.01)
+        start_init = torch.zeros(num_channels)
+
+        self.direction_raw = nn.Parameter(direction_init)
+        self.delta_raw = nn.Parameter(_softplus_inverse(delta_init))
+        self.start = nn.Parameter(start_init)
+
+    def forward(self) -> Tensor:
+        direction = self._normalized_direction()  # [C, D]
+        delta = F.softplus(self.delta_raw) + self.min_step  # [C, V-1]
+        cumulative = torch.cumsum(delta, dim=-1)
+        tail = self.start.unsqueeze(-1) + cumulative
+        tau = torch.cat([self.start.unsqueeze(-1), tail], dim=-1)  # [C, V]
+        emb = direction.unsqueeze(1) * tau.unsqueeze(-1)  # [C, V, D]
+        return emb
+
+    def _normalized_direction(self) -> Tensor:
+        direction = self.direction_raw
+        return direction / (direction.norm(dim=-1, keepdim=True) + 1e-12)
+
+    @torch.no_grad()
+    def initialize_from_weight(self, weight: Tensor) -> None:
+        """Warm start from an existing [C,V,D] weight tensor."""
+        C, V, D = weight.shape
+        assert C == self.num_channels and V == self.vocab_size and D == self.embed_dim
+        device = weight.device
+        for c in range(C):
+            W = weight[c]  # [V, D]
+            # principal direction
+            try:
+                _, _, vh = torch.linalg.svd(W, full_matrices=False)
+                basis = vh[0]
+            except RuntimeError:
+                basis = W.mean(dim=0)
+            if basis.norm() < 1e-8:
+                basis = torch.zeros_like(basis)
+                basis[0] = 1.0
+            basis = basis / (basis.norm() + 1e-12)
+            coords = W @ basis  # [V]
+            tokens = torch.arange(V, device=device, dtype=coords.dtype)
+            # flip sign to align with increasing index
+            centered_tokens = tokens - tokens.mean()
+            centered_coords = coords - coords.mean()
+            cov = (centered_tokens * centered_coords).mean()
+            if cov < 0:
+                coords = -coords
+                basis = -basis
+            coords = _pava_projection(coords)
+            delta = coords[1:] - coords[:-1]
+            delta = torch.clamp(delta, min=self.min_step + 1e-6)
+            start_val = coords[0]
+            self.direction_raw.data[c] = basis
+            self.start.data[c] = start_val
+            target = delta - self.min_step
+            target = torch.clamp(target, min=1e-6)
+            self.delta_raw.data[c] = _softplus_inverse(target)
+
+
+class _Arc2DLUTParam(nn.Module):
+    """Monotone arc parameterization on a great/small circle."""
+
+    def __init__(
+        self,
+        *,
+        num_channels: int,
+        vocab_size: int,
+        embed_dim: int,
+        monotone_mode: str = "softplus",
+        radius: float = 1.0,
+        min_step: float = 1e-4,
+    ) -> None:
+        super().__init__()
+        if embed_dim < 2:
+            raise ValueError("arc2d parameterization requires embed_dim >= 2")
+        if vocab_size < 2:
+            raise ValueError("vocab_size must be >=2")
+        if monotone_mode != "softplus":
+            raise ValueError(f"Unsupported monotone_mode '{monotone_mode}' for arc2d")
+        self.num_channels = num_channels
+        self.vocab_size = vocab_size
+        self.embed_dim = embed_dim
+        self.min_step = float(min_step)
+        self.radius = nn.Parameter(torch.full((num_channels,), float(radius)))
+
+        basis_init = torch.randn(num_channels, embed_dim, 2)
+        delta_init = torch.full((num_channels, vocab_size - 1), 0.01)
+        theta_start = torch.zeros(num_channels)
+        self.basis_raw = nn.Parameter(basis_init)
+        self.delta_raw = nn.Parameter(_softplus_inverse(delta_init))
+        self.theta_start = nn.Parameter(theta_start)
+
+    def forward(self) -> Tensor:
+        basis = self._orthonormal_basis()  # [C, D, 2]
+        delta = F.softplus(self.delta_raw) + self.min_step  # [C, V-1]
+        theta = self.theta_start.unsqueeze(-1) + torch.cumsum(delta, dim=-1)
+        theta = torch.cat(
+            [self.theta_start.unsqueeze(-1), theta], dim=-1
+        )  # prepend start
+        cos_t = torch.cos(theta)
+        sin_t = torch.sin(theta)
+        coords = torch.stack([cos_t, sin_t], dim=-1)  # [C, V, 2]
+        coords = coords * self.radius.view(self.num_channels, 1, 1)
+        emb = torch.einsum("cdk,cvk->cvd", basis, coords)
+        return emb
+
+    def _orthonormal_basis(self) -> Tensor:
+        q, _ = torch.linalg.qr(self.basis_raw, mode="reduced")
+        return q
+
+    @torch.no_grad()
+    def initialize_from_weight(self, weight: Tensor) -> None:
+        C, V, D = weight.shape
+        assert C == self.num_channels and V == self.vocab_size and D == self.embed_dim
+        device = weight.device
+        for c in range(C):
+            W = weight[c]  # [V, D]
+            try:
+                _, _, vh = torch.linalg.svd(W, full_matrices=False)
+                basis = vh[:2].T  # [D,2]
+            except RuntimeError:
+                basis = torch.zeros(D, 2, device=device, dtype=W.dtype)
+                basis[:, 0] = torch.randn(D, device=device, dtype=W.dtype)
+                basis[:, 0] = basis[:, 0] / (basis[:, 0].norm() + 1e-12)
+                basis[:, 1] = torch.randn(D, device=device, dtype=W.dtype)
+                basis[:, 1] -= (
+                    basis[:, 0]
+                    * (basis[:, 1] * basis[:, 0]).sum()
+                )
+                basis[:, 1] = basis[:, 1] / (basis[:, 1].norm() + 1e-12)
+            coords = W @ basis  # [V,2]
+            radius_vals = torch.linalg.vector_norm(coords, dim=-1)
+            r = radius_vals.median()
+            radius_vals = torch.clamp(radius_vals, min=1e-6)
+            unit = coords / radius_vals.unsqueeze(-1)
+            theta = torch.atan2(unit[:, 1], unit[:, 0])
+            theta_np = theta.detach().cpu().numpy()
+            theta_np = np.unwrap(theta_np)
+            theta_tensor = torch.from_numpy(theta_np).to(device=device, dtype=W.dtype)
+            tokens = torch.arange(V, device=device, dtype=W.dtype)
+            centered_tokens = tokens - tokens.mean()
+            centered_theta = theta_tensor - theta_tensor.mean()
+            cov = (centered_tokens * centered_theta).mean()
+            if cov < 0:
+                theta_tensor = -theta_tensor
+                basis[:, 0] = -basis[:, 0]
+            theta_tensor = _pava_projection(theta_tensor)
+            delta = theta_tensor[1:] - theta_tensor[:-1]
+            delta = torch.clamp(delta, min=self.min_step + 1e-6)
+            target = delta - self.min_step
+            target = torch.clamp(target, min=1e-6)
+            self.basis_raw.data[c] = basis
+            self.radius.data[c] = r
+            self.theta_start.data[c] = theta_tensor[0]
+            self.delta_raw.data[c] = _softplus_inverse(target)
+
+
+class LearnableParametricLUT(nn.Module):
+    """Parametric LUT with geometric constraints (line/arc)."""
+
+    def __init__(
+        self,
+        *,
+        num_channels: int,
+        vocab_size: int,
+        embed_dim: int,
+        param_mode: str = "line2d",
+        monotone_mode: str = "softplus",
+        embed_range: str = "pm1",
+        device: Optional[torch.device],
+        dtype: torch.dtype,
+        arc_radius: float = 1.0,
+    ) -> None:
+        super().__init__()
+        self.param_mode = param_mode
+        if param_mode == "line2d":
+            self.param = _Line2DLUTParam(
+                num_channels=num_channels,
+                vocab_size=vocab_size,
+                embed_dim=embed_dim,
+                monotone_mode=monotone_mode,
+            )
+        elif param_mode == "arc2d":
+            self.param = _Arc2DLUTParam(
+                num_channels=num_channels,
+                vocab_size=vocab_size,
+                embed_dim=embed_dim,
+                monotone_mode=monotone_mode,
+                radius=arc_radius,
+            )
+        else:
+            raise ValueError(f"Unknown param_mode '{param_mode}'")
+        if device is not None or dtype is not None:
+            self.to(device=device, dtype=dtype)
+        if self.param_mode == "arc2d":
+            base_weight = self._default_arc_baseline(
+                num_channels,
+                vocab_size,
+                embed_dim,
+                dtype=dtype,
+                device=device,
+                radius=arc_radius,
+            )
+        else:
+            base_weight = self._default_baseline(
+                num_channels,
+                vocab_size,
+                embed_dim,
+                embed_range,
+                dtype=dtype,
+                device=device,
+            )
+        self.initialize_from_weight(base_weight)
+
+    def forward(self) -> Tensor:
+        return self.param()
+
+    def initialize_from_weight(self, weight: Tensor) -> None:
+        self.param.initialize_from_weight(weight)
+
+    @property
+    def weight(self) -> Tensor:
+        return self.forward()
+
+    @staticmethod
+    def _default_baseline(
+        num_channels: int,
+        vocab_size: int,
+        embed_dim: int,
+        embed_range: str,
+        *,
+        dtype: torch.dtype,
+        device: Optional[torch.device],
+    ) -> Tensor:
+        base = torch.zeros(num_channels, vocab_size, embed_dim, dtype=dtype)
+        if embed_range == "pm1":
+            linear = torch.linspace(-1.0, 1.0, steps=vocab_size, dtype=dtype)
+        else:
+            linear = torch.linspace(0.0, 1.0, steps=vocab_size, dtype=dtype)
+        for c in range(num_channels):
+            base[c, :, 0] = linear
+        if device is not None:
+            base = base.to(device=device)
+        return base
+
+    @staticmethod
+    def _default_arc_baseline(
+        num_channels: int,
+        vocab_size: int,
+        embed_dim: int,
+        *,
+        dtype: torch.dtype,
+        device: Optional[torch.device],
+        radius: float = 1.0,
+    ) -> Tensor:
+        base = torch.zeros(num_channels, vocab_size, embed_dim, dtype=dtype)
+        theta = torch.linspace(0.0, math.pi, steps=vocab_size, dtype=dtype)
+        base[:, :, 0] = torch.cos(theta) * radius
+        if embed_dim > 1:
+            base[:, :, 1] = torch.sin(theta) * radius
+        if device is not None:
+            base = base.to(device=device)
+        return base
     def _linear_init_base(self) -> Tensor:
         """Initialize base LUT (without noise) for renormalization target.
         
@@ -644,6 +973,9 @@ class MetricInducedGibbsProbPath(ProbPath):
         lut_init_noise_scale: float = 0.01,
         use_normalized_distance: bool = False,
         lut_cosine_scale: float = 1.0,
+        lut_param_mode: Optional[str] = None,
+        lut_monotone_mode: str = "softplus",
+        lut_arc_radius: float = 1.0,
     ):
         super().__init__()
         self.metric_name = metric
@@ -669,18 +1001,22 @@ class MetricInducedGibbsProbPath(ProbPath):
             p.requires_grad_(False)
 
         self.learnable_metric: Optional[MahalanobisTokenMetric] = None
-        self.learnable_lut: Optional[LearnableScalarLUT] = None
+        self.learnable_lut: Optional[nn.Module] = None
         self._lut_num_channels = int(max(1, lut_num_channels))
         self._lut_share_across_channels = bool(lut_share_across_channels)
         self._lut_renorm_to_init_norm = bool(lut_renorm_to_init_norm)
         self._lut_bounded_residual_scale = bool(lut_bounded_residual_scale)
         self._lut_scale_baseline = float(lut_scale_baseline)
         self._lut_scale_epsilon = float(lut_scale_epsilon)
-        self._lut_init_method = str(lut_init_method)
-        self._lut_init_noise_scale = float(lut_init_noise_scale)
         self._use_normalized_distance = bool(use_normalized_distance)
         # Optional cosine metric scale (applied to 1-cos distance)
         self._lut_cosine_scale: float = float(lut_cosine_scale)
+        lut_param_mode = lut_param_mode or None
+        if lut_param_mode is not None and lut_param_mode.lower() in {"none", "free"}:
+            lut_param_mode = None
+        self._lut_param_mode = lut_param_mode
+        self._lut_monotone_mode = str(lut_monotone_mode)
+        self._lut_arc_radius = float(lut_arc_radius)
 
         if learnable_lut:
             if learnable_metric_dim > 0:
@@ -695,21 +1031,34 @@ class MetricInducedGibbsProbPath(ProbPath):
                     self._lut_cosine_scale,
                 )
             num_channels = 1 if self._lut_share_across_channels else self._lut_num_channels
-            lut_module = LearnableScalarLUT(
-                num_channels=num_channels,
-                vocab_size=vocab_size,
-                emb_dim=int(lut_emb_dim),
-                embed_range="pm1" if embed_range == "pm1" else "unit",
-                device=device,
-                dtype=dtype,
-                lp_order=float(lp_order),
-                renormalize_to_init_norm=self._lut_renorm_to_init_norm,
-                bounded_residual_scale=self._lut_bounded_residual_scale,
-                scale_baseline=self._lut_scale_baseline,
-                scale_epsilon=self._lut_scale_epsilon,
-                init_method=self._lut_init_method,
-                init_noise_scale=self._lut_init_noise_scale,
-            )
+            if self._lut_param_mode is not None:
+                lut_module = LearnableParametricLUT(
+                    num_channels=num_channels,
+                    vocab_size=vocab_size,
+                    embed_dim=int(lut_emb_dim),
+                    param_mode=self._lut_param_mode,
+                    monotone_mode=self._lut_monotone_mode,
+                    embed_range="pm1" if embed_range == "pm1" else "unit",
+                    device=device,
+                    dtype=dtype,
+                    arc_radius=self._lut_arc_radius,
+                )
+            else:
+                lut_module = LearnableScalarLUT(
+                    num_channels=num_channels,
+                    vocab_size=vocab_size,
+                    emb_dim=int(lut_emb_dim),
+                    embed_range="pm1" if embed_range == "pm1" else "unit",
+                    device=device,
+                    dtype=dtype,
+                    lp_order=float(lp_order),
+                    renormalize_to_init_norm=self._lut_renorm_to_init_norm,
+                    bounded_residual_scale=self._lut_bounded_residual_scale,
+                    scale_baseline=self._lut_scale_baseline,
+                    scale_epsilon=self._lut_scale_epsilon,
+                    init_method=self._lut_init_method,
+                    init_noise_scale=self._lut_init_noise_scale,
+                )
             if device is not None:
                 lut_module = lut_module.to(device=device, dtype=dtype)
             else:

--- a/flow_matching/path/mixture.py
+++ b/flow_matching/path/mixture.py
@@ -72,6 +72,11 @@ class LearnableScalarLUT(nn.Module):
         # Set initialization parameters before calling _init_weight
         self.init_method = str(init_method)
         self.init_noise_scale = float(init_noise_scale)
+        if self.init_method == "small_noise_qr" and self.emb_dim > self.vocab_size:
+            raise ValueError(
+                "small_noise_qr initialization requires emb_dim <= vocab_size "
+                f"(got emb_dim={self.emb_dim}, vocab_size={self.vocab_size})"
+            )
 
         weight = self._init_weight()
         if device is not None:
@@ -638,6 +643,7 @@ class MetricInducedGibbsProbPath(ProbPath):
         lut_init_method: str = "linear",
         lut_init_noise_scale: float = 0.01,
         use_normalized_distance: bool = False,
+        lut_cosine_scale: float = 1.0,
     ):
         super().__init__()
         self.metric_name = metric
@@ -673,13 +679,20 @@ class MetricInducedGibbsProbPath(ProbPath):
         self._lut_init_method = str(lut_init_method)
         self._lut_init_noise_scale = float(lut_init_noise_scale)
         self._use_normalized_distance = bool(use_normalized_distance)
+        # Optional cosine metric scale (applied to 1-cos distance)
+        self._lut_cosine_scale: float = float(lut_cosine_scale)
 
         if learnable_lut:
             if learnable_metric_dim > 0:
                 raise ValueError("Cannot enable both learnable_metric and learnable_lut")
-            if metric not in {"lp", "euclidean"}:
+            if metric not in {"lp", "euclidean", "cosine"}:
                 raise ValueError(
-                    "learnable_lut currently supports only 'lp' or 'euclidean' metrics (absolute difference)"
+                    "learnable_lut supports metrics: 'lp', 'euclidean', or 'cosine'"
+                )
+            if metric == "cosine":
+                logger.info(
+                    "Initializing learnable LUT with cosine distance (scale=%.3f)",
+                    self._lut_cosine_scale,
                 )
             num_channels = 1 if self._lut_share_across_channels else self._lut_num_channels
             lut_module = LearnableScalarLUT(
@@ -728,6 +741,8 @@ class MetricInducedGibbsProbPath(ProbPath):
         self._cached_lp_order: Optional[float] = None
         # Cache for learned metric during eval (parameters frozen)
         self._cached_learned_dist_table: Optional[Tensor] = None  # [K,K]
+        # Cache for learnable LUT distance tables during eval
+        self._cached_lut_dist_table: Optional[Tensor] = None  # [C,K,K]
 
         self.metric_interp_lambda = 0.0
         self.set_metric_interpolation_lambda(metric_interp_lambda)
@@ -939,10 +954,17 @@ class MetricInducedGibbsProbPath(ProbPath):
         if weight.device != device or weight.dtype != dtype:
             weight = weight.to(device=device, dtype=dtype)
         channels, vocab_size, emb_dim = weight.shape
-        
+
+        # Cosine metric: compute 1 - cosine similarity on unit-normalized embeddings
+        if self.metric_name == "cosine":
+            wn = F.normalize(weight, p=2, dim=-1, eps=1e-12)  # [C,V,D]
+            sim = torch.matmul(wn, wn.transpose(-1, -2))      # [C,V,V]
+            dist = (1.0 - sim) * float(self._lut_cosine_scale)
+            return dist
+
         # Compute pairwise differences: [C, V, V, D]
         diff = weight[:, :, None, :] - weight[:, None, :, :]  # [C, V, 1, D] - [C, 1, V, D]
-        
+
         if self._use_normalized_distance:
             # Normalized distance: ||diff||_2 / sqrt(m)
             # For scalar embeddings (emb_dim=1): m=1, so just ||diff||_2
@@ -1004,6 +1026,36 @@ class MetricInducedGibbsProbPath(ProbPath):
         dist = rows.gather(1, flat1.view(-1, 1))
         return dist.view(x_tokens.shape + (1,))
 
+    def precompute_lut_distance_table(
+        self,
+        *,
+        device: torch.device,
+        dtype: torch.dtype,
+    ) -> None:
+        """Precompute and cache the learnable LUT distance table for evaluation.
+
+        This should be called at the start of evaluation when LUT parameters are
+        frozen so that repeated sampling steps can reuse the cached distances.
+        """
+        if self.learnable_lut is None:
+            logger.warning("precompute_lut_distance_table is a no-op (learnable_lut is None)")
+            return
+        with torch.no_grad():
+            table = self._build_lut_distance_table(device=device, dtype=dtype).detach()
+        self._cached_lut_dist_table = table
+        logger.info(
+            "Precomputed learnable LUT distance table [%s] on %s with dtype %s",
+            tuple(table.shape),
+            device,
+            dtype,
+        )
+
+    def clear_lut_cache(self) -> None:
+        """Clear the cached LUT distance table (if any)."""
+        if self._cached_lut_dist_table is not None:
+            logger.info("Clearing cached learnable LUT distance table")
+            self._cached_lut_dist_table = None
+
     def precompute_learned_metric_table(
         self,
         *,
@@ -1011,20 +1063,20 @@ class MetricInducedGibbsProbPath(ProbPath):
         dtype: torch.dtype,
         metric_module: Optional[MahalanobisTokenMetric] = None,
     ) -> None:
-        if self.learnable_lut is not None:
-            logger.warning("precompute_learned_metric_table is a no-op when learnable_lut is enabled")
-            return
         """Precompute and cache learned metric distance table for evaluation.
-        
-        This should be called once at the start of evaluation to avoid recomputing
-        the distance table at every timestep when the metric parameters are frozen.
-        
+
         Args:
-            device: Device to store the cached table on
-            dtype: Data type for the cached table
-            metric_module: Optional metric module to use (e.g., EMA teacher).
-                If None, uses self.learnable_metric.
+            device: Device to store the cached table on.
+            dtype: Data type for the cached table.
+            metric_module: Optional override for the metric (e.g., EMA teacher).
+                When omitted, uses ``self.learnable_metric``.
         """
+        if self.learnable_lut is not None:
+            logger.warning(
+                "precompute_learned_metric_table is intended for learnable metrics; "
+                "call precompute_lut_distance_table when using a learnable LUT instead."
+            )
+            return
         learned_table = self._learned_distance_table(
             device=device,
             dtype=dtype,
@@ -1071,7 +1123,12 @@ class MetricInducedGibbsProbPath(ProbPath):
         use_cache: bool = False,
     ) -> Tensor:
         if self.learnable_lut is not None:
-            table = self._build_lut_distance_table(device=device, dtype=dtype)
+            if use_cache and self._cached_lut_dist_table is not None:
+                table = self._cached_lut_dist_table
+                if table.device != device or table.dtype != dtype:
+                    table = table.to(device=device, dtype=dtype)
+            else:
+                table = self._build_lut_distance_table(device=device, dtype=dtype)
             return table
 
         base = self._get_base_distance_table(device=device, dtype=dtype)
@@ -1119,7 +1176,9 @@ class MetricInducedGibbsProbPath(ProbPath):
         
         # LUT path: [C, K, K] distance table requires channel-aware indexing
         if self.learnable_lut is not None:
-            dist_table = self._build_lut_distance_table(device=device, dtype=dtype)
+            dist_table = self._build_distance_table(
+                device=device, dtype=dtype, use_cache=True
+            )
             return self._lut_rows(dist_table, token_indices)
         
         # Standard path: [K, K] distance table

--- a/flow_matching/path/mixture.py
+++ b/flow_matching/path/mixture.py
@@ -403,14 +403,6 @@ class MetricInducedGibbsProbPath(ProbPath):
         d_beta_t = self.c * self.a * (y ** (self.a - 1.0)) * dy_dt
         return beta_t, d_beta_t
 
-    def learnable_parameters(self) -> Iterable[nn.Parameter]:
-        params: list[nn.Parameter] = []
-        if isinstance(self.beta_schedule, nn.Module):
-            params.extend(self.beta_schedule.parameters())
-        if self.learnable_metric is not None:
-            params.extend(self.learnable_metric.parameters())
-        return params
-
     def schedule_parameters(self) -> Iterable[nn.Parameter]:
         if isinstance(self.beta_schedule, nn.Module):
             yield from self.beta_schedule.parameters()
@@ -482,6 +474,35 @@ class MetricInducedGibbsProbPath(ProbPath):
             base = base.to(device=device, dtype=dtype)
         return base
 
+    def _scaled_learned_distance_table(
+        self,
+        *,
+        device: torch.device,
+        dtype: torch.dtype,
+        metric_module: Optional[MahalanobisTokenMetric] = None,
+    ) -> Optional[Tensor]:
+        module = metric_module if metric_module is not None else self.learnable_metric
+        if module is None:
+            return None
+
+        learned_table = module.pairwise_distance_table(device=device, dtype=dtype)
+        base_scale = self._base_dist_offdiag_scale
+        if base_scale is not None and base_scale > 0.0:
+            try:
+                learned_scale = _offdiag_mad_float(learned_table)
+            except ValueError:
+                learned_scale = None
+            if learned_scale is not None and learned_scale > 0.0:
+                scale_value = base_scale / max(learned_scale, 1e-12)
+                if math.isfinite(scale_value) and scale_value > 0.0:
+                    scale_tensor = torch.as_tensor(
+                        scale_value,
+                        device=learned_table.device,
+                        dtype=learned_table.dtype,
+                    )
+                    learned_table = learned_table * scale_tensor
+        return learned_table
+
     def _build_distance_table(
         self,
         device: torch.device,
@@ -492,26 +513,12 @@ class MetricInducedGibbsProbPath(ProbPath):
     ) -> Tensor:
         base = self._get_base_distance_table(device=device, dtype=dtype)
 
-        module = metric_module if metric_module is not None else self.learnable_metric
-        learned_table = None
         lam = float(self.metric_interp_lambda)
-        if module is not None and lam > 0.0:
-            learned_table = module.pairwise_distance_table(device=device, dtype=dtype)
-            base_scale = self._base_dist_offdiag_scale
-            if base_scale is not None and base_scale > 0.0:
-                try:
-                    learned_scale = _offdiag_mad_float(learned_table)
-                except ValueError:
-                    learned_scale = None
-                if learned_scale is not None and learned_scale > 0.0:
-                    scale_value = base_scale / max(learned_scale, 1e-12)
-                    if math.isfinite(scale_value) and scale_value > 0.0:
-                        scale_tensor = torch.as_tensor(
-                            scale_value,
-                            device=learned_table.device,
-                            dtype=learned_table.dtype,
-                        )
-                        learned_table = learned_table * scale_tensor
+        learned_table = None
+        if lam > 0.0:
+            learned_table = self._scaled_learned_distance_table(
+                device=device, dtype=dtype, metric_module=metric_module
+            )
 
         if learned_table is None or lam <= 0.0:
             dist = base

--- a/flow_matching/path/mixture.py
+++ b/flow_matching/path/mixture.py
@@ -24,6 +24,37 @@ def _inv_softplus_tensor(x: Tensor) -> Tensor:
     return torch.log(torch.expm1(x))
 
 
+def _linear_lut_baseline(
+    *,
+    num_channels: int,
+    vocab_size: int,
+    emb_dim: int,
+    embed_range: str,
+    dtype: Optional[torch.dtype] = None,
+    device: Optional[torch.device] = None,
+) -> Tensor:
+    """Deterministic linear baseline used by learnable LUTs."""
+    if dtype is None:
+        dtype = torch.get_default_dtype()
+    linspace_kwargs = {"dtype": dtype}
+    if device is not None:
+        linspace_kwargs["device"] = device
+    if embed_range == "pm1":
+        values = torch.linspace(-1.0, 1.0, steps=vocab_size, **linspace_kwargs)
+    else:
+        values = torch.linspace(0.0, 1.0, steps=vocab_size, **linspace_kwargs)
+    base = torch.zeros(
+        num_channels,
+        vocab_size,
+        emb_dim,
+        dtype=dtype,
+        device=device,
+    )
+    base_pattern = values.unsqueeze(0).expand(num_channels, -1)  # [C, V]
+    base[:] = base_pattern.unsqueeze(-1)
+    return base
+
+
 class LearnableScalarLUT(nn.Module):
     """Per-channel learnable embedding lookup table.
 
@@ -121,378 +152,27 @@ class LearnableScalarLUT(nn.Module):
 
     def _linear_init(self) -> Tensor:
         """Initialize LUT with linearly spaced values along each dimension.
-        
+
         Returns:
             Tensor of shape [num_channels, vocab_size, emb_dim]
         """
-        # Initialize each dimension independently with linspace + small noise
-        weight = torch.zeros(self.num_channels, self.vocab_size, self.emb_dim)
-        
-        for d in range(self.emb_dim):
-            if self.embed_range == "pm1":
-                base = torch.linspace(-1.0, 1.0, steps=self.vocab_size)
-            else:
-                base = torch.linspace(0.0, 1.0, steps=self.vocab_size)
-            
-            # Repeat base pattern for all channels
-            base_repeated = base.repeat(self.num_channels, 1)  # [C, V]
-            
-            # Add small Gaussian noise to break channel symmetry
-            # σ = 1e-3 is ~7.8x smaller than linear step size (≈0.00784 for V=256)
-            # This preserves monotonicity (P(inversion) ≈ 0) while decorrelating RGB
-            noise = torch.randn_like(base_repeated) * 1e-3
-            
-            weight[:, :, d] = base_repeated + noise
-        
-        return weight
+        weight = _linear_lut_baseline(
+            num_channels=self.num_channels,
+            vocab_size=self.vocab_size,
+            emb_dim=self.emb_dim,
+            embed_range=self.embed_range,
+        )
+        noise = torch.randn_like(weight) * 1e-3
+        return weight + noise
 
-
-def _softplus_inverse(y: Tensor) -> Tensor:
-    """Stable inverse of softplus for positive ``y``."""
-    return torch.log(torch.expm1(y))
-
-
-def _pava_1d(values: Tensor) -> Tensor:
-    """Pool Adjacent Violators Algorithm for 1D isotonic regression."""
-    v = values.detach().cpu().double().numpy()
-    n = v.shape[0]
-    y = v.copy()
-    w = np.ones(n, dtype=np.double)
-    i = 0
-    while i < n - 1:
-        if y[i] > y[i + 1]:
-            s = y[i] * w[i] + y[i + 1] * w[i + 1]
-            w_new = w[i] + w[i + 1]
-            y[i] = y[i + 1] = s / w_new
-            w[i] = w[i + 1] = w_new
-            j = i
-            while j > 0 and y[j - 1] > y[j]:
-                s = y[j - 1] * w[j - 1] + y[j] * w[j]
-                w_new = w[j - 1] + w[j]
-                y[j - 1] = y[j] = s / w_new
-                w[j - 1] = w[j] = w_new
-                j -= 1
-            i = j
-        else:
-            i += 1
-    return torch.from_numpy(y).to(values)
-
-
-def _pava_projection(values: Tensor) -> Tensor:
-    """Apply PAVA independently along the last dimension."""
-    if values.dim() == 1:
-        return _pava_1d(values)
-    out = torch.empty_like(values)
-    for idx in range(values.shape[0]):
-        out[idx] = _pava_1d(values[idx])
-    return out
-
-
-class _Line2DLUTParam(nn.Module):
-    """1D monotone curve embedded along a single direction."""
-
-    def __init__(
-        self,
-        *,
-        num_channels: int,
-        vocab_size: int,
-        embed_dim: int,
-        monotone_mode: str = "softplus",
-        min_step: float = 1e-4,
-    ) -> None:
-        super().__init__()
-        if vocab_size < 2:
-            raise ValueError("vocab_size must be >= 2 for line2d parameterization")
-        if monotone_mode != "softplus":
-            raise ValueError(f"Unsupported monotone_mode '{monotone_mode}' for line2d")
-        self.num_channels = num_channels
-        self.vocab_size = vocab_size
-        self.embed_dim = embed_dim
-        self.monotone_mode = monotone_mode
-        self.min_step = float(min_step)
-
-        direction_init = torch.randn(num_channels, embed_dim)
-        delta_init = torch.full((num_channels, vocab_size - 1), 0.01)
-        start_init = torch.zeros(num_channels)
-
-        self.direction_raw = nn.Parameter(direction_init)
-        self.delta_raw = nn.Parameter(_softplus_inverse(delta_init))
-        self.start = nn.Parameter(start_init)
-
-    def forward(self) -> Tensor:
-        direction = self._normalized_direction()  # [C, D]
-        delta = F.softplus(self.delta_raw) + self.min_step  # [C, V-1]
-        cumulative = torch.cumsum(delta, dim=-1)
-        tail = self.start.unsqueeze(-1) + cumulative
-        tau = torch.cat([self.start.unsqueeze(-1), tail], dim=-1)  # [C, V]
-        emb = direction.unsqueeze(1) * tau.unsqueeze(-1)  # [C, V, D]
-        return emb
-
-    def _normalized_direction(self) -> Tensor:
-        direction = self.direction_raw
-        return direction / (direction.norm(dim=-1, keepdim=True) + 1e-12)
-
-    @torch.no_grad()
-    def initialize_from_weight(self, weight: Tensor) -> None:
-        """Warm start from an existing [C,V,D] weight tensor."""
-        C, V, D = weight.shape
-        assert C == self.num_channels and V == self.vocab_size and D == self.embed_dim
-        device = weight.device
-        for c in range(C):
-            W = weight[c]  # [V, D]
-            # principal direction
-            try:
-                _, _, vh = torch.linalg.svd(W, full_matrices=False)
-                basis = vh[0]
-            except RuntimeError:
-                basis = W.mean(dim=0)
-            if basis.norm() < 1e-8:
-                basis = torch.zeros_like(basis)
-                basis[0] = 1.0
-            basis = basis / (basis.norm() + 1e-12)
-            coords = W @ basis  # [V]
-            tokens = torch.arange(V, device=device, dtype=coords.dtype)
-            # flip sign to align with increasing index
-            centered_tokens = tokens - tokens.mean()
-            centered_coords = coords - coords.mean()
-            cov = (centered_tokens * centered_coords).mean()
-            if cov < 0:
-                coords = -coords
-                basis = -basis
-            coords = _pava_projection(coords)
-            delta = coords[1:] - coords[:-1]
-            delta = torch.clamp(delta, min=self.min_step + 1e-6)
-            start_val = coords[0]
-            self.direction_raw.data[c] = basis
-            self.start.data[c] = start_val
-            target = delta - self.min_step
-            target = torch.clamp(target, min=1e-6)
-            self.delta_raw.data[c] = _softplus_inverse(target)
-
-
-class _Arc2DLUTParam(nn.Module):
-    """Monotone arc parameterization on a great/small circle."""
-
-    def __init__(
-        self,
-        *,
-        num_channels: int,
-        vocab_size: int,
-        embed_dim: int,
-        monotone_mode: str = "softplus",
-        radius: float = 1.0,
-        min_step: float = 1e-4,
-    ) -> None:
-        super().__init__()
-        if embed_dim < 2:
-            raise ValueError("arc2d parameterization requires embed_dim >= 2")
-        if vocab_size < 2:
-            raise ValueError("vocab_size must be >=2")
-        if monotone_mode != "softplus":
-            raise ValueError(f"Unsupported monotone_mode '{monotone_mode}' for arc2d")
-        self.num_channels = num_channels
-        self.vocab_size = vocab_size
-        self.embed_dim = embed_dim
-        self.min_step = float(min_step)
-        self.radius = nn.Parameter(torch.full((num_channels,), float(radius)))
-
-        basis_init = torch.randn(num_channels, embed_dim, 2)
-        delta_init = torch.full((num_channels, vocab_size - 1), 0.01)
-        theta_start = torch.zeros(num_channels)
-        self.basis_raw = nn.Parameter(basis_init)
-        self.delta_raw = nn.Parameter(_softplus_inverse(delta_init))
-        self.theta_start = nn.Parameter(theta_start)
-
-    def forward(self) -> Tensor:
-        basis = self._orthonormal_basis()  # [C, D, 2]
-        delta = F.softplus(self.delta_raw) + self.min_step  # [C, V-1]
-        theta = self.theta_start.unsqueeze(-1) + torch.cumsum(delta, dim=-1)
-        theta = torch.cat(
-            [self.theta_start.unsqueeze(-1), theta], dim=-1
-        )  # prepend start
-        cos_t = torch.cos(theta)
-        sin_t = torch.sin(theta)
-        coords = torch.stack([cos_t, sin_t], dim=-1)  # [C, V, 2]
-        coords = coords * self.radius.view(self.num_channels, 1, 1)
-        emb = torch.einsum("cdk,cvk->cvd", basis, coords)
-        return emb
-
-    def _orthonormal_basis(self) -> Tensor:
-        q, _ = torch.linalg.qr(self.basis_raw, mode="reduced")
-        return q
-
-    @torch.no_grad()
-    def initialize_from_weight(self, weight: Tensor) -> None:
-        C, V, D = weight.shape
-        assert C == self.num_channels and V == self.vocab_size and D == self.embed_dim
-        device = weight.device
-        for c in range(C):
-            W = weight[c]  # [V, D]
-            try:
-                _, _, vh = torch.linalg.svd(W, full_matrices=False)
-                basis = vh[:2].T  # [D,2]
-            except RuntimeError:
-                basis = torch.zeros(D, 2, device=device, dtype=W.dtype)
-                basis[:, 0] = torch.randn(D, device=device, dtype=W.dtype)
-                basis[:, 0] = basis[:, 0] / (basis[:, 0].norm() + 1e-12)
-                basis[:, 1] = torch.randn(D, device=device, dtype=W.dtype)
-                basis[:, 1] -= (
-                    basis[:, 0]
-                    * (basis[:, 1] * basis[:, 0]).sum()
-                )
-                basis[:, 1] = basis[:, 1] / (basis[:, 1].norm() + 1e-12)
-            coords = W @ basis  # [V,2]
-            radius_vals = torch.linalg.vector_norm(coords, dim=-1)
-            r = radius_vals.median()
-            radius_vals = torch.clamp(radius_vals, min=1e-6)
-            unit = coords / radius_vals.unsqueeze(-1)
-            theta = torch.atan2(unit[:, 1], unit[:, 0])
-            theta_np = theta.detach().cpu().numpy()
-            theta_np = np.unwrap(theta_np)
-            theta_tensor = torch.from_numpy(theta_np).to(device=device, dtype=W.dtype)
-            tokens = torch.arange(V, device=device, dtype=W.dtype)
-            centered_tokens = tokens - tokens.mean()
-            centered_theta = theta_tensor - theta_tensor.mean()
-            cov = (centered_tokens * centered_theta).mean()
-            if cov < 0:
-                theta_tensor = -theta_tensor
-                basis[:, 0] = -basis[:, 0]
-            theta_tensor = _pava_projection(theta_tensor)
-            delta = theta_tensor[1:] - theta_tensor[:-1]
-            delta = torch.clamp(delta, min=self.min_step + 1e-6)
-            target = delta - self.min_step
-            target = torch.clamp(target, min=1e-6)
-            self.basis_raw.data[c] = basis
-            self.radius.data[c] = r
-            self.theta_start.data[c] = theta_tensor[0]
-            self.delta_raw.data[c] = _softplus_inverse(target)
-
-
-class LearnableParametricLUT(nn.Module):
-    """Parametric LUT with geometric constraints (line/arc)."""
-
-    def __init__(
-        self,
-        *,
-        num_channels: int,
-        vocab_size: int,
-        embed_dim: int,
-        param_mode: str = "line2d",
-        monotone_mode: str = "softplus",
-        embed_range: str = "pm1",
-        device: Optional[torch.device],
-        dtype: torch.dtype,
-        arc_radius: float = 1.0,
-    ) -> None:
-        super().__init__()
-        self.param_mode = param_mode
-        if param_mode == "line2d":
-            self.param = _Line2DLUTParam(
-                num_channels=num_channels,
-                vocab_size=vocab_size,
-                embed_dim=embed_dim,
-                monotone_mode=monotone_mode,
-            )
-        elif param_mode == "arc2d":
-            self.param = _Arc2DLUTParam(
-                num_channels=num_channels,
-                vocab_size=vocab_size,
-                embed_dim=embed_dim,
-                monotone_mode=monotone_mode,
-                radius=arc_radius,
-            )
-        else:
-            raise ValueError(f"Unknown param_mode '{param_mode}'")
-        if device is not None or dtype is not None:
-            self.to(device=device, dtype=dtype)
-        if self.param_mode == "arc2d":
-            base_weight = self._default_arc_baseline(
-                num_channels,
-                vocab_size,
-                embed_dim,
-                dtype=dtype,
-                device=device,
-                radius=arc_radius,
-            )
-        else:
-            base_weight = self._default_baseline(
-                num_channels,
-                vocab_size,
-                embed_dim,
-                embed_range,
-                dtype=dtype,
-                device=device,
-            )
-        self.initialize_from_weight(base_weight)
-
-    def forward(self) -> Tensor:
-        return self.param()
-
-    def initialize_from_weight(self, weight: Tensor) -> None:
-        self.param.initialize_from_weight(weight)
-
-    @property
-    def weight(self) -> Tensor:
-        return self.forward()
-
-    @staticmethod
-    def _default_baseline(
-        num_channels: int,
-        vocab_size: int,
-        embed_dim: int,
-        embed_range: str,
-        *,
-        dtype: torch.dtype,
-        device: Optional[torch.device],
-    ) -> Tensor:
-        base = torch.zeros(num_channels, vocab_size, embed_dim, dtype=dtype)
-        if embed_range == "pm1":
-            linear = torch.linspace(-1.0, 1.0, steps=vocab_size, dtype=dtype)
-        else:
-            linear = torch.linspace(0.0, 1.0, steps=vocab_size, dtype=dtype)
-        for c in range(num_channels):
-            base[c, :, 0] = linear
-        if device is not None:
-            base = base.to(device=device)
-        return base
-
-    @staticmethod
-    def _default_arc_baseline(
-        num_channels: int,
-        vocab_size: int,
-        embed_dim: int,
-        *,
-        dtype: torch.dtype,
-        device: Optional[torch.device],
-        radius: float = 1.0,
-    ) -> Tensor:
-        base = torch.zeros(num_channels, vocab_size, embed_dim, dtype=dtype)
-        theta = torch.linspace(0.0, math.pi, steps=vocab_size, dtype=dtype)
-        base[:, :, 0] = torch.cos(theta) * radius
-        if embed_dim > 1:
-            base[:, :, 1] = torch.sin(theta) * radius
-        if device is not None:
-            base = base.to(device=device)
-        return base
     def _linear_init_base(self) -> Tensor:
-        """Initialize base LUT (without noise) for renormalization target.
-        
-        Returns:
-            Tensor of shape [num_channels, vocab_size, emb_dim]
-        """
-        weight = torch.zeros(self.num_channels, self.vocab_size, self.emb_dim)
-        
-        for d in range(self.emb_dim):
-            if self.embed_range == "pm1":
-                base = torch.linspace(-1.0, 1.0, steps=self.vocab_size)
-            else:
-                base = torch.linspace(0.0, 1.0, steps=self.vocab_size)
-            
-            # Repeat base pattern for all channels (no noise)
-            base_repeated = base.repeat(self.num_channels, 1)  # [C, V]
-            weight[:, :, d] = base_repeated
-        
-        return weight
+        """Baseline (noise-free) linear LUT initialization."""
+        return _linear_lut_baseline(
+            num_channels=self.num_channels,
+            vocab_size=self.vocab_size,
+            emb_dim=self.emb_dim,
+            embed_range=self.embed_range,
+        )
 
     def _small_noise_qr_init(self) -> Tensor:
         """Initialize LUT with small noise QR decomposition for orthogonal warm start.
@@ -531,7 +211,7 @@ class LearnableParametricLUT(nn.Module):
                 A[:, d] = base_unit + noise
         
         # Step 3: Apply QR decomposition for orthogonality
-        Q, R = torch.linalg.qr(A)
+        Q, _ = torch.linalg.qr(A)
         
         # Step 4: Scale to target norm (same as linear init for consistency)
         # Target norm should match the linear initialization norm
@@ -615,6 +295,361 @@ class LearnableParametricLUT(nn.Module):
         )
 
 
+def _pava_1d(values: Tensor) -> Tensor:
+    """Pool Adjacent Violators Algorithm for 1D isotonic regression."""
+    v = values.detach().cpu().double().numpy()
+    n = v.shape[0]
+    y = v.copy()
+    w = np.ones(n, dtype=np.double)
+    i = 0
+    while i < n - 1:
+        if y[i] > y[i + 1]:
+            s = y[i] * w[i] + y[i + 1] * w[i + 1]
+            w_new = w[i] + w[i + 1]
+            y[i] = y[i + 1] = s / w_new
+            w[i] = w[i + 1] = w_new
+            j = i
+            while j > 0 and y[j - 1] > y[j]:
+                s = y[j - 1] * w[j - 1] + y[j] * w[j]
+                w_new = w[j - 1] + w[j]
+                y[j - 1] = y[j] = s / w_new
+                w[j - 1] = w[j] = w_new
+                j -= 1
+            i = j
+        else:
+            i += 1
+    return torch.from_numpy(y).to(values)
+
+
+def _pava_projection(values: Tensor) -> Tensor:
+    """Apply PAVA independently along the last dimension."""
+    if values.dim() == 1:
+        return _pava_1d(values)
+    out = torch.empty_like(values)
+    for idx in range(values.shape[0]):
+        out[idx] = _pava_1d(values[idx])
+    return out
+
+
+class _Line2DLUTParam(nn.Module):
+    """1D monotone curve embedded along a single direction."""
+
+    def __init__(
+        self,
+        *,
+        num_channels: int,
+        vocab_size: int,
+        embed_dim: int,
+        monotone_mode: str = "softplus",
+        min_step: float = 1e-4,
+    ) -> None:
+        super().__init__()
+        if vocab_size < 2:
+            raise ValueError("vocab_size must be >= 2 for line2d parameterization")
+        if monotone_mode != "softplus":
+            raise ValueError(f"Unsupported monotone_mode '{monotone_mode}' for line2d")
+        self.num_channels = num_channels
+        self.vocab_size = vocab_size
+        self.embed_dim = embed_dim
+        self.monotone_mode = monotone_mode
+        self.min_step = float(min_step)
+
+        direction_init = torch.randn(num_channels, embed_dim)
+        delta_init = torch.full((num_channels, vocab_size - 1), 0.01)
+        start_init = torch.zeros(num_channels)
+
+        self.direction_raw = nn.Parameter(direction_init)
+        self.delta_raw = nn.Parameter(_inv_softplus_tensor(delta_init))
+        self.start = nn.Parameter(start_init)
+
+    def forward(self) -> Tensor:
+        direction = self._normalized_direction()  # [C, D]
+        delta = F.softplus(self.delta_raw) + self.min_step  # [C, V-1]
+        cumulative = torch.cumsum(delta, dim=-1)
+        tail = self.start.unsqueeze(-1) + cumulative
+        tau = torch.cat([self.start.unsqueeze(-1), tail], dim=-1)  # [C, V]
+        emb = direction.unsqueeze(1) * tau.unsqueeze(-1)  # [C, V, D]
+        return emb
+
+    def _normalized_direction(self) -> Tensor:
+        direction = self.direction_raw
+        return direction / (direction.norm(dim=-1, keepdim=True) + 1e-12)
+
+    @torch.no_grad()
+    def initialize_from_weight(self, weight: Tensor) -> None:
+        """Warm start from an existing [C,V,D] weight tensor."""
+        C, V, D = weight.shape
+        assert C == self.num_channels and V == self.vocab_size and D == self.embed_dim
+        device = weight.device
+        for c in range(C):
+            W = weight[c]  # [V, D]
+            try:
+                _, _, vh = torch.linalg.svd(W, full_matrices=False)
+                basis = vh[0]
+            except RuntimeError:
+                basis = W.mean(dim=0)
+            if basis.norm() < 1e-8:
+                basis = torch.zeros_like(basis)
+                basis[0] = 1.0
+            basis = basis / (basis.norm() + 1e-12)
+            coords = W @ basis  # [V]
+            tokens = torch.arange(V, device=device, dtype=coords.dtype)
+            centered_tokens = tokens - tokens.mean()
+            centered_coords = coords - coords.mean()
+            cov = (centered_tokens * centered_coords).mean()
+            if cov < 0:
+                coords = -coords
+                basis = -basis
+            coords = _pava_projection(coords)
+            delta = coords[1:] - coords[:-1]
+            delta = torch.clamp(delta, min=self.min_step + 1e-6)
+            start_val = coords[0]
+            self.direction_raw.data[c] = basis
+            self.start.data[c] = start_val
+            target = delta - self.min_step
+            target = torch.clamp(target, min=1e-6)
+            self.delta_raw.data[c] = _inv_softplus_tensor(target)
+
+
+class _Arc2DLUTParam(nn.Module):
+    """Monotone arc parameterization on a great/small circle."""
+
+    def __init__(
+        self,
+        *,
+        num_channels: int,
+        vocab_size: int,
+        embed_dim: int,
+        monotone_mode: str = "softplus",
+        radius: float = 1.0,
+        min_step: float = 1e-4,
+    ) -> None:
+        super().__init__()
+        if embed_dim < 2:
+            raise ValueError("arc2d parameterization requires embed_dim >= 2")
+        if vocab_size < 2:
+            raise ValueError("vocab_size must be >=2")
+        if monotone_mode != "softplus":
+            raise ValueError(f"Unsupported monotone_mode '{monotone_mode}' for arc2d")
+        self.num_channels = num_channels
+        self.vocab_size = vocab_size
+        self.embed_dim = embed_dim
+        self.min_step = float(min_step)
+        self.radius = nn.Parameter(torch.full((num_channels,), float(radius)))
+
+        basis_init = torch.randn(num_channels, embed_dim, 2)
+        delta_init = torch.full((num_channels, vocab_size - 1), 0.01)
+        theta_start = torch.zeros(num_channels)
+        self.basis_raw = nn.Parameter(basis_init)
+        self.delta_raw = nn.Parameter(_inv_softplus_tensor(delta_init))
+        self.theta_start = nn.Parameter(theta_start)
+
+    def forward(self) -> Tensor:
+        basis = self._orthonormal_basis()  # [C, D, 2]
+        delta = F.softplus(self.delta_raw) + self.min_step  # [C, V-1]
+        theta = self.theta_start.unsqueeze(-1) + torch.cumsum(delta, dim=-1)
+        theta = torch.cat(
+            [self.theta_start.unsqueeze(-1), theta], dim=-1
+        )  # prepend start
+        cos_t = torch.cos(theta)
+        sin_t = torch.sin(theta)
+        coords = torch.stack([cos_t, sin_t], dim=-1)  # [C, V, 2]
+        coords = coords * self.radius.view(self.num_channels, 1, 1)
+        emb = torch.einsum("cdk,cvk->cvd", basis, coords)
+        return emb
+
+    def _orthonormal_basis(self) -> Tensor:
+        q, _ = torch.linalg.qr(self.basis_raw, mode="reduced")
+        return q
+
+    @torch.no_grad()
+    def initialize_from_weight(self, weight: Tensor) -> None:
+        C, V, D = weight.shape
+        assert C == self.num_channels and V == self.vocab_size and D == self.embed_dim
+        device = weight.device
+        for c in range(C):
+            W = weight[c]  # [V, D]
+            try:
+                _, _, vh = torch.linalg.svd(W, full_matrices=False)
+                basis = vh[:2].T  # [D,2]
+            except RuntimeError:
+                basis = torch.zeros(D, 2, device=device, dtype=W.dtype)
+                basis[:, 0] = torch.randn(D, device=device, dtype=W.dtype)
+                basis[:, 0] = basis[:, 0] / (basis[:, 0].norm() + 1e-12)
+                basis[:, 1] = torch.randn(D, device=device, dtype=W.dtype)
+                basis[:, 1] -= basis[:, 0] * (basis[:, 1] * basis[:, 0]).sum()
+                basis[:, 1] = basis[:, 1] / (basis[:, 1].norm() + 1e-12)
+            coords = W @ basis  # [V,2]
+            radius_vals = torch.linalg.vector_norm(coords, dim=-1)
+            r = radius_vals.median()
+            radius_vals = torch.clamp(radius_vals, min=1e-6)
+            unit = coords / radius_vals.unsqueeze(-1)
+            theta = torch.atan2(unit[:, 1], unit[:, 0])
+            theta_np = theta.detach().cpu().numpy()
+            theta_np = np.unwrap(theta_np)
+            theta_tensor = torch.from_numpy(theta_np).to(device=device, dtype=W.dtype)
+            tokens = torch.arange(V, device=device, dtype=W.dtype)
+            centered_tokens = tokens - tokens.mean()
+            centered_theta = theta_tensor - theta_tensor.mean()
+            cov = (centered_tokens * centered_theta).mean()
+            if cov < 0:
+                theta_tensor = -theta_tensor
+                basis[:, 0] = -basis[:, 0]
+            theta_tensor = _pava_projection(theta_tensor)
+            delta = theta_tensor[1:] - theta_tensor[:-1]
+            delta = torch.clamp(delta, min=self.min_step + 1e-6)
+            target = delta - self.min_step
+            target = torch.clamp(target, min=1e-6)
+            self.basis_raw.data[c] = basis
+            self.radius.data[c] = r
+            self.theta_start.data[c] = theta_tensor[0]
+            self.delta_raw.data[c] = _inv_softplus_tensor(target)
+
+
+class LearnableParametricLUT(nn.Module):
+    """Parametric LUT with geometric constraints (line/arc)."""
+
+    def __init__(
+        self,
+        *,
+        num_channels: int,
+        vocab_size: int,
+        embed_dim: int,
+        param_mode: str = "line2d",
+        monotone_mode: str = "softplus",
+        embed_range: str = "pm1",
+        device: Optional[torch.device],
+        dtype: torch.dtype,
+        arc_radius: float = 1.0,
+        renormalize_to_init_norm: bool = False,
+        renorm_eps: float = 1e-12,
+        bounded_residual_scale: bool = False,
+        scale_baseline: float = 1.0,
+        scale_epsilon: float = 0.25,
+    ) -> None:
+        super().__init__()
+        if embed_range not in {"pm1", "unit"}:
+            raise ValueError("embed_range must be 'pm1' or 'unit'")
+        self.param_mode = param_mode
+        self.embed_range = embed_range
+        self.num_channels = int(num_channels)
+        self.vocab_size = int(vocab_size)
+        self.emb_dim = int(embed_dim)
+        self.renormalize_to_init_norm = bool(renormalize_to_init_norm)
+        self.renorm_eps = float(renorm_eps)
+        self.bounded_residual_scale = bool(bounded_residual_scale)
+        self.scale_baseline = float(scale_baseline)
+        self.scale_epsilon = float(scale_epsilon)
+
+        if param_mode == "line2d":
+            self.param = _Line2DLUTParam(
+                num_channels=num_channels,
+                vocab_size=vocab_size,
+                embed_dim=embed_dim,
+                monotone_mode=monotone_mode,
+            )
+        elif param_mode == "arc2d":
+            self.param = _Arc2DLUTParam(
+                num_channels=num_channels,
+                vocab_size=vocab_size,
+                embed_dim=embed_dim,
+                monotone_mode=monotone_mode,
+                radius=arc_radius,
+            )
+        else:
+            raise ValueError(f"Unknown param_mode '{param_mode}'")
+
+        baseline_dtype = torch.get_default_dtype()
+        base_weight = (
+            self._default_arc_baseline(
+                num_channels,
+                vocab_size,
+                embed_dim,
+                dtype=baseline_dtype,
+                device=None,
+                radius=arc_radius,
+            )
+            if self.param_mode == "arc2d"
+            else self._default_baseline(
+                num_channels,
+                vocab_size,
+                embed_dim,
+                embed_range,
+                dtype=baseline_dtype,
+                device=None,
+            )
+        )
+        self.initialize_from_weight(base_weight)
+        base_norm = torch.linalg.vector_norm(base_weight, dim=(1, 2))
+        self.register_buffer("_base_fro_norm_per_channel", base_norm, persistent=False)
+
+        if self.bounded_residual_scale:
+            self.scale_c = nn.Parameter(torch.zeros(self.num_channels))
+        else:
+            self.scale_c = None
+
+        if device is not None or dtype is not None:
+            self.to(device=device, dtype=dtype)
+
+    def forward(self) -> Tensor:
+        weight = self.param()
+        if self.bounded_residual_scale and self.scale_c is not None:
+            scale = self.scale_baseline * (1.0 + self.scale_epsilon * torch.tanh(self.scale_c))
+            weight = weight * scale.view(-1, 1, 1)
+        if not self.renormalize_to_init_norm:
+            return weight
+        target = self._base_fro_norm_per_channel.to(device=weight.device, dtype=weight.dtype)
+        current = torch.linalg.vector_norm(weight, dim=(1, 2))
+        scale = target / (current + self.renorm_eps)
+        return weight * scale.view(-1, 1, 1)
+
+    def initialize_from_weight(self, weight: Tensor) -> None:
+        self.param.initialize_from_weight(weight)
+
+    @property
+    def weight(self) -> Tensor:
+        return self.forward()
+
+    @staticmethod
+    def _default_baseline(
+        num_channels: int,
+        vocab_size: int,
+        embed_dim: int,
+        embed_range: str,
+        *,
+        dtype: torch.dtype,
+        device: Optional[torch.device],
+    ) -> Tensor:
+        return _linear_lut_baseline(
+            num_channels=num_channels,
+            vocab_size=vocab_size,
+            emb_dim=embed_dim,
+            embed_range=embed_range,
+            dtype=dtype,
+            device=device,
+        )
+
+    @staticmethod
+    def _default_arc_baseline(
+        num_channels: int,
+        vocab_size: int,
+        embed_dim: int,
+        *,
+        dtype: torch.dtype,
+        device: Optional[torch.device],
+        radius: float = 1.0,
+    ) -> Tensor:
+        if dtype is None:
+            dtype = torch.get_default_dtype()
+        linspace_kwargs = {"dtype": dtype}
+        if device is not None:
+            linspace_kwargs["device"] = device
+        base = torch.zeros(num_channels, vocab_size, embed_dim, dtype=dtype, device=device)
+        theta = torch.linspace(0.0, math.pi, steps=vocab_size, **linspace_kwargs)
+        base[:, :, 0] = torch.cos(theta) * radius
+        if embed_dim > 1:
+            base[:, :, 1] = torch.sin(theta) * radius
+        return base
 class MahalanobisTokenMetric(nn.Module):
     """Learnable PSD metric with unit-Frobenius retraction constraint.
     
@@ -992,7 +1027,8 @@ class MetricInducedGibbsProbPath(ProbPath):
         self.use_gumbel = bool(use_gumbel)
         self.gumbel_tau = float(gumbel_tau)
         self.gumbel_hard = bool(gumbel_hard)
-
+        self._lut_init_method = str(lut_init_method)
+        self._lut_init_noise_scale = float(lut_init_noise_scale)
         self.embedding = self._build_embedding(
             embedding_path_or_weight, vocab_size, emb_dim, device, dtype
         )
@@ -1042,6 +1078,10 @@ class MetricInducedGibbsProbPath(ProbPath):
                     device=device,
                     dtype=dtype,
                     arc_radius=self._lut_arc_radius,
+                    renormalize_to_init_norm=self._lut_renorm_to_init_norm,
+                    bounded_residual_scale=self._lut_bounded_residual_scale,
+                    scale_baseline=self._lut_scale_baseline,
+                    scale_epsilon=self._lut_scale_epsilon,
                 )
             else:
                 lut_module = LearnableScalarLUT(
@@ -1314,28 +1354,26 @@ class MetricInducedGibbsProbPath(ProbPath):
         # Compute pairwise differences: [C, V, V, D]
         diff = weight[:, :, None, :] - weight[:, None, :, :]  # [C, V, 1, D] - [C, 1, V, D]
 
-        if self._use_normalized_distance:
-            # Normalized distance: ||diff||_2 / sqrt(m)
-            # For scalar embeddings (emb_dim=1): m=1, so just ||diff||_2
-            # For vector embeddings (emb_dim>1): m=emb_dim
-            m = float(emb_dim)  # embedding dimension as normalization factor
+        if self._use_normalized_distance and emb_dim > 1:
+            # Normalized distance: ||diff||_2 / sqrt(m) for vector embeddings
+            m = float(emb_dim)
             dist = torch.linalg.vector_norm(diff, dim=-1) / math.sqrt(m)  # [C, V, V]
         else:
-            # Original Lp norm distance
-            p = self.learnable_lut.lp_order
+            # Metric-controlled Lp distance (scalar or vector embeddings)
             if emb_dim == 1:
-                # Scalar case: simple absolute difference (backward compatible)
                 dist = diff.abs().squeeze(-1)  # [C, V, V]
-            elif p == 1.0:
-                # L1 norm: sum of absolute differences
-                dist = diff.abs().sum(dim=-1)  # [C, V, V]
-            elif p == 2.0:
-                # L2 norm: Euclidean distance
-                dist = (diff ** 2).sum(dim=-1).sqrt()  # [C, V, V]
             else:
-                # General Lp norm
-                dist = (diff.abs() ** p).sum(dim=-1) ** (1.0 / p)  # [C, V, V]
-        
+                if self.metric_name == "lp":
+                    p = float(self.lp_order)
+                else:
+                    p = 2.0  # euclidean fallback
+                if math.isclose(p, 1.0):
+                    dist = diff.abs().sum(dim=-1)
+                elif math.isclose(p, 2.0):
+                    dist = torch.linalg.vector_norm(diff, ord=2.0, dim=-1)
+                else:
+                    dist = (diff.abs() ** p).sum(dim=-1) ** (1.0 / p)
+
         return dist
 
     def _lut_channel_assignments(self, tokens: Tensor) -> Tensor:

--- a/flow_matching/path/mixture.py
+++ b/flow_matching/path/mixture.py
@@ -4,7 +4,6 @@
 # This source code is licensed under the CC-by-NC license found in the
 # LICENSE file in the root directory of this source tree.
 
-import math
 import torch
 import torch.nn.functional as F
 import torch.nn as nn
@@ -94,26 +93,6 @@ from flow_matching.path.path import ProbPath
 from flow_matching.path.path_sample import DiscretePathSample
 from flow_matching.path.scheduler import ConvexScheduler
 from flow_matching.utils import expand_tensor_like, unsqueeze_to_match
-    
-def _offdiag_mad_float(matrix: Tensor) -> float:
-    """Return the off-diagonal median absolute deviation of a square matrix."""
-
-    if matrix.ndim != 2 or matrix.size(0) != matrix.size(1):
-        raise ValueError("matrix must be square")
-    if matrix.size(0) <= 1:
-        return 0.0
-
-    mat = matrix.detach().to(dtype=torch.float64)
-    n = mat.size(0)
-    mask = ~torch.eye(n, dtype=torch.bool, device=mat.device)
-    values = mat.masked_select(mask)
-    if values.numel() == 0:
-        return 0.0
-
-    median = torch.median(values)
-    deviations = (values - median).abs()
-    mad = torch.median(deviations)
-    return float(mad)
 
 
 class MixtureDiscreteProbPath(ProbPath):
@@ -463,10 +442,6 @@ class MetricInducedGibbsProbPath(ProbPath):
             self._cached_emb_weight = E
             self._cached_metric_name = self.metric_name
             self._cached_lp_order = float(self.lp_order)
-            try:
-                self._base_dist_offdiag_scale = _offdiag_mad_float(dist_cpu)
-            except ValueError:
-                self._base_dist_offdiag_scale = None
 
         base = self._base_dist_table_cpu
         assert base is not None
@@ -474,7 +449,7 @@ class MetricInducedGibbsProbPath(ProbPath):
             base = base.to(device=device, dtype=dtype)
         return base
 
-    def _scaled_learned_distance_table(
+    def _learned_distance_table(
         self,
         *,
         device: torch.device,
@@ -485,23 +460,7 @@ class MetricInducedGibbsProbPath(ProbPath):
         if module is None:
             return None
 
-        learned_table = module.pairwise_distance_table(device=device, dtype=dtype)
-        base_scale = self._base_dist_offdiag_scale
-        if base_scale is not None and base_scale > 0.0:
-            try:
-                learned_scale = _offdiag_mad_float(learned_table)
-            except ValueError:
-                learned_scale = None
-            if learned_scale is not None and learned_scale > 0.0:
-                scale_value = base_scale / max(learned_scale, 1e-12)
-                if math.isfinite(scale_value) and scale_value > 0.0:
-                    scale_tensor = torch.as_tensor(
-                        scale_value,
-                        device=learned_table.device,
-                        dtype=learned_table.dtype,
-                    )
-                    learned_table = learned_table * scale_tensor
-        return learned_table
+        return module.pairwise_distance_table(device=device, dtype=dtype)
 
     def _build_distance_table(
         self,
@@ -516,7 +475,7 @@ class MetricInducedGibbsProbPath(ProbPath):
         lam = float(self.metric_interp_lambda)
         learned_table = None
         if lam > 0.0:
-            learned_table = self._scaled_learned_distance_table(
+            learned_table = self._learned_distance_table(
                 device=device, dtype=dtype, metric_module=metric_module
             )
 

--- a/tasks/copilot_work_summary.md
+++ b/tasks/copilot_work_summary.md
@@ -4,6 +4,7 @@
 - Integrated EDM2-inspired stabilizers into the CIFAR-10 image UNet training stack.
 - Added configurability and diagnostics for cosine attention and weight-normalized output heads.
 - Hardened the training loop to respect per-step weight renormalization and guard numerical stability.
+- Expanded beta-schedule diagnostics to cover logβ-uniform sampling, mixture densities, and tail behavior needed for MIS regularization.
 
 ## Key Changes
 - Implemented cosine attention with explicit Q/K normalization, epsilon guards, and \sqrt{d} rescaling inside `models/unet.py`.
@@ -11,13 +12,19 @@
 - Threaded CLI flags (e.g., `--head_weight_norm`, cosine attention toggles) through argument parsing, configuration builders, and distributed training entry points.
 - Extended weight-norm target propagation across EMA wrappers, discrete UNet variants, and DDP boundaries so that all replicas share consistent renorm behavior.
 - Updated `training/grad_scaler.py` and `training/train_loop.py` to register weight-norm modules once and invoke their pre-step renormalization hooks before every optimizer update.
+- Augmented `beta_schedule_analysis copy.ipynb` with tooling to sample uniformly in logβ, map points back to `(t, β(t))`, and tabulate `q_logβ` / `q_mix` statistics for the latest epoch.
 
 ## Testing and Validation
 - Ran `python -m compileall` on modified modules to ensure syntax integrity.
 - Executed targeted sanity scripts confirming post-renorm RMS equals `1/sqrt(fan_in)` for weight-normalized layers.
 - Launched distributed CIFAR-10 training runs (6 GPUs) to verify stable loss trajectories with the new head normalization and cosine attention enabled.
+- Visually inspected the new beta-schedule plots and quantile tables to confirm MIS weights remain well-behaved near the truncated boundaries.
 
 ## Follow-ups
 - Re-run long-horizon training with the corrected fan-in scaling to collect updated FID curves.
 - Monitor KL and tau metrics under the new cosine attention regime for potential regressions.
 - Expand automated tests around weight renormalization hooks to catch future initialization regressions.
+- Add automated checks that integrate `q_mix(t)` over the truncated domain and report ESS during evaluation to guarantee parity with the training sampler.
+
+## To-Do (delegated to code agents)
+- Integrate and streamline the discrete flow-matching codepath so it is easier to read and reuse, pruning redundant components left over from the metric-induced path implementation.

--- a/tasks/copilot_work_summary.md
+++ b/tasks/copilot_work_summary.md
@@ -1,0 +1,23 @@
+# Work Summary (September 2025)
+
+## Scope
+- Integrated EDM2-inspired stabilizers into the CIFAR-10 image UNet training stack.
+- Added configurability and diagnostics for cosine attention and weight-normalized output heads.
+- Hardened the training loop to respect per-step weight renormalization and guard numerical stability.
+
+## Key Changes
+- Implemented cosine attention with explicit Q/K normalization, epsilon guards, and \sqrt{d} rescaling inside `models/unet.py`.
+- Wrapped the UNet output head with optional weight-normalized convolutions, including fan-in scaling fixes and `force_weight_renorm` helpers.
+- Threaded CLI flags (e.g., `--head_weight_norm`, cosine attention toggles) through argument parsing, configuration builders, and distributed training entry points.
+- Extended weight-norm target propagation across EMA wrappers, discrete UNet variants, and DDP boundaries so that all replicas share consistent renorm behavior.
+- Updated `training/grad_scaler.py` and `training/train_loop.py` to register weight-norm modules once and invoke their pre-step renormalization hooks before every optimizer update.
+
+## Testing and Validation
+- Ran `python -m compileall` on modified modules to ensure syntax integrity.
+- Executed targeted sanity scripts confirming post-renorm RMS equals `1/sqrt(fan_in)` for weight-normalized layers.
+- Launched distributed CIFAR-10 training runs (6 GPUs) to verify stable loss trajectories with the new head normalization and cosine attention enabled.
+
+## Follow-ups
+- Re-run long-horizon training with the corrected fan-in scaling to collect updated FID curves.
+- Monitor KL and tau metrics under the new cosine attention regime for potential regressions.
+- Expand automated tests around weight renormalization hooks to catch future initialization regressions.

--- a/tasks/eval-fid-regression/plan.md
+++ b/tasks/eval-fid-regression/plan.md
@@ -1,0 +1,18 @@
+# Plan to restore eval stability
+
+1. **Restore robust real-sample updates**
+   - Always feed full dataloader batches to the FID metric as before.
+   - Track `num_real` using a saturated counter for early-exit logic, but keep the underlying data unchanged.
+
+2. **Target synthetic quota precisely**
+   - Derive `remaining_fake` from the quota and construct conditioning batches by slicing the loader batch and labels.
+   - Skip solver calls when no quota remains and ensure counters saturate after each update.
+
+3. **Clarify distributed logging**
+   - Aggregate per-rank sample counts with an `all_reduce` before printing progress so logs reflect global coverage.
+
+4. **Fix snapshot padding artefacts**
+   - Introduce a helper that pads sampled batches by repeating initial images to complete the final grid row before calling `save_image`.
+
+5. **Regression checks**
+   - Run the existing unit test suite (`pytest tests/path/test_path.py`) to verify no regressions.

--- a/tasks/eval-fid-regression/research.md
+++ b/tasks/eval-fid-regression/research.md
@@ -1,0 +1,19 @@
+# Eval FID regression investigation
+
+## Context
+- User noticed evaluation FID scores became worse after recent changes.
+- Suspects running FID logging only counts single-GPU samples.
+- Snapshot grid images now show black tiles in bottom-right corner.
+
+## Findings
+- Current eval loop trims both real and synthetic batches to respect the remaining `fid_samples` per rank.
+- Real features fed into `FrechetInceptionDistance` are now limited to the same remainder, whereas the previous implementation always ingested the full dataloader batches (often many more real samples). Fewer real samples increase FID variance and can degrade the score.
+- Logging reports per-rank counters (`num_real`, `num_synthetic`), so on multi-GPU runs the progress printout reflects a single worker’s contribution.
+- Snapshot grids are saved with `torchvision.utils.save_image`, which lays out images in a fixed-width grid (default `nrow=8`). When the last batch is truncated the grid contains fewer images than expected, leaving zero-filled tiles rendered as black squares.
+
+## Opportunities
+- Keep the reduced synthetic workload but revert to feeding full real batches so FID statistics match historical behaviour.
+- Clamp counters with `min(..., fid_samples)` and break once both quotas are satisfied to avoid iterating the whole loader.
+- Build synthetic conditioning batches from the remaining quota only—this still saves solver work.
+- Aggregate counters across distributed workers for logging to avoid confusion.
+- Pad snapshot batches by repeating early samples so the saved grid is rectangular without black placeholders.

--- a/tasks/eval-speed-gif/plan.md
+++ b/tasks/eval-speed-gif/plan.md
@@ -1,0 +1,24 @@
+# Plan: Eval speed tweaks + GIF logging
+
+1. **Trim real FID batches**
+   - Track how many real samples have already been accumulated inside `eval_model`.
+   - Slice the current batch (and labels) so at most `fid_samples` reals are pushed into `fid_metric` and skip updates once the quota is met.
+   - Ensure synthetic sampling uses the trimmed tensors, and exit the loop once both real and synthetic quotas are satisfied.
+
+2. **Introduce GIF logging controls**
+   - Extend `examples/image/train_arg_parser.py` with flags such as `--save_eval_gif`, `--eval_gif_max_batch`, `--eval_gif_stride`, and `--eval_gif_fps` (choose sensible defaults).
+   - Expose these settings via the parsed `args` object.
+
+3. **Capture sampling trajectories**
+   - In the eval loop, detect when GIF logging is requested and only for the first batch on the main process request solver trajectories via `return_intermediates=True`.
+   - Handle all solver branches (mixture discrete, metric-induced, continuous) and fall back to final samples otherwise.
+
+4. **Emit GIF artifacts**
+   - Add a helper that downsamples trajectories (`stride`, `max_batch`), normalizes to `[0, 1]`, arranges them into a grid, and saves a GIF under `output_dir/gifs`.
+   - Reuse PIL for GIF writing and optionally log to wandb when available.
+   - Guard against datasets with 1 or 3 channels and release GPU memory promptly.
+
+5. **Verification**
+   - Run the existing targeted unit tests (e.g., `pytest tests/path/test_path.py`) to ensure the refactor doesn’t break prior behavior.
+   - Manually lint the modified modules for obvious style regressions.
+

--- a/tasks/eval-speed-gif/research.md
+++ b/tasks/eval-speed-gif/research.md
@@ -1,0 +1,18 @@
+# Research Notes: Eval speed + GIF logging
+
+## Evaluation loop structure
+- `examples/image/training/eval_loop.py` drives evaluation. It always updates the FID metric with the full batch of real samples (`fid_metric.update(samples, real=True)`) before any synthetic generation. The loop doesn't track how many real examples have been accumulated, so if `fid_samples` is smaller than the evaluation loader batch size it still processes entire batches of real images.
+- Synthetic sampling stops when `num_synthetic` reaches `fid_samples`, but the dataloader keeps feeding batches even if enough real examples have already been collected. The code trims synthetic batches via slicing when the cumulative count would exceed `fid_samples`, but real samples are never truncated.
+
+## Sampler APIs
+- Discrete mixture solver (`flow_matching/solver/discrete_solver.py`) and KO Gibbs solver (`flow_matching/solver/ko_discrete_solver.py`) both accept `return_intermediates=True` and return a tensor of shape `(num_steps + 1, batch, ...)` capturing the intermediate states.
+- Continuous ODE solver (`flow_matching/solver/ode_solver.py`) also supports `return_intermediates=True` and returns the entire trajectory sampled over the provided time grid.
+
+## Existing logging utilities
+- The eval loop already writes a PNG snapshot via `torchvision.utils.save_image` the first time synthetic samples are generated when `args.output_dir` is set.
+- Metric-induced schedule logging uses disk writes and optionally wandb logging, so GIF export can follow a similar pattern (create directories under `args.output_dir` and optionally push to wandb if available).
+
+## CLI surface
+- `examples/image/train_arg_parser.py` currently exposes FID-related flags (`--fid_samples`, `--compute_fid`, `--save_fid_samples`) but nothing for trajectory logging, so adding explicit GIF controls is reasonable.
+- No dedicated helper exists for trimming FID batches; implementing the logic in the eval loop or factoring out a small utility are both viable.
+

--- a/tasks/exp-rqs-inverse/plan.md
+++ b/tasks/exp-rqs-inverse/plan.md
@@ -1,0 +1,15 @@
+# Plan: Implement inverse for Exp RQS schedule
+
+1. **Implement `_ExpRQS1D.inverse`:**
+   - Mirror parameter reconstruction from `forward` (widths, heights, deltas, knot locations).
+   - Flatten inputs and separate tail vs central cases.
+   - For central values, bucketize over `yk` to find bin, compute normalized target `z`, solve quadratic using coefficients from research, clamp discriminant, choose valid root, map back to `s`.
+   - Reshape output to original shape and obtain derivative by calling `forward` on recovered `s` (reuse existing routine).
+
+2. **Add unit tests:**
+   - Create test covering random samples across range verifying `inverse(forward(x)[0])[0]` ≈ `x` (use tolerance) for interior.
+   - Include boundary/tail cases (values beyond tail bound) ensuring identity mapping.
+   - Confirm derivative returned by inverse matches forward derivative by comparing second output shapes/positivity.
+
+3. **Run existing tests:**
+   - Execute targeted test module to ensure new functionality passes (e.g., `pytest tests/path/test_path.py`).

--- a/tasks/exp-rqs-inverse/research.md
+++ b/tasks/exp-rqs-inverse/research.md
@@ -1,0 +1,13 @@
+# Research: Exp RQS inverse implementation
+
+- `_ExpRQS1D.forward` constructs monotone RQS with linear tails; parameters derived from `theta_w`, `theta_h`, `theta_d`.
+- Forward builds `xk`, `yk`, `delta` exactly as specified by NSF. Inverse must reconstruct identical arrays to ensure consistency.
+- For input in central region, we need to identify bin via `torch.bucketize` over `xk[1:]` or `yk[1:]` depending on value to invert.
+- Quadratic coefficients from NSF for solving normalized coordinate ξ given normalized output `z = (slope*ξ^2 + d0*ξ(1-ξ)) / (slope + (d0 + d1 - 2*slope)*ξ(1-ξ))` are:
+  - `a = slope - d0 + z * (d0 + d1 - 2 * slope)`
+  - `b = d0 - z * (d0 + d1 - 2 * slope)`
+  - `c = -z * slope`
+- Tails remain linear with slope 1 ⇒ inverse is identity there; derivative = 1.
+- To avoid numerical issues, we need eps for denominators and clamp discriminant >=0. Use root `(-b + sqrt(disc)) / (2*a)` (monotone case) and clamp to [0,1].
+- After solving, map `s = x0 + w * xi`. Then compute derivative using forward at `s` to reuse existing code.
+- Tests should draw random inputs within [-tail_bound, tail_bound], check inverse(forward(x)[0])[0] ≈ x, also test outside (tails) and gradient shape.

--- a/tasks/fid-eval-trim/plan.md
+++ b/tasks/fid-eval-trim/plan.md
@@ -1,0 +1,6 @@
+# Plan to align real FID counts with the requested quota
+
+1. Update `examples/image/training/eval_loop.py` so that each iteration slices the real batch to the remaining quota before calling `fid_metric.update(..., real=True)` and increments `num_real` by the actual number of real images fed to the metric.
+2. Preserve the ability to draw conditioning examples for synthesis by continuing to take them from the dataloader batch, but cap them by the outstanding synthetic quota as before.
+3. Ensure the updated logic gracefully handles the case where the real quota is already satisfied (skip the metric update while still allowing early exit once fakes catch up).
+4. Run the existing unit test suite (or the closest available subset) to confirm the change passes.

--- a/tasks/fid-eval-trim/research.md
+++ b/tasks/fid-eval-trim/research.md
@@ -1,0 +1,5 @@
+# FID eval trimming research
+
+- The evaluation loop keeps a running `num_real` counter capped at the per-rank `fid_samples`, but it still feeds full dataloader batches into `fid_metric.update(..., real=True)`.
+- When the dataloader batch exceeds the target real quota, the FID metric accumulates more than the desired number of real images even though the counters and early-exit logic assume only `fid_samples` examples were consumed.
+- This mismatch explains the regression report: the loop can exit after a single oversized batch while the metric internally measured FID against the whole batch, so results differ from the intended "N real vs N fake" comparison.

--- a/tasks/logbeta-sampling-helper/plan.md
+++ b/tasks/logbeta-sampling-helper/plan.md
@@ -1,0 +1,5 @@
+# Plan
+1. **Implement sampling helper**: In `flow_matching/path/beta_schedules.py`, add a `sample_t_uniform_logbeta` method to `ExpMonotoneRQSSchedule` that draws uniform log-β samples, inverts them via `_ExpRQS1D.inverse`, maps logits back to `t`, clamps to `[t_eps, 1-t_eps]`, and returns both `t` and the importance weight `dt/dℓ = t(1-t)/(a * r'(s))` with a small clamp to avoid division by zero.
+2. **Unit tests**: Extend `tests/path/test_path.py` to cover the new helper by sampling a batch of log-β values, verifying that forward/inverse agree with the original tensor, checking the returned weights against finite differences of β(t), and testing boundary behavior (e.g., lmin/lmax corresponding to spline tails).
+3. **Documentation snippet**: Update the README or inline docstring if needed to mention the helper usage so downstream training can discover it.
+4. **Run tests**: Execute the existing test suite (or focused subset) to ensure the new helper and tests pass.

--- a/tasks/logbeta-sampling-helper/research.md
+++ b/tasks/logbeta-sampling-helper/research.md
@@ -1,0 +1,6 @@
+# Research Notes
+- `ExpMonotoneRQSSchedule.beta_and_derivative` exponentiates `y0 + a * r(s)` with `s = logit(t)` to produce `beta` and its derivative `dot_beta`.
+- `_ExpRQS1D.forward` already returns both the spline value `r(s)` and its derivative `dr/ds` for any logit input.
+- `_ExpRQS1D.inverse` (added previously) reconstructs the logit input `s` from a spline output and reuses `forward` to obtain the derivative at the recovered point.
+- No helper exists yet to sample log-β uniformly and map back to `t`; training callers still need to implement this manually.
+- Tests in `tests/path/test_path.py` cover round-trip consistency between `_ExpRQS1D.forward` and `.inverse` but do not exercise any sampling helper on the schedule.

--- a/tasks/logbeta-training-integration/plan.md
+++ b/tasks/logbeta-training-integration/plan.md
@@ -1,0 +1,21 @@
+# Plan
+
+1. **Expose CLI controls**
+   - Add `--mi_logbeta_min` and `--mi_logbeta_max` to `examples/image/train_arg_parser.py` with defaults matching the analytic KO schedule evaluated at safe quantiles (e.g., log β at `t_eps` and `1 - t_eps`).
+   - Document their usage in the help text and ensure values are stored on `args` for training/eval.
+
+2. **Plumb arguments into training setup**
+   - In `examples/image/train.py`, read the new args when constructing the metric-induced path or during loop prep so the training loop can access them (store on `args` if not already available).
+
+3. **Update training loop sampling**
+   - In `train_one_epoch`, replace the uniform `torch.rand` sampling with a call to `metric_path.beta_schedule.sample_t_uniform_logbeta` when the schedule is an `ExpMonotoneRQSSchedule` and log-β interval arguments are provided.
+   - Multiply the per-sample loss by the returned importance weights before reduction.
+   - Maintain existing behavior (uniform `t`) when the helper or schedule is unavailable to keep backward compatibility.
+
+4. **Add safeguards and logging**
+   - Validate `l_min < l_max` on startup and warn or fall back gracefully if not.
+   - Optionally log once per epoch when the importance sampling branch is active (reuse existing logging infrastructure).
+
+5. **Tests**
+   - Extend `tests/path/test_path.py` or add a new test to cover the helper integration if feasible (e.g., check weights > 0), or add a focused unit test that mocks a schedule to confirm weight application in the training loop utility.
+   - Run `pytest tests/path/test_path.py` to ensure existing schedule tests still pass.

--- a/tasks/logbeta-training-integration/research.md
+++ b/tasks/logbeta-training-integration/research.md
@@ -1,0 +1,13 @@
+# Research Notes
+
+## Context
+- `ExpMonotoneRQSSchedule.sample_t_uniform_logbeta` already exposes the helper to sample log-β uniformly and return both `t` and `dt/dℓ`.
+- Metric-induced KO training in `examples/image/training/train_loop.py` currently samples `t = torch.rand(...)` in the metric-induced branch, so the helper is unused.
+- Learnable β-schedule is instantiated in `examples/image/train.py` and stored on the metric-induced path when `--mi_learnable_beta` is enabled.
+- CLI options for metric-induced schedule live in `examples/image/train_arg_parser.py`; no arguments currently expose log-β sampling limits.
+
+## Integration requirements
+- Replace the uniform-in-`t` draw with uniform-in-`log β` sampling when a learnable exponential spline is active.
+- Importance weights must multiply the per-time loss to preserve the original objective.
+- Need CLI flags (likely `--mi_logbeta_min`, `--mi_logbeta_max`) to configure the sampling interval.
+- Training loop requires access to those args; defaults should be sensible and backward compatible.

--- a/tasks/logbeta-weight-broadcast/plan.md
+++ b/tasks/logbeta-weight-broadcast/plan.md
@@ -1,0 +1,4 @@
+# Plan
+1. Update the KL penalty computation in `examples/image/training/train_loop.py` to apply log-β importance weights with correct broadcasting (e.g., unsqueeze weights or reduce KL per sample).
+2. Ensure numerical behavior remains unchanged when weights are `None`.
+3. Add a unit test covering the weighted KL path to guard against regressions.

--- a/tasks/logbeta-weight-broadcast/research.md
+++ b/tasks/logbeta-weight-broadcast/research.md
@@ -1,0 +1,4 @@
+# Research Notes
+- Runtime error occurs during metric-induced training when computing schedule KL value: `(kl_tensor * logbeta_weights)` fails because `kl_tensor` has shape `(batch, num_tokens)` while `logbeta_weights` has shape `(batch,)`.
+- Importance weights from `sample_t_uniform_logbeta` correspond to per-sample factors and should broadcast across token dimension in KL calculation.
+- Need to reshape or reduce KL tensor to avoid shape mismatch.

--- a/tasks/logbeta-weight-density/plan.md
+++ b/tasks/logbeta-weight-density/plan.md
@@ -1,0 +1,3 @@
+1. Update `ExpMonotoneRQSSchedule.sample_t_uniform_logbeta` to multiply the Jacobian weight by the interval length `(lmax - lmin)` with an epsilon clamp for degenerate intervals.
+2. Adjust the corresponding unit test in `tests/path/test_path.py` to expect the rescaled weight and, if needed, assert the interval factor explicitly.
+3. Run `pytest tests/path/test_path.py` to confirm the schedule helper behaviour and ensure no unintended normalization changes in the training loop.

--- a/tasks/logbeta-weight-density/research.md
+++ b/tasks/logbeta-weight-density/research.md
@@ -1,0 +1,3 @@
+- Checked `ExpMonotoneRQSSchedule.sample_t_uniform_logbeta` implementation; currently returns Jacobian `t(1-t)/(a*r'(s))` without log-β interval factor.
+- Reviewed tests in `tests/path/test_path.py`; they assert the weight equals `beta/d_beta`, consistent with missing interval scaling.
+- Training loop uses `_importance_weighted_mean` directly with helper outputs.

--- a/tasks/metric-geometry-args/plan.md
+++ b/tasks/metric-geometry-args/plan.md
@@ -1,0 +1,4 @@
+# Plan
+- Add a README section under `examples/image/` documenting common flag combinations for metric geometry diagnostics and evaluation GIF logging.
+- Highlight typical values for subset sizes, pair sampling, k-NN overlap, and GIF stride/batch/FPS so users can copy/paste commands.
+- Mention any dependencies (e.g., matplotlib for heatmaps, wandb optional) and clarify when the flags apply (metric-induced path vs generic eval).

--- a/tasks/metric-geometry-args/research.md
+++ b/tasks/metric-geometry-args/research.md
@@ -1,0 +1,4 @@
+# Research
+- Metric geometry evaluation flags live in `examples/image/train_arg_parser.py` and toggle Spearman/k-NN/heatmap diagnostics.
+- GIF logging knobs were added alongside evaluation loop changes to control tiling/stride/fps for saved animations.
+- Documentation currently lacks concrete CLI examples for the new flags; `examples/image/README.md` is the primary quickstart reference for commands.

--- a/tasks/metric-geometry-eval/plan.md
+++ b/tasks/metric-geometry-eval/plan.md
@@ -1,0 +1,24 @@
+# Plan: Metric geometry evaluation features
+
+1. **CLI extensions**
+   - Add metric-geometry evaluation flags to `examples/image/train_arg_parser.py` so runs can opt-in and configure the probes.
+   - Options will cover enabling the evaluation, choosing the token subset size, number of pair samples for Spearman, k for the overlap, optional RNG seed, and toggling heatmap export.
+
+2. **Helper utilities in eval loop**
+   - Implement helpers inside `examples/image/training/eval_loop.py` to
+     - choose the evaluation subset of token indices,
+     - extract baseline / learned / teacher / blended distance tables from the metric-induced path on CPU,
+     - compute Spearman rank correlation with optional subsampling,
+     - compute k-NN overlap (Jaccard) between neighbor sets, and
+     - export heatmaps via matplotlib when available (falling back with a warning otherwise).
+
+3. **Integrate geometry probes into evaluation**
+   - When metric-induced sampling is active, invoke the helper once per eval (main process only) after the KO path is instantiated.
+   - Generate statistics for the student, blended path, and optional EMA teacher, attach them to `eval_stats`, and save any requested heatmaps / wandb artifacts under the configured output directory.
+
+4. **Documentation / logging polish**
+   - Ensure log messages explain when computations are skipped (e.g. EMA absent, matplotlib missing, subset too small).
+   - Keep evaluation return dict backward compatible when probes disabled.
+
+5. **Testing / verification**
+   - Run targeted unit tests (`pytest tests/path/test_path.py`) and, if necessary, create small synthetic sanity checks within the eval helper to validate numerical stability (e.g. shape assertions).

--- a/tasks/metric-geometry-eval/research.md
+++ b/tasks/metric-geometry-eval/research.md
@@ -1,0 +1,20 @@
+# Research: Metric geometry evaluation hooks
+
+## Existing metric distance infrastructure
+- `flow_matching/path/mixture.py` implements `MetricInducedGibbsProbPath`.
+  - `_get_base_distance_table(device, dtype)` returns the cached fixed geometry distance matrix for the embedding.
+  - `_build_distance_table(device, dtype, metric_module=None, cache_result=True)` mixes the baseline table with either the in-place learnable metric or an override module (e.g. EMA teacher) scaled to match baseline MAD, and caches the blended matrix when `metric_module` is `None`.
+  - `learnable_metric` (a `MahalanobisTokenMetric`) exposes `pairwise_distance_table(device, dtype)` that expands to the full learned distance matrix.
+
+## Evaluation loop context
+- `examples/image/training/eval_loop.py` runs sampling for FID and currently only logs snapshots/GIFs.
+  - When metric-induced sampling is active, the loop instantiates the `MetricInducedGibbsProbPath` (either provided or constructed on-the-fly) and has access to the KO path object used for sampling.
+  - Evaluation already branches on `args.metric_induced` / `args.ko_metric_induced`, so path-specific probes can be inserted after the solver is constructed.
+
+## Potential reporting surface
+- `eval_model` returns a dictionary merged into the eval stats. Existing keys include just `fid`.
+- Wandb logging already happens higher up; eval loop could emit additional artifacts (CSVs, heatmaps, etc.) by writing into `args.output_dir` and optionally pushing to wandb.
+
+## External utilities
+- No direct helper for Spearman or k-NN overlap exists yet. PyTorch has `torchmetrics` but Spearman is available via `torchmetrics.functional.spearmanr` or SciPy (if available). Need to guard imports to avoid hard dependency.
+- Heatmap generation can reuse matplotlib or seaborn if available; otherwise fallback to PIL/torch image export similar to existing snapshot logic.

--- a/tasks/metric-kl-metric-interp/plan.md
+++ b/tasks/metric-kl-metric-interp/plan.md
@@ -1,0 +1,7 @@
+# Plan
+
+1. Update the adaptive KL controller usage so the weight adapts as soon as at least one averaged KL observation is available. Compute the running average using the window sum/length and call `kl_controller.update` every optimizer step with valid KL statistics.
+2. Surface the averaged KL for logging regardless of window fill so the dashboard reflects the measurements that drive the controller.
+3. Simplify the metric interpolation by removing the MAD-based rescaling in `flow_matching/path/mixture.py`. Replace the `_scaled_learned_distance_table` helper with a direct distance-table fetch and blend using `(1 - λ) * base + λ * learned`.
+4. Remove any now-unused helpers or cached scale fields associated with the MAD normalization.
+5. Run the existing targeted unit test suite (`pytest tests/path/test_path.py`) to confirm the path helpers still function.

--- a/tasks/metric-kl-metric-interp/research.md
+++ b/tasks/metric-kl-metric-interp/research.md
@@ -1,0 +1,6 @@
+# Research Notes
+
+- `AdaptiveKLController` updates its weight only when the KL rolling window reaches its max length; with large `mi_beta_kl_avg_window` values this delays adaptation and can keep the weight stuck at its initial value even when the KL explodes.
+- The update hook lives in `examples/image/training/train_loop.py` and currently requires `len(kl_window) == kl_window.maxlen` before adapting.
+- Metric interpolation between the frozen baseline and the learnable Mahalanobis metric is implemented in `flow_matching/path/mixture.py`; the helper `_scaled_learned_distance_table` rescales the learned table to match the baseline MAD before blending.
+- The user would like to drop the MAD renormalization and revert to a direct convex combination of the two distance tables.

--- a/tasks/redundancy-cleanup/plan.md
+++ b/tasks/redundancy-cleanup/plan.md
@@ -1,0 +1,18 @@
+# Plan
+
+1. **Deduplicate KL controller setup in `train_one_epoch`.**
+   - Remove the second initialization block that resets `kl_window`/`kl_metric` so the restored window from `_load_kl_window_state` is preserved.
+   - Ensure downstream code still has valid defaults when trust region is disabled.
+
+2. **Drop the unused `--temp` CLI flag.**
+   - Delete the argument declaration from `examples/image/train_arg_parser.py`.
+   - Search for any documentation mentions and prune them if found.
+
+3. **Remove the dead `learnable_parameters` helper.**
+   - Delete the method from `MetricInducedGibbsProbPath` in `flow_matching/path/mixture.py`.
+   - Confirm no references remain.
+
+4. **Run unit tests or the targeted test suite.**
+   - Execute `pytest tests/path/test_path.py` to cover the modified path module.
+   - If numerical tolerances in the cache refresh test prove too loose, tighten the
+     assertion to check for a non-zero difference directly.

--- a/tasks/redundancy-cleanup/research.md
+++ b/tasks/redundancy-cleanup/research.md
@@ -1,0 +1,12 @@
+# Research Notes
+
+## Train loop redundancy
+- `examples/image/training/train_loop.py` initializes the KL controller state twice in succession within `train_one_epoch`.
+- The first branch restores a saved deque via `_load_kl_window_state`, while the second immediately discards it and reinitializes an empty deque.
+
+## Unused CLI argument
+- `examples/image/train_arg_parser.py` still declares a `--temp` flag, but no caller reads `args.temp` across the repository (confirmed via `rg "args.temp"`).
+
+## Dead helper on metric-induced path
+- `MetricInducedGibbsProbPath.learnable_parameters()` in `flow_matching/path/mixture.py` simply concatenates schedule and metric parameter iterators, yet no code invokes it (verified via `rg "\.learnable_parameters"`).
+- Optimizer setup explicitly consumes `schedule_parameters()` and `metric_parameters()` instead.

--- a/tests/path/test_learnable_lut.py
+++ b/tests/path/test_learnable_lut.py
@@ -120,13 +120,13 @@ class TestLearnableScalarLUT(unittest.TestCase):
             dtype=torch.float32,
             renormalize_to_init_norm=True,
         )
-        init_norm = lut._init_fro_norm.item()
+        init_norm = lut._base_fro_norm_per_channel.detach().clone()
 
         with torch.no_grad():
             lut.weight.mul_(5.0)
 
-    effective = torch.linalg.vector_norm(lut()).item()
-        self.assertAlmostEqual(effective, init_norm, places=6)
+        effective = torch.linalg.vector_norm(lut(), dim=(1, 2))
+        self.assertTrue(torch.allclose(effective, init_norm, atol=1e-6))
 
     def test_forward_renorm_preserves_gradient(self):
         """Renormalization should keep gradient flow intact."""
@@ -233,10 +233,11 @@ class TestMetricInducedPathWithLUT(unittest.TestCase):
             lut_num_channels=2,
             lut_renorm_to_init_norm=True,
         )
-        init_norm = path.learnable_lut._init_fro_norm.item()
+        init_norm = torch.linalg.norm(path.learnable_lut._base_fro_norm_per_channel).item()
         with torch.no_grad():
             path.learnable_lut.weight.mul_(7.0)
-        effective = torch.linalg.norm(path.learnable_lut(), ord="fro").item()
+        per_channel_norm = torch.linalg.vector_norm(path.learnable_lut(), dim=(1, 2))
+        effective = torch.linalg.norm(per_channel_norm).item()
         self.assertAlmostEqual(effective, init_norm, places=6)
     
     def test_lut_distance_table_shape(self):
@@ -526,7 +527,10 @@ class TestLUTEdgeCases(unittest.TestCase):
         )
         
         self.assertEqual(path.learnable_lut.num_channels, 16)
-        self.assertEqual(path.learnable_lut.weight.shape, (16, 16))
+        self.assertEqual(
+            path.learnable_lut.weight.shape,
+            (16, 16, path.learnable_lut.emb_dim),
+        )
 
 
 if __name__ == "__main__":

--- a/tests/path/test_learnable_lut.py
+++ b/tests/path/test_learnable_lut.py
@@ -1,0 +1,533 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the CC-by-NC license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Unit tests for LearnableScalarLUT and MetricInducedGibbsProbPath with LUT."""
+
+import unittest
+import torch
+import torch.nn as nn
+
+from flow_matching.path import MetricInducedGibbsProbPath
+from flow_matching.path.mixture import LearnableScalarLUT
+
+
+class TestLearnableScalarLUT(unittest.TestCase):
+    """Test the LearnableScalarLUT module in isolation."""
+
+    def test_init_pm1_range(self):
+        """Test initialization with [-1, 1] range."""
+        lut = LearnableScalarLUT(
+            num_channels=3,
+            vocab_size=256,
+            embed_range="pm1",
+            device=None,
+            dtype=torch.float32,
+        )
+        self.assertEqual(lut.num_channels, 3)
+        self.assertEqual(lut.vocab_size, 256)
+        self.assertEqual(lut.embed_range, "pm1")
+    self.assertEqual(lut.weight.shape, (3, 256, 1))
+
+    # Check linear initialization bounds
+    self.assertAlmostEqual(lut.weight[0, 0, 0].item(), -1.0, places=6)
+    self.assertAlmostEqual(lut.weight[0, -1, 0].item(), 1.0, places=6)
+    self.assertTrue(torch.allclose(lut.weight[0], lut.weight[1]))  # All channels identical initially
+        
+    def test_init_unit_range(self):
+        """Test initialization with [0, 1] range."""
+        lut = LearnableScalarLUT(
+            num_channels=1,
+            vocab_size=16,
+            embed_range="unit",
+            device=None,
+            dtype=torch.float32,
+        )
+        self.assertEqual(lut.embed_range, "unit")
+    self.assertAlmostEqual(lut.weight[0, 0, 0].item(), 0.0, places=6)
+    self.assertAlmostEqual(lut.weight[0, -1, 0].item(), 1.0, places=6)
+        
+    def test_invalid_params(self):
+        """Test validation of constructor arguments."""
+        with self.assertRaises(ValueError):
+            LearnableScalarLUT(num_channels=0, vocab_size=256, embed_range="pm1", device=None, dtype=torch.float32)
+        
+        with self.assertRaises(ValueError):
+            LearnableScalarLUT(num_channels=3, vocab_size=-1, embed_range="pm1", device=None, dtype=torch.float32)
+        
+        with self.assertRaises(ValueError):
+            LearnableScalarLUT(num_channels=3, vocab_size=256, embed_range="invalid", device=None, dtype=torch.float32)
+    
+    def test_reset_parameters(self):
+        """Test reset_parameters restores linear initialization."""
+        lut = LearnableScalarLUT(
+            num_channels=2,
+            vocab_size=8,
+            embed_range="pm1",
+            device=None,
+            dtype=torch.float32,
+        )
+        original_weight = lut.weight.clone()
+        
+        # Perturb weights
+        lut.weight.data.add_(torch.randn_like(lut.weight))
+        self.assertFalse(torch.allclose(lut.weight, original_weight))
+        
+        # Reset
+        lut.reset_parameters()
+    self.assertTrue(torch.allclose(lut.weight, original_weight, atol=1e-6))
+    
+    def test_device_dtype(self):
+        """Test device and dtype propagation."""
+        if torch.cuda.is_available():
+            device = torch.device("cuda:0")
+        else:
+            device = torch.device("cpu")
+        
+        lut = LearnableScalarLUT(
+            num_channels=3,
+            vocab_size=256,
+            embed_range="pm1",
+            device=device,
+            dtype=torch.float64,
+        )
+        self.assertEqual(lut.weight.device, device)
+        self.assertEqual(lut.weight.dtype, torch.float64)
+    
+    def test_parameters_are_learnable(self):
+        """Test that weight is registered as a learnable parameter."""
+        lut = LearnableScalarLUT(
+            num_channels=3,
+            vocab_size=256,
+            embed_range="pm1",
+            device=None,
+            dtype=torch.float32,
+        )
+        params = list(lut.parameters())
+        self.assertEqual(len(params), 1)
+        self.assertIs(params[0], lut.weight)
+        self.assertTrue(params[0].requires_grad)
+
+    def test_forward_renorm_keeps_init_norm(self):
+        """Renormalized forward should preserve the initialization Frobenius norm."""
+        lut = LearnableScalarLUT(
+            num_channels=2,
+            vocab_size=16,
+            embed_range="pm1",
+            device=None,
+            dtype=torch.float32,
+            renormalize_to_init_norm=True,
+        )
+        init_norm = lut._init_fro_norm.item()
+
+        with torch.no_grad():
+            lut.weight.mul_(5.0)
+
+    effective = torch.linalg.vector_norm(lut()).item()
+        self.assertAlmostEqual(effective, init_norm, places=6)
+
+    def test_forward_renorm_preserves_gradient(self):
+        """Renormalization should keep gradient flow intact."""
+        lut = LearnableScalarLUT(
+            num_channels=1,
+            vocab_size=8,
+            embed_range="pm1",
+            device=None,
+            dtype=torch.float32,
+            renormalize_to_init_norm=True,
+        )
+        loss = lut().sum()
+        loss.backward()
+        self.assertIsNotNone(lut.weight.grad)
+        self.assertGreater(lut.weight.grad.abs().sum().item(), 0.0)
+
+
+class TestMetricInducedPathWithLUT(unittest.TestCase):
+    """Test MetricInducedGibbsProbPath integration with learnable LUT."""
+    
+    def test_lut_creation_basic(self):
+        """Test basic LUT creation within MetricInducedGibbsProbPath."""
+        path = MetricInducedGibbsProbPath(
+            vocab_size=256,
+            metric="lp",
+            lp_order=3.0,
+            learnable_lut=True,
+            lut_num_channels=3,
+            lut_share_across_channels=False,
+            embed_range="pm1",
+        )
+        
+        self.assertIsNotNone(path.learnable_lut)
+        self.assertEqual(path.learnable_lut.num_channels, 3)
+        self.assertEqual(path.learnable_lut.vocab_size, 256)
+        self.assertEqual(path.learnable_lut.embed_range, "pm1")
+    
+    def test_lut_shared_channels(self):
+        """Test LUT with channel sharing (num_channels=1)."""
+        path = MetricInducedGibbsProbPath(
+            vocab_size=256,
+            metric="lp",
+            lp_order=3.0,
+            learnable_lut=True,
+            lut_num_channels=3,
+            lut_share_across_channels=True,  # Should force num_channels=1
+            embed_range="unit",
+        )
+        
+        self.assertIsNotNone(path.learnable_lut)
+        self.assertEqual(path.learnable_lut.num_channels, 1)
+        self.assertEqual(path.learnable_lut.embed_range, "unit")
+    
+    def test_lut_metric_mutual_exclusion(self):
+        """Test that learnable_lut and learnable_metric cannot be enabled simultaneously."""
+        with self.assertRaisesRegex(ValueError, "Cannot enable both learnable_metric and learnable_lut"):
+            MetricInducedGibbsProbPath(
+                vocab_size=256,
+                metric="lp",
+                learnable_lut=True,
+                learnable_metric_dim=8,  # Conflict
+            )
+    
+    def test_lut_requires_lp_metric(self):
+        """Test that LUT requires 'lp' or 'euclidean' metric."""
+        with self.assertRaisesRegex(ValueError, "learnable_lut currently supports only 'lp' or 'euclidean'"):
+            MetricInducedGibbsProbPath(
+                vocab_size=256,
+                metric="cosine",  # Incompatible
+                learnable_lut=True,
+            )
+    
+    def test_lut_parameters_iterator(self):
+        """Test lut_parameters() yields correct parameters."""
+        path = MetricInducedGibbsProbPath(
+            vocab_size=128,
+            metric="lp",
+            learnable_lut=True,
+            lut_num_channels=3,
+        )
+        
+        lut_params = list(path.lut_parameters())
+        self.assertEqual(len(lut_params), 1)
+    self.assertEqual(lut_params[0].shape, (3, 128, 1))
+        self.assertTrue(lut_params[0].requires_grad)
+    
+    def test_lut_parameters_empty_when_disabled(self):
+        """Test lut_parameters() returns empty iterator when LUT disabled."""
+        path = MetricInducedGibbsProbPath(
+            vocab_size=256,
+            metric="lp",
+            learnable_lut=False,
+        )
+        
+        lut_params = list(path.lut_parameters())
+        self.assertEqual(len(lut_params), 0)
+
+    def test_lut_renorm_flag_preserves_norm(self):
+        """Test that enabling renorm keeps the effective LUT norm fixed."""
+        path = MetricInducedGibbsProbPath(
+            vocab_size=32,
+            metric="lp",
+            learnable_lut=True,
+            lut_num_channels=2,
+            lut_renorm_to_init_norm=True,
+        )
+        init_norm = path.learnable_lut._init_fro_norm.item()
+        with torch.no_grad():
+            path.learnable_lut.weight.mul_(7.0)
+        effective = torch.linalg.norm(path.learnable_lut(), ord="fro").item()
+        self.assertAlmostEqual(effective, init_norm, places=6)
+    
+    def test_lut_distance_table_shape(self):
+        """Test that distance table has correct shape with LUT."""
+        vocab_size = 16
+        num_channels = 3
+        path = MetricInducedGibbsProbPath(
+            vocab_size=vocab_size,
+            metric="lp",
+            learnable_lut=True,
+            lut_num_channels=num_channels,
+        )
+        
+        # Build distance table (on CPU for testing)
+        device = torch.device("cpu")
+        dtype = torch.float32
+        table = path._build_lut_distance_table(device=device, dtype=dtype)
+        
+        # Shape is [C, K, K] where C=channels, K=vocab_size
+        self.assertEqual(table.shape, (num_channels, vocab_size, vocab_size))
+        self.assertEqual(table.dtype, dtype)
+        self.assertEqual(table.device, device)
+    
+    def test_lut_distance_symmetry(self):
+        """Test that distance table is symmetric."""
+        path = MetricInducedGibbsProbPath(
+            vocab_size=8,
+            metric="lp",
+            learnable_lut=True,
+            lut_num_channels=2,
+        )
+        
+        device = torch.device("cpu")
+        dtype = torch.float32
+        table = path._build_lut_distance_table(device=device, dtype=dtype)
+        
+        # Distance should be symmetric: [C, K, K] -> transpose last two dims
+        self.assertTrue(torch.allclose(table, table.transpose(-2, -1), atol=1e-6))
+    
+    def test_lut_distance_diagonal_zero(self):
+        """Test that diagonal of distance table is zero (d(i,i) = 0)."""
+        path = MetricInducedGibbsProbPath(
+            vocab_size=10,
+            metric="lp",
+            learnable_lut=True,
+            lut_num_channels=1,
+        )
+        
+        device = torch.device("cpu")
+        dtype = torch.float32
+        table = path._build_lut_distance_table(device=device, dtype=dtype)
+        
+        # table is [C, K, K]; check diagonal for each channel
+        for c in range(table.shape[0]):
+            diagonal = torch.diagonal(table[c])
+            self.assertTrue(torch.allclose(diagonal, torch.zeros_like(diagonal), atol=1e-6))
+    
+    def test_lut_distance_positive(self):
+        """Test that all distances are non-negative."""
+        path = MetricInducedGibbsProbPath(
+            vocab_size=12,
+            metric="lp",
+            learnable_lut=True,
+            lut_num_channels=3,
+        )
+        
+        device = torch.device("cpu")
+        dtype = torch.float32
+        table = path._build_lut_distance_table(device=device, dtype=dtype)
+        
+        self.assertTrue((table >= 0).all())
+    
+    def test_lut_absolute_difference_semantics(self):
+        """Test that LUT distances follow absolute difference semantics."""
+        vocab_size = 4
+        path = MetricInducedGibbsProbPath(
+            vocab_size=vocab_size,
+            metric="lp",
+            lp_order=1.0,  # L1 norm = sum of absolute differences
+            learnable_lut=True,
+            lut_num_channels=2,
+            lut_share_across_channels=False,
+        )
+        
+        # Manually set LUT weights for predictable distances
+        # Channel 0: [0, 1, 2, 3]
+        # Channel 1: [0, 10, 20, 30]
+        with torch.no_grad():
+            path.learnable_lut.weight[0] = torch.tensor([0.0, 1.0, 2.0, 3.0])
+            path.learnable_lut.weight[1] = torch.tensor([0.0, 10.0, 20.0, 30.0])
+        
+        device = torch.device("cpu")
+        dtype = torch.float32
+        table = path._build_lut_distance_table(device=device, dtype=dtype)
+        
+        # table is [2, 4, 4] - check channel 0 and 1 separately
+        # Channel 0: d(0, 1) = |0-1| = 1
+        self.assertAlmostEqual(table[0, 0, 1].item(), 1.0, places=5)
+        
+        # Channel 0: d(0, 3) = |0-3| = 3
+        self.assertAlmostEqual(table[0, 0, 3].item(), 3.0, places=5)
+        
+        # Channel 1: d(0, 1) = |0-10| = 10
+        self.assertAlmostEqual(table[1, 0, 1].item(), 10.0, places=5)
+    
+    def test_lut_channel_assignments(self):
+        """Test _lut_channel_assignments helper."""
+        vocab_size = 12  # 3 channels × 4 pixels
+        path = MetricInducedGibbsProbPath(
+            vocab_size=vocab_size,
+            metric="lp",
+            learnable_lut=True,
+            lut_num_channels=3,
+        )
+        
+        # Create dummy token tensor
+        tokens = torch.zeros((2, 12), dtype=torch.long)  # batch=2, seq=12
+        assignments = path._lut_channel_assignments(tokens)
+        
+        # Should be [0,0,0,0, 1,1,1,1, 2,2,2,2] for each batch
+        expected_per_batch = torch.tensor([0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2], dtype=torch.long)
+        self.assertTrue(torch.equal(assignments[0], expected_per_batch))
+        self.assertTrue(torch.equal(assignments[1], expected_per_batch))
+    
+    def test_lut_rows_helper(self):
+        """Test _lut_rows helper returns correct row indices."""
+        vocab_size = 8  # 2 channels × 4 pixels
+        path = MetricInducedGibbsProbPath(
+            vocab_size=vocab_size,
+            metric="lp",
+            learnable_lut=True,
+            lut_num_channels=2,
+        )
+        
+        # Build distance table and token indices
+        device = torch.device("cpu")
+        dtype = torch.float32
+        dist_table = path._build_lut_distance_table(device=device, dtype=dtype)
+        
+        # Create dummy token indices: [batch=2, seq=8]
+        token_indices = torch.arange(8).unsqueeze(0).expand(2, -1)
+        
+        # _lut_rows returns [B, S, K]
+        rows = path._lut_rows(dist_table, token_indices)
+        
+        self.assertEqual(rows.shape, (2, 8, vocab_size))
+    
+    def test_lut_interpolation_disabled(self):
+        """Test that interpolation lambda is forced to 0 when LUT enabled."""
+        path = MetricInducedGibbsProbPath(
+            vocab_size=256,
+            metric="lp",
+            learnable_lut=True,
+            metric_interp_lambda=0.5,  # Should be ignored
+        )
+        
+        # Should log warning and clamp to 0
+        # Sample to trigger the warning check
+        x0 = torch.randint(0, 256, (4, 8))
+        x1 = torch.randint(0, 256, (4, 8))
+        t = torch.rand(4)
+        
+        # If lambda were non-zero, this would raise an error or log warning
+        # We just check the path initializes correctly
+        self.assertIsNotNone(path.learnable_lut)
+
+
+class TestLUTGradientFlow(unittest.TestCase):
+    """Test gradient flow through LUT in training scenarios."""
+    
+    def test_lut_gradients_computed(self):
+        """Test that gradients flow back to LUT parameters."""
+        path = MetricInducedGibbsProbPath(
+            vocab_size=8,
+            metric="lp",
+            lp_order=2.0,
+            learnable_lut=True,
+            lut_num_channels=1,
+        )
+        
+        # Create dummy loss: sum of all distances
+        device = torch.device("cpu")
+        dtype = torch.float32
+        table = path._build_lut_distance_table(device=device, dtype=dtype)
+        
+        loss = table.sum()
+        loss.backward()
+        
+        # Check gradients exist
+        self.assertIsNotNone(path.learnable_lut.weight.grad)
+        self.assertGreater(path.learnable_lut.weight.grad.abs().sum().item(), 0)
+    
+    def test_lut_optimizer_integration(self):
+        """Test LUT parameters can be optimized."""
+        path = MetricInducedGibbsProbPath(
+            vocab_size=4,
+            metric="lp",
+            learnable_lut=True,
+            lut_num_channels=1,
+        )
+        
+        optimizer = torch.optim.SGD(path.lut_parameters(), lr=0.01)
+        
+        initial_weight = path.learnable_lut.weight.clone()
+        
+        # Simple optimization step
+        for _ in range(5):
+            optimizer.zero_grad()
+            device = torch.device("cpu")
+            dtype = torch.float32
+            table = path._build_lut_distance_table(device=device, dtype=dtype)
+            loss = table.sum()
+            loss.backward()
+            optimizer.step()
+        
+        # Weights should have changed
+        self.assertFalse(torch.allclose(path.learnable_lut.weight, initial_weight))
+    
+    def test_lut_freeze(self):
+        """Test freezing LUT parameters (requires_grad=False)."""
+        path = MetricInducedGibbsProbPath(
+            vocab_size=8,
+            metric="lp",
+            learnable_lut=True,
+            lut_num_channels=2,
+        )
+        
+        # Freeze
+        for param in path.lut_parameters():
+            param.requires_grad = False
+        
+        # Try to compute gradients - this should not raise because requires_grad=False
+        device = torch.device("cpu")
+        dtype = torch.float32
+        table = path._build_lut_distance_table(device=device, dtype=dtype)
+        
+        # Cannot backward on a detached tensor
+        # Just verify the parameter is frozen
+        self.assertFalse(path.learnable_lut.weight.requires_grad)
+
+
+class TestLUTEdgeCases(unittest.TestCase):
+    """Test edge cases and boundary conditions."""
+    
+    def test_single_channel_vocab(self):
+        """Test with minimal vocab_size and channels."""
+        path = MetricInducedGibbsProbPath(
+            vocab_size=2,
+            metric="lp",
+            learnable_lut=True,
+            lut_num_channels=1,
+        )
+        
+        self.assertEqual(path.learnable_lut.vocab_size, 2)
+        self.assertEqual(path.learnable_lut.num_channels, 1)
+        
+        device = torch.device("cpu")
+        dtype = torch.float32
+        table = path._build_lut_distance_table(device=device, dtype=dtype)
+        self.assertEqual(table.shape, (1, 2, 2))  # [C=1, K=2, K=2]
+    
+    def test_large_vocab(self):
+        """Test with large vocabulary size."""
+        vocab_size = 1024
+        num_channels = 3
+        path = MetricInducedGibbsProbPath(
+            vocab_size=vocab_size,
+            metric="lp",
+            learnable_lut=True,
+            lut_num_channels=num_channels,
+        )
+        
+        device = torch.device("cpu")
+        dtype = torch.float32
+        table = path._build_lut_distance_table(device=device, dtype=dtype)
+        
+        self.assertEqual(table.shape, (num_channels, vocab_size, vocab_size))
+        self.assertTrue(torch.allclose(table, table.transpose(-2, -1), atol=1e-5))
+    
+    def test_many_channels(self):
+        """Test with many channels."""
+        path = MetricInducedGibbsProbPath(
+            vocab_size=16,
+            metric="lp",
+            learnable_lut=True,
+            lut_num_channels=16,  # 16 channels × 1 pixel each
+        )
+        
+        self.assertEqual(path.learnable_lut.num_channels, 16)
+        self.assertEqual(path.learnable_lut.weight.shape, (16, 16))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/path/test_path.py
+++ b/tests/path/test_path.py
@@ -387,6 +387,53 @@ class TestExpMonotoneRQSchedule(unittest.TestCase):
         self.assertTrue(torch.allclose(d_beta, baseline_deriv, atol=1e-7, rtol=1e-5))
         self.assertTrue(torch.all(d_beta > 0))
 
+    def test_sample_uniform_logbeta_round_trip_and_weight(self):
+        seed = 1234
+        torch.manual_seed(seed)
+        config = ExpMonotoneRQSConfig(
+            num_bins=4,
+            tail_bound=3.0,
+            init_c=1.2,
+            init_a=2.3,
+            t_eps=1e-5,
+            logit_eps=1e-6,
+        )
+        schedule = ExpMonotoneRQSSchedule(config=config).to(dtype=torch.float64)
+
+        batch_shape = (16,)
+        lmin, lmax = -1.5, 1.8
+        t, weight = schedule.sample_t_uniform_logbeta(batch_shape, lmin, lmax)
+
+        self.assertEqual(t.shape, torch.Size(batch_shape))
+        self.assertEqual(weight.shape, torch.Size(batch_shape))
+        self.assertTrue(torch.all(t >= config.t_eps))
+        self.assertTrue(torch.all(t <= 1.0 - config.t_eps))
+
+        beta, d_beta = schedule.beta_and_derivative(t)
+        ell_recovered = beta.log()
+
+        self.assertTrue(torch.all(ell_recovered >= lmin - 1e-6))
+        self.assertTrue(torch.all(ell_recovered <= lmax + 1e-6))
+
+        expected_weight = beta / d_beta
+        self.assertTrue(torch.all(expected_weight > 0))
+        self.assertTrue(
+            torch.allclose(weight, expected_weight, atol=1e-6, rtol=1e-5)
+        )
+
+        torch.manual_seed(seed)
+        expected_ell = torch.empty(
+            batch_shape, dtype=ell_recovered.dtype, device=ell_recovered.device
+        ).uniform_(lmin, lmax)
+        self.assertTrue(
+            torch.allclose(ell_recovered, expected_ell, atol=1e-6, rtol=1e-5)
+        )
+
+    def test_sample_uniform_logbeta_interval_validation(self):
+        schedule = ExpMonotoneRQSSchedule()
+        with self.assertRaises(ValueError):
+            schedule.sample_t_uniform_logbeta((4,), 1.0, 0.0)
+
 
 class TestExpRQSInverse(unittest.TestCase):
     def test_inverse_round_trip(self):

--- a/tests/path/test_path.py
+++ b/tests/path/test_path.py
@@ -253,7 +253,8 @@ class TestMetricInducedProbPath(unittest.TestCase):
             assert path.learnable_metric is not None
             path.learnable_metric.codes.mul_(1.1)
         dist_after = path.distances_from_tokens(tokens).detach()
-        self.assertFalse(torch.allclose(dist_before, dist_after))
+        diff = (dist_after - dist_before).abs().sum()
+        self.assertGreater(diff.item(), 0.0)
 
 
 class TestScheduleUtilities(unittest.TestCase):

--- a/tests/path/test_path.py
+++ b/tests/path/test_path.py
@@ -434,6 +434,33 @@ class TestExpMonotoneRQSchedule(unittest.TestCase):
         with self.assertRaises(ValueError):
             schedule.sample_t_uniform_logbeta((4,), 1.0, 0.0)
 
+    def test_sample_uniform_logbeta_with_default_bounds(self):
+        config = ExpMonotoneRQSConfig(
+            num_bins=3,
+            tail_bound=4.0,
+            init_c=1.1,
+            init_a=2.7,
+            t_eps=1e-4,
+            logit_eps=1e-6,
+        )
+        schedule = ExpMonotoneRQSSchedule(config=config)
+        with torch.no_grad():
+            t_bounds = torch.tensor(
+                [config.t_eps, 1.0 - config.t_eps], dtype=schedule.y0.dtype
+            )
+            beta_bounds, _ = schedule.beta_and_derivative(t_bounds)
+            beta_bounds = beta_bounds.clamp_min(1e-12)
+            lmin, lmax = beta_bounds.log().tolist()
+
+        self.assertLess(lmin, lmax)
+
+        t, weight = schedule.sample_t_uniform_logbeta((8,), lmin, lmax)
+        self.assertEqual(t.shape, torch.Size([8]))
+        self.assertEqual(weight.shape, torch.Size([8]))
+        self.assertTrue(torch.all(t >= config.t_eps))
+        self.assertTrue(torch.all(t <= 1.0 - config.t_eps))
+        self.assertTrue(torch.all(weight > 0))
+
 
 class TestExpRQSInverse(unittest.TestCase):
     def test_inverse_round_trip(self):

--- a/tests/path/test_path.py
+++ b/tests/path/test_path.py
@@ -22,6 +22,7 @@ from flow_matching.path import (
 )
 from flow_matching.path.scheduler import CondOTScheduler
 from flow_matching.utils.manifolds import FlatTorus, Sphere
+from flow_matching.path.beta_schedules import _ExpRQS1D
 
 
 class TestAffineProbPath(unittest.TestCase):
@@ -385,6 +386,30 @@ class TestExpMonotoneRQSchedule(unittest.TestCase):
         self.assertTrue(torch.allclose(beta, baseline, atol=1e-7, rtol=1e-5))
         self.assertTrue(torch.allclose(d_beta, baseline_deriv, atol=1e-7, rtol=1e-5))
         self.assertTrue(torch.all(d_beta > 0))
+
+
+class TestExpRQSInverse(unittest.TestCase):
+    def test_inverse_round_trip(self):
+        torch.manual_seed(0)
+        rqs = _ExpRQS1D(num_bins=5, tail_bound=2.5).to(dtype=torch.float64)
+        with torch.no_grad():
+            rqs.theta_w.copy_(torch.randn_like(rqs.theta_w))
+            rqs.theta_h.copy_(torch.randn_like(rqs.theta_h))
+            if rqs.theta_d.numel() > 0:
+                rqs.theta_d.copy_(torch.randn_like(rqs.theta_d))
+
+        inputs = torch.linspace(-3.0, 3.0, steps=41, dtype=torch.float64)
+        outputs, derivatives = rqs(inputs)
+        recovered, recovered_derivatives = rqs.inverse(outputs)
+
+        max_error = (recovered - inputs).abs().max().item()
+        self.assertLessEqual(max_error, 5e-6)
+        self.assertTrue(torch.all(recovered_derivatives > 0.0))
+        self.assertTrue(
+            torch.allclose(
+                recovered_derivatives, derivatives, atol=1e-6, rtol=1e-5
+            )
+        )
 
 
 if __name__ == "__main__":

--- a/tests/path/test_path.py
+++ b/tests/path/test_path.py
@@ -415,7 +415,8 @@ class TestExpMonotoneRQSchedule(unittest.TestCase):
         self.assertTrue(torch.all(ell_recovered >= lmin - 1e-6))
         self.assertTrue(torch.all(ell_recovered <= lmax + 1e-6))
 
-        expected_weight = beta / d_beta
+        interval = max(lmax - lmin, torch.finfo(beta.dtype).eps)
+        expected_weight = interval * (beta / d_beta)
         self.assertTrue(torch.all(expected_weight > 0))
         self.assertTrue(
             torch.allclose(weight, expected_weight, atol=1e-6, rtol=1e-5)

--- a/tests/path/test_path.py
+++ b/tests/path/test_path.py
@@ -462,6 +462,22 @@ class TestExpMonotoneRQSchedule(unittest.TestCase):
         self.assertTrue(torch.all(t <= 1.0 - config.t_eps))
         self.assertTrue(torch.all(weight > 0))
 
+    def test_logbeta_regularization_returns_finite_scalars(self):
+        config = ExpMonotoneRQSConfig(num_bins=6, tail_bound=3.0, init_c=1.2, init_a=2.1)
+        schedule = ExpMonotoneRQSSchedule(config=config)
+
+        base_terms = schedule.logbeta_regularization()
+        narrow_terms = schedule.logbeta_regularization(t_lo=0.2, t_hi=0.8)
+        weighted_terms = schedule.logbeta_regularization(power=1.5)
+
+        for terms in (base_terms, narrow_terms, weighted_terms):
+            for key in ("delta", "delta2", "endpoint"):
+                value = terms[key]
+                self.assertIsInstance(value, torch.Tensor)
+                self.assertEqual(value.shape, torch.Size([]))
+                self.assertTrue(torch.isfinite(value))
+        
+
 
 class TestExpRQSInverse(unittest.TestCase):
     def test_inverse_round_trip(self):

--- a/tests/test_lut_training_integration.py
+++ b/tests/test_lut_training_integration.py
@@ -1,0 +1,293 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the CC-by-NC license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Integration tests for LUT training pipeline."""
+
+import unittest
+import sys
+import tempfile
+import torch
+from pathlib import Path
+
+# Add examples/image to path for imports
+_test_dir = Path(__file__).resolve().parent
+_examples_image = _test_dir.parent / "examples" / "image"
+if str(_examples_image) not in sys.path:
+    sys.path.insert(0, str(_examples_image))
+
+from train_arg_parser import get_args_parser
+from flow_matching.path import MetricInducedGibbsProbPath
+
+
+class TestLUTArgumentParsing(unittest.TestCase):
+    """Test CLI argument parsing for LUT options."""
+    
+    def test_lut_default_disabled(self):
+        """Test LUT is disabled by default."""
+        parser = get_args_parser()
+        args = parser.parse_args([
+            "--data_path", "/tmp",
+            "--output_dir", "/tmp",
+        ])
+        
+        self.assertFalse(getattr(args, "mi_learnable_lut", False))
+    
+    def test_lut_enable_flag(self):
+        """Test --mi_learnable_lut flag."""
+        parser = get_args_parser()
+        args = parser.parse_args([
+            "--data_path", "/tmp",
+            "--output_dir", "/tmp",
+            "--mi_learnable_lut",
+        ])
+        
+        self.assertTrue(args.mi_learnable_lut)
+    
+    def test_lut_num_channels(self):
+        """Test --mi_lut_num_channels argument."""
+        parser = get_args_parser()
+        args = parser.parse_args([
+            "--data_path", "/tmp",
+            "--output_dir", "/tmp",
+            "--mi_learnable_lut",
+            "--mi_lut_num_channels", "1",
+        ])
+        
+        self.assertEqual(args.mi_lut_num_channels, 1)
+    
+    def test_lut_share_channels(self):
+        """Test --mi_lut_share_channels flag."""
+        parser = get_args_parser()
+        args = parser.parse_args([
+            "--data_path", "/tmp",
+            "--output_dir", "/tmp",
+            "--mi_learnable_lut",
+            "--mi_lut_share_channels",
+        ])
+        
+        self.assertTrue(getattr(args, "mi_lut_share_channels", False))
+    
+    def test_lut_freeze_flag(self):
+        """Test --mi_freeze_lut flag."""
+        parser = get_args_parser()
+        args = parser.parse_args([
+            "--data_path", "/tmp",
+            "--output_dir", "/tmp",
+            "--mi_learnable_lut",
+            "--mi_freeze_lut",
+        ])
+        
+        self.assertTrue(args.mi_freeze_lut)
+    
+    def test_lut_lr_scale(self):
+        """Test --mi_lut_lr_scale argument."""
+        parser = get_args_parser()
+        args = parser.parse_args([
+            "--data_path", "/tmp",
+            "--output_dir", "/tmp",
+            "--mi_learnable_lut",
+            "--mi_lut_lr_scale", "0.05",
+        ])
+        
+        self.assertAlmostEqual(args.mi_lut_lr_scale, 0.05)
+    
+    def test_lut_weight_decay(self):
+        """Test --mi_lut_weight_decay argument."""
+        parser = get_args_parser()
+        args = parser.parse_args([
+            "--data_path", "/tmp",
+            "--output_dir", "/tmp",
+            "--mi_learnable_lut",
+            "--mi_lut_weight_decay", "1e-3",
+        ])
+        
+        self.assertAlmostEqual(args.mi_lut_weight_decay, 1e-3)
+
+
+class TestLUTOptimizerIntegration(unittest.TestCase):
+    """Test LUT parameter groups in optimizer."""
+    
+    def test_lut_parameters_in_optimizer(self):
+        """Test LUT parameters are added to optimizer."""
+        path = MetricInducedGibbsProbPath(
+            vocab_size=256,
+            metric="lp",
+            learnable_lut=True,
+            lut_num_channels=3,
+        )
+        
+        # Collect LUT parameters
+        lut_params = list(path.lut_parameters())
+        self.assertEqual(len(lut_params), 1)
+        
+        # Create optimizer with separate groups
+        model_params = [torch.nn.Parameter(torch.randn(10, 10))]
+        
+        optimizer = torch.optim.AdamW([
+            {"params": model_params, "lr": 1e-4, "name": "model"},
+            {"params": lut_params, "lr": 1e-5, "name": "lut"},
+        ])
+        
+        # Check optimizer has 2 param groups
+        self.assertEqual(len(optimizer.param_groups), 2)
+        self.assertEqual(optimizer.param_groups[0]["name"], "model")
+        self.assertEqual(optimizer.param_groups[1]["name"], "lut")
+        self.assertEqual(optimizer.param_groups[1]["lr"], 1e-5)
+    
+    def test_frozen_lut_excluded_from_optimizer(self):
+        """Test frozen LUT parameters are not in optimizer."""
+        path = MetricInducedGibbsProbPath(
+            vocab_size=256,
+            metric="lp",
+            learnable_lut=True,
+            lut_num_channels=3,
+        )
+        
+        # Freeze LUT
+        for param in path.lut_parameters():
+            param.requires_grad = False
+        
+        # Filter parameters by requires_grad
+        lut_params_trainable = [p for p in path.lut_parameters() if p.requires_grad]
+        self.assertEqual(len(lut_params_trainable), 0)
+        
+        # Optimizer should skip frozen params
+        model_params = [torch.nn.Parameter(torch.randn(10, 10))]
+        
+        optimizer = torch.optim.AdamW([
+            {"params": model_params, "lr": 1e-4},
+        ])
+        
+        # Only model params in optimizer
+        self.assertEqual(len(optimizer.param_groups), 1)
+    
+    def test_lut_gradient_step(self):
+        """Test LUT parameters can be optimized."""
+        path = MetricInducedGibbsProbPath(
+            vocab_size=16,
+            metric="lp",
+            learnable_lut=True,
+            lut_num_channels=1,
+        )
+        
+        lut_params = list(path.lut_parameters())
+        optimizer = torch.optim.SGD(lut_params, lr=0.1)
+        
+        initial_weight = path.learnable_lut.weight.clone()
+        
+        # Perform optimization step
+        for _ in range(3):
+            optimizer.zero_grad()
+            table = path._build_lut_distance_table(
+                device=torch.device("cpu"),
+                dtype=torch.float32
+            )
+            loss = table.sum()
+            loss.backward()
+            optimizer.step()
+        
+        # Weights should have changed
+        self.assertFalse(torch.allclose(path.learnable_lut.weight, initial_weight, atol=1e-6))
+
+
+class TestLUTCheckpointSaving(unittest.TestCase):
+    """Test LUT state_dict saving/loading."""
+    
+    def test_lut_state_dict(self):
+        """Test LUT parameters appear in state_dict."""
+        path = MetricInducedGibbsProbPath(
+            vocab_size=256,
+            metric="lp",
+            learnable_lut=True,
+            lut_num_channels=3,
+        )
+        
+        # LUT module should have state_dict
+        lut_state = path.learnable_lut.state_dict()
+        self.assertIn("weight", lut_state)
+        self.assertEqual(lut_state["weight"].shape, (3, 256))
+    
+    def test_lut_load_state_dict(self):
+        """Test loading LUT from state_dict."""
+        path1 = MetricInducedGibbsProbPath(
+            vocab_size=128,
+            metric="lp",
+            learnable_lut=True,
+            lut_num_channels=2,
+        )
+        
+        # Modify LUT weights
+        with torch.no_grad():
+            path1.learnable_lut.weight.fill_(0.5)
+        
+        # Save state
+        state = path1.learnable_lut.state_dict()
+        
+        # Create new path and load
+        path2 = MetricInducedGibbsProbPath(
+            vocab_size=128,
+            metric="lp",
+            learnable_lut=True,
+            lut_num_channels=2,
+        )
+        
+        path2.learnable_lut.load_state_dict(state)
+        
+        # Weights should match
+        self.assertTrue(torch.allclose(
+            path1.learnable_lut.weight,
+            path2.learnable_lut.weight
+        ))
+
+
+class TestLUTMutualExclusion(unittest.TestCase):
+    """Test mutual exclusion between LUT and learnable metric."""
+    
+    def test_cannot_enable_both_lut_and_metric(self):
+        """Test error when both LUT and metric are enabled."""
+        with self.assertRaisesRegex(ValueError, "Cannot enable both"):
+            MetricInducedGibbsProbPath(
+                vocab_size=256,
+                metric="lp",
+                learnable_lut=True,
+                learnable_metric_dim=16,
+            )
+    
+    def test_lut_only(self):
+        """Test LUT can be enabled alone."""
+        path = MetricInducedGibbsProbPath(
+            vocab_size=256,
+            metric="lp",
+            learnable_lut=True,
+        )
+        
+        self.assertIsNotNone(path.learnable_lut)
+        self.assertIsNone(path.learnable_metric)
+    
+    def test_metric_only(self):
+        """Test metric can be enabled alone."""
+        path = MetricInducedGibbsProbPath(
+            vocab_size=256,
+            metric="lp",
+            learnable_metric_dim=16,
+        )
+        
+        self.assertIsNone(path.learnable_lut)
+        self.assertIsNotNone(path.learnable_metric)
+    
+    def test_neither_enabled(self):
+        """Test neither LUT nor metric enabled."""
+        path = MetricInducedGibbsProbPath(
+            vocab_size=256,
+            metric="lp",
+        )
+        
+        self.assertIsNone(path.learnable_lut)
+        self.assertIsNone(path.learnable_metric)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_lut_training_integration.py
+++ b/tests/test_lut_training_integration.py
@@ -208,7 +208,12 @@ class TestLUTCheckpointSaving(unittest.TestCase):
         # LUT module should have state_dict
         lut_state = path.learnable_lut.state_dict()
         self.assertIn("weight", lut_state)
-        self.assertEqual(lut_state["weight"].shape, (3, 256))
+        weight_tensor = lut_state["weight"]
+        self.assertEqual(weight_tensor.shape[0], 3)
+        self.assertEqual(weight_tensor.shape[1], 256)
+        self.assertGreaterEqual(weight_tensor.ndim, 2)
+        if weight_tensor.ndim >= 3 and hasattr(path.learnable_lut, "emb_dim"):
+            self.assertEqual(weight_tensor.shape[-1], path.learnable_lut.emb_dim)
     
     def test_lut_load_state_dict(self):
         """Test loading LUT from state_dict."""

--- a/tests/utils/test_importance_weighted_mean.py
+++ b/tests/utils/test_importance_weighted_mean.py
@@ -1,0 +1,54 @@
+import sys
+import types
+
+import torch
+
+stub_models = types.ModuleType("models")
+stub_models_ema = types.ModuleType("models.ema")
+stub_training = types.ModuleType("training")
+stub_training_grad_scaler = types.ModuleType("training.grad_scaler")
+stub_training_distributed = types.ModuleType("training.distributed_mode")
+
+
+class _StubEMA:  # pragma: no cover - simple placeholder
+    def __init__(self, *args, **kwargs):
+        raise RuntimeError("EMA should not be constructed during tests")
+
+
+stub_models_ema.EMA = _StubEMA
+stub_models.ema = stub_models_ema
+sys.modules.setdefault("models", stub_models)
+sys.modules.setdefault("models.ema", stub_models_ema)
+
+
+class _StubScaler:  # pragma: no cover - placeholder
+    def __init__(self, *args, **kwargs):
+        raise RuntimeError("Scaler should not be constructed during tests")
+
+
+stub_training_grad_scaler.NativeScalerWithGradNormCount = _StubScaler
+stub_training.grad_scaler = stub_training_grad_scaler
+stub_training.distributed_mode = stub_training_distributed
+stub_training_distributed.get_world_size = lambda: 1
+stub_training_distributed.get_rank = lambda: 0
+stub_training_distributed.is_main_process = lambda: True
+stub_training_distributed.is_dist_avail_and_initialized = lambda: False
+sys.modules.setdefault("training", stub_training)
+sys.modules.setdefault("training.grad_scaler", stub_training_grad_scaler)
+sys.modules.setdefault("training.distributed_mode", stub_training_distributed)
+
+from examples.image.training.train_loop import _importance_weighted_mean
+
+
+def test_importance_weighted_mean_without_weights():
+    values = torch.tensor([1.0, 2.0, 3.0])
+    result = _importance_weighted_mean(values, None)
+    assert torch.isclose(result, values.mean())
+
+
+def test_importance_weighted_mean_broadcasts_weights():
+    values = torch.ones(2, 3)
+    weights = torch.tensor([2.0, 0.5])
+    expected = (values * weights.unsqueeze(-1)).mean()
+    result = _importance_weighted_mean(values, weights)
+    assert torch.isclose(result, expected)


### PR DESCRIPTION
## Summary
- add CLI switches to enable metric geometry probes and configure token subsets, pair sampling, k-NN size, and heatmap export during evaluation
- compute Spearman correlation, k-NN overlap, and optional heatmaps for metric-induced runs, with support for EMA teachers, and log the results alongside FID
- expose a scaled learned-distance helper for reuse when comparing baseline, student, teacher, and blended geometries

## Testing
- pytest tests/path/test_path.py

------
https://chatgpt.com/codex/tasks/task_e_68d3a2b2c4b883219ad316fd459545b8

## Summary by Sourcery

Add configurable metric geometry probes and GIF logging to the evaluation loop: compute and log Spearman correlations, k-NN overlap, and optional heatmaps for metric-induced paths alongside FID, trim real-sample FID updates, refactor the path module for scaled distance tables, and update tests accordingly.

New Features:
- Add CLI flags for metric geometry evaluation (subset size, pair sampling, k-NN size, RNG seed, heatmap export) and GIF logging (max batch, stride, fps, and enable switch)
- Integrate metric geometry diagnostics into the evaluation loop, computing Spearman correlations and k-NN overlap for baseline, student, teacher, and blended metrics with optional heatmap export and wandb logging
- Implement sampling trajectory capture from solvers and export tiled GIFs of intermediate states during evaluation

Enhancements:
- Trim FID computation of real samples to exactly fid_samples by slicing batches
- Refactor MetricInducedGibbsProbPath to expose a scaled learned-distance helper and simplify distance-table construction
- Remove unused `--temp` flag, `learnable_parameters` method, and redundant KL controller setup

Tests:
- Strengthen test to assert non-zero change in learned metric distances after update