### PR TITLE
Add adaptive log-beta sampling for metric-induced path

### DIFF
--- a/examples/image/train.py
+++ b/examples/image/train.py
@@ -179,10 +179,36 @@ def main(args):
                         defaults = beta_vals.log().tolist()
                     if logbeta_min is None:
                         logbeta_min = float(defaults[0])
-                    if logbeta_max is None:
-                        logbeta_max = float(defaults[1])
-                args.mi_logbeta_min = float(logbeta_min)
-                args.mi_logbeta_max = float(logbeta_max)
+                if logbeta_max is None:
+                    logbeta_max = float(defaults[1])
+            args.mi_logbeta_min = float(logbeta_min)
+            args.mi_logbeta_max = float(logbeta_max)
+
+        args.mi_difficulty_refresh_interval = max(
+            1, int(getattr(args, "mi_difficulty_refresh_interval", 128))
+        )
+        sample_frac = float(getattr(args, "mi_difficulty_sample_fraction", 0.05))
+        args.mi_difficulty_sample_fraction = float(max(0.0, min(sample_frac, 1.0)))
+        args.mi_difficulty_max_positions = max(
+            1, int(getattr(args, "mi_difficulty_max_positions", 8192))
+        )
+        alpha = float(getattr(args, "mi_difficulty_alpha", 0.5))
+        args.mi_difficulty_alpha = float(max(0.0, min(alpha, 1.0)))
+        ratio_min = float(getattr(args, "mi_difficulty_ratio_min", 0.5))
+        ratio_max = float(getattr(args, "mi_difficulty_ratio_max", 0.05))
+        eps_ratio = 1e-6
+        args.mi_difficulty_ratio_min = float(
+            max(eps_ratio, min(ratio_min, 1.0 - eps_ratio))
+        )
+        args.mi_difficulty_ratio_max = float(
+            max(eps_ratio, min(ratio_max, 1.0 - eps_ratio))
+        )
+        fallback_min = float(getattr(args, "mi_difficulty_fallback_min", 0.5))
+        fallback_max = float(getattr(args, "mi_difficulty_fallback_max", 2.2))
+        if fallback_max < fallback_min:
+            fallback_min, fallback_max = fallback_max, fallback_min
+        args.mi_difficulty_fallback_min = float(fallback_min)
+        args.mi_difficulty_fallback_max = float(fallback_max)
 
         gumbel_tau_default = float(getattr(args, "mi_gumbel_tau", 1.0))
         tau_start = getattr(args, "mi_gumbel_tau_start", None)

--- a/examples/image/train_arg_parser.py
+++ b/examples/image/train_arg_parser.py
@@ -350,6 +350,54 @@ def get_args_parser():
         ),
     )
     parser.add_argument(
+        "--mi_difficulty_refresh_interval",
+        default=128,
+        type=int,
+        help="Micro-batch interval (in training steps) between log-β band refreshes.",
+    )
+    parser.add_argument(
+        "--mi_difficulty_sample_fraction",
+        default=0.05,
+        type=float,
+        help="Fraction of target-token positions to sample when estimating the difficulty band.",
+    )
+    parser.add_argument(
+        "--mi_difficulty_max_positions",
+        default=8192,
+        type=int,
+        help="Maximum number of token positions to include when refreshing the difficulty band.",
+    )
+    parser.add_argument(
+        "--mi_difficulty_alpha",
+        default=0.5,
+        type=float,
+        help="Mixture weight α for the uniform-t component in the MIS timestep sampler.",
+    )
+    parser.add_argument(
+        "--mi_difficulty_ratio_min",
+        default=0.5,
+        type=float,
+        help="Desired easy-case posterior ratio r_min used to set the lower log-β bound.",
+    )
+    parser.add_argument(
+        "--mi_difficulty_ratio_max",
+        default=0.05,
+        type=float,
+        help="Desired hard-case posterior ratio r_max used to set the upper log-β bound.",
+    )
+    parser.add_argument(
+        "--mi_difficulty_fallback_min",
+        default=0.5,
+        type=float,
+        help="Fallback lower log-β bound (ℓ_min) before difficulty statistics are available.",
+    )
+    parser.add_argument(
+        "--mi_difficulty_fallback_max",
+        default=2.2,
+        type=float,
+        help="Fallback upper log-β bound (ℓ_max) before difficulty statistics are available.",
+    )
+    parser.add_argument(
         "--mi_beta_use_ema",
         action="store_true",
         help="Track an exponential moving average teacher of the learnable β(t) schedule",

--- a/examples/image/training/train_loop.py
+++ b/examples/image/training/train_loop.py
@@ -8,6 +8,7 @@ import gc
 import logging
 import math
 from collections import deque
+from dataclasses import dataclass
 from typing import Iterable, Optional
 
 import torch
@@ -65,6 +66,173 @@ def _importance_weighted_mean(
     while weight_tensor.dim() < values.dim():
         weight_tensor = weight_tensor.unsqueeze(-1)
     return (values * weight_tensor).mean()
+
+
+def _compute_gap_quantiles(distances: torch.Tensor) -> tuple[float, float]:
+    """Return the 10th and 90th percentile of two-nearest distance gaps."""
+
+    if distances.numel() == 0:
+        raise ValueError("Cannot compute quantiles from an empty tensor")
+
+    top2 = torch.topk(distances, k=2, dim=-1, largest=False).values
+    gaps = (top2[..., 1] - top2[..., 0]).clamp_min(1e-12)
+    gaps_flat = gaps.view(-1).to(dtype=torch.float32)
+    quantiles = torch.quantile(
+        gaps_flat,
+        torch.tensor([0.10, 0.90], device=gaps_flat.device, dtype=gaps_flat.dtype),
+    )
+    return float(quantiles[0].item()), float(quantiles[1].item())
+
+
+def _map_gaps_to_logbeta_band(
+    q10: float,
+    q90: float,
+    ratio_min: float,
+    ratio_max: float,
+    *,
+    beta_min_clip: float = 1e-3,
+    beta_max_clip: float = 1e3,
+) -> Optional[tuple[float, float]]:
+    """Convert gap quantiles into a log-β interval."""
+
+    if not (math.isfinite(q10) and math.isfinite(q90)):
+        return None
+
+    eps = 1e-12
+    q10 = max(q10, eps)
+    q90 = max(q90, eps)
+
+    clamp_ratio = lambda r: max(1e-6, min(r, 1.0 - 1e-6))
+    r_min = clamp_ratio(ratio_min)
+    r_max = clamp_ratio(ratio_max)
+
+    beta_min = math.log(1.0 / r_min) / q90
+    beta_max = math.log(1.0 / r_max) / q10
+
+    beta_min = min(max(beta_min, beta_min_clip), beta_max_clip)
+    beta_max = min(max(beta_max, beta_min_clip), beta_max_clip)
+
+    if beta_max < beta_min:
+        beta_min, beta_max = beta_max, beta_min
+
+    if beta_min <= 0.0 or beta_max <= 0.0:
+        return None
+    if not (math.isfinite(beta_min) and math.isfinite(beta_max)):
+        return None
+
+    return math.log(beta_min), math.log(beta_max)
+
+
+@dataclass
+class DifficultyBandState:
+    """Tracks adaptive log-β bounds driven by batch difficulty statistics."""
+
+    lmin: float
+    lmax: float
+    q10: Optional[float] = None
+    q90: Optional[float] = None
+    last_refresh_step: int = -1
+    has_stats: bool = False
+
+    def interval(self) -> float:
+        return max(self.lmax - self.lmin, 1e-6)
+
+    def should_refresh(self, step: int, interval: int) -> bool:
+        if interval <= 0:
+            return False
+        if self.last_refresh_step < 0:
+            return True
+        return (step - self.last_refresh_step) >= interval
+
+    def refresh(
+        self,
+        *,
+        tokens: torch.Tensor,
+        path: MetricInducedGibbsProbPath,
+        step: int,
+        sample_fraction: float,
+        max_positions: int,
+        ratio_min: float,
+        ratio_max: float,
+        beta_min_clip: float = 1e-3,
+        beta_max_clip: float = 1e3,
+    ) -> bool:
+        if tokens.numel() == 0:
+            return False
+
+        sample_fraction = float(max(0.0, min(sample_fraction, 1.0)))
+        max_positions = max(1, int(max_positions))
+
+        with torch.no_grad():
+            flat_tokens = tokens.view(-1)
+            num_positions = flat_tokens.numel()
+            if num_positions == 0:
+                return False
+
+            sample_count = int(math.ceil(num_positions * sample_fraction))
+            sample_count = max(1, min(sample_count, num_positions, max_positions))
+
+            if sample_count >= num_positions:
+                sampled = flat_tokens
+            else:
+                indices = torch.randperm(num_positions, device=flat_tokens.device)[:sample_count]
+                sampled = flat_tokens.index_select(0, indices)
+
+            sampled = sampled.view(-1, 1)
+            distances = path.distances_from_tokens(sampled).squeeze(1).to(dtype=torch.float32)
+            if distances.numel() == 0:
+                return False
+
+            try:
+                q10, q90 = _compute_gap_quantiles(distances)
+            except ValueError:
+                return False
+
+            band = _map_gaps_to_logbeta_band(
+                q10,
+                q90,
+                ratio_min,
+                ratio_max,
+                beta_min_clip=beta_min_clip,
+                beta_max_clip=beta_max_clip,
+            )
+            if band is None:
+                return False
+
+            self.lmin, self.lmax = band
+            self.q10 = q10
+            self.q90 = q90
+            self.last_refresh_step = int(step)
+            self.has_stats = True
+
+            beta_bounds = (math.exp(self.lmin), math.exp(self.lmax))
+            logger.info(
+                "Refreshed log-β band: q10=%.4e, q90=%.4e, β∈[%.4f, %.4f], ℓ∈[%.4f, %.4f]",
+                q10,
+                q90,
+                beta_bounds[0],
+                beta_bounds[1],
+                self.lmin,
+                self.lmax,
+            )
+        return True
+
+
+def _logbeta_density(
+    schedule: ExpMonotoneRQSSchedule, t: torch.Tensor, lmin: float, lmax: float
+) -> torch.Tensor:
+    """Evaluate q_{logβ}(t) for the provided schedule and bounds."""
+
+    interval = max(lmax - lmin, 1e-6)
+    with torch.no_grad():
+        device = schedule.y0.device
+        dtype = schedule.y0.dtype
+        t_sched = t.to(device=device, dtype=dtype)
+        beta_vals, d_beta_vals = schedule.beta_and_derivative(t_sched)
+        beta_vals = beta_vals.clamp_min(1e-12)
+        density = (d_beta_vals / beta_vals) / interval
+        density = density.to(device=t.device, dtype=t.dtype)
+    return density.clamp_min(1e-12).detach()
 
 
 def skewed_timestep_sample(num_samples: int, device: torch.device) -> torch.Tensor:
@@ -334,41 +502,88 @@ def train_one_epoch(
             samples = (samples * 255.0).to(torch.long)
             logbeta_weights: Optional[torch.Tensor] = None
             schedule = getattr(path, "beta_schedule", None)
-            lmin = getattr(args, "mi_logbeta_min", None)
-            lmax = getattr(args, "mi_logbeta_max", None)
-            use_logbeta_sampling = (
-                isinstance(schedule, ExpMonotoneRQSSchedule)
-                and hasattr(schedule, "sample_t_uniform_logbeta")
-                and lmin is not None
-                and lmax is not None
-            )
-            if use_logbeta_sampling and lmax <= lmin:
-                if not getattr(args, "_mi_logbeta_interval_warned", False):
-                    logger.warning(
-                        "Ignoring log-β sampling interval with l_min >= l_max (%.4f, %.4f)",
-                        lmin,
-                        lmax,
+            difficulty_state: Optional[DifficultyBandState] = None
+            diff_step = int(getattr(args, "_mi_difficulty_step", 0))
+            alpha = float(getattr(args, "mi_difficulty_alpha", 0.5))
+            alpha = max(0.0, min(alpha, 1.0))
+            if isinstance(schedule, ExpMonotoneRQSSchedule):
+                difficulty_state = getattr(args, "_mi_difficulty_state", None)
+                if difficulty_state is None:
+                    fallback_min = float(getattr(args, "mi_difficulty_fallback_min", 0.5))
+                    fallback_max = float(getattr(args, "mi_difficulty_fallback_max", 2.2))
+                    if fallback_max < fallback_min:
+                        fallback_min, fallback_max = fallback_max, fallback_min
+                    difficulty_state = DifficultyBandState(fallback_min, fallback_max)
+                refresh_interval = int(getattr(args, "mi_difficulty_refresh_interval", 128))
+                sample_fraction = float(getattr(args, "mi_difficulty_sample_fraction", 0.05))
+                max_positions = int(getattr(args, "mi_difficulty_max_positions", 8192))
+                ratio_min = float(getattr(args, "mi_difficulty_ratio_min", 0.5))
+                ratio_max = float(getattr(args, "mi_difficulty_ratio_max", 0.05))
+                if difficulty_state.should_refresh(diff_step, refresh_interval):
+                    refreshed = difficulty_state.refresh(
+                        tokens=samples,
+                        path=path,
+                        step=diff_step,
+                        sample_fraction=sample_fraction,
+                        max_positions=max_positions,
+                        ratio_min=ratio_min,
+                        ratio_max=ratio_max,
                     )
-                    setattr(args, "_mi_logbeta_interval_warned", True)
-                use_logbeta_sampling = False
+                    if refreshed:
+                        setattr(args, "mi_logbeta_min", float(difficulty_state.lmin))
+                        setattr(args, "mi_logbeta_max", float(difficulty_state.lmax))
+                setattr(args, "_mi_difficulty_state", difficulty_state)
+            setattr(args, "_mi_difficulty_step", diff_step + 1)
 
-            if use_logbeta_sampling:
-                t_samples, weights = schedule.sample_t_uniform_logbeta(
-                    batch_shape=(samples.shape[0],),
-                    lmin=float(lmin),
-                    lmax=float(lmax),
-                )
-                t = t_samples.to(device=device)
-                logbeta_weights = weights.to(device=device, dtype=torch.float32)
-                if not getattr(args, "_mi_logbeta_sampling_announced", False):
-                    logger.info(
-                        "Using uniform log-β sampling with interval [%.4f, %.4f]",
-                        float(lmin),
-                        float(lmax),
+            use_difficulty_sampling = (
+                isinstance(schedule, ExpMonotoneRQSSchedule)
+                and isinstance(difficulty_state, DifficultyBandState)
+                and difficulty_state.interval() > 0.0
+            )
+
+            if use_difficulty_sampling:
+                batch_size = samples.shape[0]
+                t = torch.empty(batch_size, device=device, dtype=torch.float32)
+                if alpha <= 0.0:
+                    uniform_mask = torch.zeros(batch_size, dtype=torch.bool, device=device)
+                elif alpha >= 1.0:
+                    uniform_mask = torch.ones(batch_size, dtype=torch.bool, device=device)
+                else:
+                    uniform_mask = torch.rand(batch_size, device=device) < alpha
+
+                num_uniform = int(uniform_mask.sum().item())
+                if num_uniform > 0:
+                    t_uniform = torch.rand(num_uniform, device=device, dtype=torch.float32)
+                    t[uniform_mask] = t_uniform
+
+                num_logbeta = batch_size - num_uniform
+                if num_logbeta > 0:
+                    t_samples, _weights = schedule.sample_t_uniform_logbeta(
+                        batch_shape=(num_logbeta,),
+                        lmin=float(difficulty_state.lmin),
+                        lmax=float(difficulty_state.lmax),
                     )
-                    setattr(args, "_mi_logbeta_sampling_announced", True)
+                    t[~uniform_mask] = t_samples.to(device=device, dtype=torch.float32)
+
+                t_eps = float(getattr(schedule.config, "t_eps", 1e-4))
+                t = t.clamp_(t_eps, 1.0 - t_eps)
+
+                q_logbeta_vals = _logbeta_density(
+                    schedule,
+                    t,
+                    float(difficulty_state.lmin),
+                    float(difficulty_state.lmax),
+                )
+                q_mix = alpha + (1.0 - alpha) * q_logbeta_vals
+                weights = (1.0 / q_mix.clamp_min(1e-6)).to(dtype=torch.float32)
+                logbeta_weights = weights.detach()
             else:
-                t = torch.rand(samples.shape[0], device=device)
+                t = torch.rand(samples.shape[0], device=device, dtype=torch.float32)
+                if isinstance(schedule, ExpMonotoneRQSSchedule):
+                    t_eps = float(getattr(schedule.config, "t_eps", 1e-4))
+                else:
+                    t_eps = float(getattr(path, "eps_t", 1e-4)) if hasattr(path, "eps_t") else 1e-4
+                t = t.clamp_(t_eps, 1.0 - t_eps)
 
             # Provide dummy x_0 for signature compatibility (not used by metric-induced path)
             x_0 = torch.zeros_like(samples)

--- a/tasks/difficulty_sampling/plan.md
+++ b/tasks/difficulty_sampling/plan.md
@@ -1,0 +1,24 @@
+# Implementation Plan
+
+1. **Expose KO difficulty-sampling knobs in the CLI.**
+   - Add arguments in `examples/image/train_arg_parser.py` for the refresh interval, subsample fraction, maximum sampled positions, proposal mixture weight `α`, and probability ratios `(r_min, r_max)` plus fallback log-β bounds. Defaults: refresh every 128 micro-batches, subsample 5% up to 8192 sites, `α=0.5`, `r_min=0.5`, `r_max=0.05`, fallback band `[0.5, 2.2]`.
+   - Ensure the parsed values are stored on `args` in `examples/image/train.py` so the training loop can consume them.
+
+2. **Implement band estimation helpers.**
+   - In `examples/image/training/train_loop.py`, add a small dataclass (e.g., `DifficultyBandState`) plus pure helper functions:
+     * `_compute_gap_quantiles(distances)` → `(q10, q90)` using clamped two-nearest gaps.
+     * `_map_gaps_to_logbeta_band(q10, q90, r_min, r_max, beta_min_clip, beta_max_clip)` returning `(ℓ_min, ℓ_max)` and guarding against degenerate statistics.
+   - `DifficultyBandState.refresh(...)` should subsample the flattened target tokens, call `path.distances_from_tokens`, compute quantiles, update `(ℓ_min, ℓ_max)`, and log the refresh summary. Maintain the most recent quantiles and the last refresh step.
+
+3. **Integrate MIS timestep sampling.**
+   - Track (and persist on `args`) the difficulty state plus a monotonically increasing micro-step counter across epochs.
+   - During the KO metric-induced branch:
+     * Invoke `state.maybe_refresh` (using the per-batch counter) before sampling timesteps.
+     * Draw per-sample component assignments Bernoulli(α); sample uniform `t` for the uniform component and transform log-β samples for the others via `ExpMonotoneRQSSchedule.sample_t_uniform_logbeta`.
+     * Clamp `t` to `[t_eps, 1 - t_eps]`, compute `q_{logβ}(t)` via `beta_and_derivative`, and form detached importance weights `w = 1 / (α + (1-α) q_{logβ}(t))`.
+     * Reuse the same weights in the KL penalty branch and ESS diagnostics.
+   - Maintain the fallback band `[ℓ_min, ℓ_max]` until the first refresh succeeds; disable the mixture if no schedule or if the band is invalid.
+
+4. **Unit tests.**
+   - Add tests under `tests/examples/image/training/test_difficulty_band.py` to cover the quantile-to-band mapping (including clamping/swapping) and the band refresh path using a tiny `MetricInducedGibbsProbPath` with deterministic embeddings.
+   - Verify that the refreshed band adheres to the specified clamps and that the state keeps fallback values when statistics are degenerate.

--- a/tasks/difficulty_sampling/research.md
+++ b/tasks/difficulty_sampling/research.md
@@ -1,0 +1,22 @@
+# Research Notes
+
+## Existing KO metric-induced training loop
+- `examples/image/training/train_loop.py` handles the KO metric-induced path branch with tokenized samples.
+- Timesteps `t` are currently sampled either uniformly in `[0, 1]` or via `ExpMonotoneRQSSchedule.sample_t_uniform_logbeta`, which returns `t` along with importance weights equal to `(lmax - lmin) * dt/dℓ`.
+- Per-sample losses are aggregated through `_importance_weighted_mean`, which broadcasts optional weights across tensor dimensions before averaging.
+- No existing mechanism adapts the log-β interval based on batch difficulty; `mi_logbeta_min`/`mi_logbeta_max` are fixed scalars stored on `args` in `examples/image/train.py`.
+
+## Metric-induced path utilities
+- `flow_matching/path/mixture.py` implements `MetricInducedGibbsProbPath` with Euclidean distance as the default metric (using `torch.cdist`).
+- `distances_from_tokens` gathers per-token distances to the entire vocabulary by indexing into a cached [K, K] distance table, so obtaining per-site pairwise distances is straightforward once token indices are available.
+- The learnable β schedule `ExpMonotoneRQSSchedule` (in `flow_matching/path/beta_schedules.py`) exposes `beta_and_derivative(t)` and `sample_t_uniform_logbeta`. The derivative satisfies `dt/dℓ = β / dβ/dt`, so `q_{logβ}(t) = (dβ/dt) / (β * (ℓ_max - ℓ_min))`.
+
+## Relevant CLI wiring
+- `examples/image/train_arg_parser.py` defines KO-specific flags; currently no arguments exist for adaptive log-β bands, MIS blending, or gap sampling controls.
+- `examples/image/train.py` initializes `args.mi_logbeta_min`/`args.mi_logbeta_max` when an exponential spline schedule is used, defaulting to `log β` evaluated at `t = mi_t_eps` and `t = 1 - mi_t_eps` if the user did not supply values.
+
+## Constraints from the spec
+- Need periodic “refresh” that subsamples target tokens, computes the top-2 distance gap Δd per position (clamped ≥ 1e-12), and tracks 10th/90th percentiles.
+- Map `(q10, q90)` to a log-β band using user-chosen probability ratios `r_min`, `r_max`, clamping β within `[1e-3, 1e3]`. Use fallback `[0.5, 2.2]` (natural log) before the first refresh.
+- Perform mixture importance sampling with proposal `q(t) = α * U[0,1] + (1-α) * q_{logβ}(t)` and weight each sample by `w(t) = 1 / q(t)` (detached).
+- Clamp timesteps to `[t_ε, 1 - t_ε]` for stability and detach importance weights from autograd before applying them.

--- a/tests/examples/image/training/test_difficulty_band.py
+++ b/tests/examples/image/training/test_difficulty_band.py
@@ -1,0 +1,72 @@
+import math
+import sys
+from pathlib import Path
+
+import torch
+
+ROOT = Path(__file__).resolve().parents[4]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+EXAMPLES_ROOT = ROOT / "examples" / "image"
+if str(EXAMPLES_ROOT) not in sys.path:
+    sys.path.insert(0, str(EXAMPLES_ROOT))
+
+from examples.image.training.train_loop import (
+    DifficultyBandState,
+    _compute_gap_quantiles,
+    _map_gaps_to_logbeta_band,
+)
+from flow_matching.path.mixture import MetricInducedGibbsProbPath
+
+
+def test_map_gaps_to_logbeta_band_basic():
+    q10 = 0.1
+    q90 = 0.2
+    ratio_min = 0.5
+    ratio_max = 0.05
+
+    result = _map_gaps_to_logbeta_band(q10, q90, ratio_min, ratio_max)
+    assert result is not None
+    ell_min, ell_max = result
+
+    beta_min = math.log(1.0 / ratio_min) / q90
+    beta_max = math.log(1.0 / ratio_max) / q10
+    expected_min = math.log(beta_min)
+    expected_max = math.log(beta_max)
+
+    assert math.isclose(ell_min, expected_min, rel_tol=1e-6, abs_tol=1e-6)
+    assert math.isclose(ell_max, expected_max, rel_tol=1e-6, abs_tol=1e-6)
+
+
+@torch.no_grad()
+def test_difficulty_band_refresh_updates_state():
+    path = MetricInducedGibbsProbPath(vocab_size=16, emb_dim=1)
+    tokens = torch.arange(0, 16, dtype=torch.long).view(4, 4)
+
+    state = DifficultyBandState(lmin=0.5, lmax=2.2)
+    refreshed = state.refresh(
+        tokens=tokens,
+        path=path,
+        step=5,
+        sample_fraction=1.0,
+        max_positions=64,
+        ratio_min=0.5,
+        ratio_max=0.05,
+    )
+
+    assert refreshed is True
+    assert state.has_stats
+    assert state.last_refresh_step == 5
+
+    distances = path.distances_from_tokens(tokens.view(-1, 1)).squeeze(1)
+    q10, q90 = _compute_gap_quantiles(distances)
+    assert math.isclose(state.q10 or 0.0, q10, rel_tol=1e-6, abs_tol=1e-6)
+    assert math.isclose(state.q90 or 0.0, q90, rel_tol=1e-6, abs_tol=1e-6)
+
+    expected_band = _map_gaps_to_logbeta_band(q10, q90, 0.5, 0.05)
+    assert expected_band is not None
+    ell_min, ell_max = expected_band
+    assert math.isclose(state.lmin, ell_min, rel_tol=1e-6, abs_tol=1e-6)
+    assert math.isclose(state.lmax, ell_max, rel_tol=1e-6, abs_tol=1e-6)
+    assert state.interval() > 0.0


### PR DESCRIPTION
## Summary
- add KO CLI knobs for difficulty-driven log-β band estimation and MIS mixture weight
- implement `DifficultyBandState` with adaptive sampling weights in the metric-induced train loop
- cover the new helpers with unit tests for gap-to-band mapping and refresh behavior

## Testing
- pytest tests/examples/image/training/test_difficulty_band.py


------
https://chatgpt.com/codex/tasks/task_e_68d931ce4f088321a6fd47f5b8ea1322

## Summary by Sourcery

Enable adaptive log-beta sampling in the metric-induced training path by exposing CLI parameters, estimating dynamic log-beta bounds from token distance gaps, and mixing uniform and log-beta timestep proposals with importance weights

New Features:
- Expose CLI knobs for difficulty-driven log-beta band estimation and MIS mixture weight
- Implement DifficultyBandState to adaptively estimate and update log-beta bounds based on batch difficulty
- Integrate mixture importance sampling in the metric-induced training loop with per-sample uniform/log-beta timestep proposals

Enhancements:
- Add helper functions to compute gap quantiles, map them to log-beta intervals, and evaluate log-beta density

Tests:
- Add unit tests for quantile-to-band mapping and DifficultyBandState refresh behavior