### PR TITLE
Refine LUT diagnostics to use scalar trajectories

### DIFF
--- a/examples/image/training/train_loop.py
+++ b/examples/image/training/train_loop.py
@@ -34,20 +34,35 @@ from training import distributed_mode
 logger = logging.getLogger(__name__)
 
 
+_WANDB_CACHE: dict[str, Optional[object]] = {"module": None}
+_WANDB_ATTEMPTED = False
+_WANDB_WARNED = False
+
+
 def _resolve_wandb_module(args: argparse.Namespace) -> Optional[object]:
     """
     Try importing swanlab (preferred) and fall back to the official wandb client.
-    Cache the result on args to reuse the module across logging paths.
+
+    The resolved module is cached at the module level (not on ``args``) so that
+    checkpoint serialization never encounters an un-picklable module object.
     """
+
+    global _WANDB_ATTEMPTED
     if not getattr(args, "wandb", False):
         return None
-    cached = getattr(args, "_cached_wandb_module", None)
-    attempted = getattr(args, "_cached_wandb_attempted", False)
-    if attempted:
-        return cached
-    setattr(args, "_cached_wandb_attempted", True)
+    # Backwards compatibility: remove stale attributes set by older checkpoints
+    for legacy_attr in ("_cached_wandb_module", "_cached_wandb_attempted", "_wandb_import_warned"):
+        if hasattr(args, legacy_attr):
+            try:
+                delattr(args, legacy_attr)
+            except AttributeError:
+                setattr(args, legacy_attr, None)
+    if _WANDB_ATTEMPTED:
+        return _WANDB_CACHE["module"]
+    _WANDB_ATTEMPTED = True
+
     if not distributed_mode.is_main_process():
-        setattr(args, "_cached_wandb_module", None)
+        _WANDB_CACHE["module"] = None
         return None
 
     module: Optional[object] = None
@@ -62,12 +77,13 @@ def _resolve_wandb_module(args: argparse.Namespace) -> Optional[object]:
             module = wandb
         except ImportError:
             module = None
-            if not getattr(args, "_wandb_import_warned", False):
+            global _WANDB_WARNED
+            if not _WANDB_WARNED:
                 logger.warning(
                     "Weights & Biases logging disabled: unable to import swanlab or wandb."
                 )
-                setattr(args, "_wandb_import_warned", True)
-    setattr(args, "_cached_wandb_module", module)
+                _WANDB_WARNED = True
+    _WANDB_CACHE["module"] = module
     return module
 
 

--- a/examples/image/training/train_loop.py
+++ b/examples/image/training/train_loop.py
@@ -103,30 +103,45 @@ def _compute_lut_regularizer_and_metrics(
     lut = getattr(path, "learnable_lut", None)
     if lut is None:
         return torch.tensor(0.0, device=device), {}
-    weight = lut.weight if hasattr(lut, "weight") else lut()
+    weight: Optional[torch.Tensor] = None
+    if callable(lut):
+        weight = lut()
+    if weight is None and hasattr(lut, "weight"):
+        weight = lut.weight
     if weight is None:
         return torch.tensor(0.0, device=device), {}
     weight = weight.to(device=device)
     if weight.size(1) < 2:
         return torch.tensor(0.0, device=device), {}
     dtype = weight.dtype
-    normed = F.normalize(weight, dim=-1, eps=1e-12)
 
-    align_term = (1.0 - (normed[:, :-1, :] * normed[:, 1:, :]).sum(dim=-1)).mean()
+    if hasattr(lut, "scalar_trajectories"):
+        values = lut.scalar_trajectories(weight)
+    else:
+        values = weight.mean(dim=-1)
+    values = values.to(device=device)
 
-    diff = normed[:, 1:, :] - normed[:, :-1, :]
-    if diff.size(1) >= 2:
-        diff_prev = diff[:, :-1, :]
-        diff_next = diff[:, 1:, :]
-        denom = diff_prev.norm(dim=-1) * diff_next.norm(dim=-1) + 1e-12
-        cos_steps = (diff_prev * diff_next).sum(dim=-1) / denom
+    first_diff = values[:, 1:] - values[:, :-1]
+    align_term = torch.clamp(-first_diff, min=0.0).mean()
+
+    if first_diff.size(1) >= 2:
+        tangent = torch.stack([
+            torch.ones_like(first_diff),
+            first_diff,
+        ], dim=-1)
+        tangent_norm = F.normalize(tangent, dim=-1, eps=1e-12)
+        tangent_prev = tangent_norm[:, :-1, :]
+        tangent_next = tangent_norm[:, 1:, :]
+        cos_steps = (tangent_prev * tangent_next).sum(dim=-1)
         step_term = torch.clamp(-cos_steps, min=0.0).mean()
     else:
         cos_steps = torch.empty(0, device=device, dtype=dtype)
         step_term = weight.new_tensor(0.0)
 
-    if weight.size(1) >= 3:
-        curvature_mag = (normed[:, 2:, :] - 2 * normed[:, 1:-1, :] + normed[:, :-2, :]).norm(dim=-1)
+    if values.size(1) >= 3:
+        curvature_mag = torch.abs(
+            values[:, 2:] - 2 * values[:, 1:-1] + values[:, :-2]
+        )
         curvature_term = curvature_mag.mean()
     else:
         curvature_mag = torch.empty(0, device=device, dtype=dtype)
@@ -140,13 +155,9 @@ def _compute_lut_regularizer_and_metrics(
 
     metrics: dict[str, float] = {}
     if compute_metrics:
-        angles_cos = torch.clamp(
-            (normed[:, :-1, :] * normed[:, 1:, :]).sum(dim=-1),
-            -1.0 + 1e-6,
-            1.0 - 1e-6,
-        )
-        angles = torch.acos(angles_cos)
-        if angles.numel() > 0:
+        if cos_steps.numel() > 0:
+            clamped_cos = torch.clamp(cos_steps, -1.0 + 1e-6, 1.0 - 1e-6)
+            angles = torch.acos(clamped_cos)
             angles_flat = angles.reshape(-1)
             angle_p50 = float(
                 torch.quantile(angles_flat, 0.5).detach().cpu() * (180.0 / math.pi)
@@ -154,28 +165,21 @@ def _compute_lut_regularizer_and_metrics(
             angle_p90 = float(
                 torch.quantile(angles_flat, 0.9).detach().cpu() * (180.0 / math.pi)
             )
-        else:
-            angle_p50 = angle_p90 = 0.0
-        flip_rate = (
-            float((cos_steps < 0).float().mean().detach().cpu())
-            if cos_steps.numel() > 0
-            else 0.0
-        )
-        if cos_steps.numel() > 0:
             cos_flat = cos_steps.detach().reshape(-1).float()
             direction_mean = float(cos_flat.mean().cpu())
             direction_std = float(cos_flat.std(unbiased=False).cpu())
             direction_p10 = float(torch.quantile(cos_flat, 0.1).cpu())
             direction_p90 = float(torch.quantile(cos_flat, 0.9).cpu())
+            flip_rate = float((cos_flat < 0).float().mean().cpu())
         else:
+            angle_p50 = 0.0
+            angle_p90 = 0.0
             direction_mean = 0.0
             direction_std = 0.0
             direction_p10 = 0.0
             direction_p90 = 0.0
-        proj_vector = torch.ones(normed.shape[-1], device=device, dtype=normed.dtype)
-        proj_vector = proj_vector / (proj_vector.norm() + 1e-12)
-        proj_vals = torch.matmul(weight, proj_vector)
-        ks = _ks_uniform_metric(proj_vals.reshape(-1))
+            flip_rate = 0.0
+        ks = _ks_uniform_metric(values.detach().reshape(-1))
         metrics = {
             "lut_align": float(align_term.detach().cpu()),
             "lut_step": float(step_term.detach().cpu()),

--- a/flow_matching/path/mixture.py
+++ b/flow_matching/path/mixture.py
@@ -162,7 +162,10 @@ class LearnableScalarLUT(nn.Module):
             emb_dim=self.emb_dim,
             embed_range=self.embed_range,
         )
-        noise = torch.randn_like(weight) * 1e-3
+        noise_scale = float(self.init_noise_scale)
+        if noise_scale <= 0.0:
+            return weight
+        noise = torch.randn_like(weight) * noise_scale
         return weight + noise
 
     def _linear_init_base(self) -> Tensor:
@@ -286,6 +289,14 @@ class LearnableScalarLUT(nn.Module):
         # Broadcasting: [C, 1, 1] * [C, V, D] -> [C, V, D]
         return self.weight * scale.view(-1, 1, 1)
 
+    def scalar_trajectories(self, weight: Optional[Tensor] = None) -> Tensor:
+        """Return per-channel scalar trajectories for diagnostics."""
+
+        if weight is None:
+            weight = self()
+        # Average across embedding dimensions to recover the scalar path.
+        return weight.mean(dim=-1)
+
     def extra_repr(self) -> str:
         return (
             f"num_channels={self.num_channels}, vocab_size={self.vocab_size}, "
@@ -364,16 +375,20 @@ class _Line2DLUTParam(nn.Module):
 
     def forward(self) -> Tensor:
         direction = self._normalized_direction()  # [C, D]
-        delta = F.softplus(self.delta_raw) + self.min_step  # [C, V-1]
-        cumulative = torch.cumsum(delta, dim=-1)
-        tail = self.start.unsqueeze(-1) + cumulative
-        tau = torch.cat([self.start.unsqueeze(-1), tail], dim=-1)  # [C, V]
+        tau = self.scalar_trajectory()  # [C, V]
         emb = direction.unsqueeze(1) * tau.unsqueeze(-1)  # [C, V, D]
         return emb
 
     def _normalized_direction(self) -> Tensor:
         direction = self.direction_raw
         return direction / (direction.norm(dim=-1, keepdim=True) + 1e-12)
+
+    def scalar_trajectory(self) -> Tensor:
+        delta = F.softplus(self.delta_raw) + self.min_step  # [C, V-1]
+        cumulative = torch.cumsum(delta, dim=-1)
+        tail = self.start.unsqueeze(-1) + cumulative
+        tau = torch.cat([self.start.unsqueeze(-1), tail], dim=-1)
+        return tau
 
     @torch.no_grad()
     def initialize_from_weight(self, weight: Tensor) -> None:
@@ -446,11 +461,7 @@ class _Arc2DLUTParam(nn.Module):
 
     def forward(self) -> Tensor:
         basis = self._orthonormal_basis()  # [C, D, 2]
-        delta = F.softplus(self.delta_raw) + self.min_step  # [C, V-1]
-        theta = self.theta_start.unsqueeze(-1) + torch.cumsum(delta, dim=-1)
-        theta = torch.cat(
-            [self.theta_start.unsqueeze(-1), theta], dim=-1
-        )  # prepend start
+        theta = self.scalar_trajectory()
         cos_t = torch.cos(theta)
         sin_t = torch.sin(theta)
         coords = torch.stack([cos_t, sin_t], dim=-1)  # [C, V, 2]
@@ -461,6 +472,14 @@ class _Arc2DLUTParam(nn.Module):
     def _orthonormal_basis(self) -> Tensor:
         q, _ = torch.linalg.qr(self.basis_raw, mode="reduced")
         return q
+
+    def scalar_trajectory(self) -> Tensor:
+        delta = F.softplus(self.delta_raw) + self.min_step  # [C, V-1]
+        theta = self.theta_start.unsqueeze(-1) + torch.cumsum(delta, dim=-1)
+        theta = torch.cat(
+            [self.theta_start.unsqueeze(-1), theta], dim=-1
+        )
+        return theta
 
     @torch.no_grad()
     def initialize_from_weight(self, weight: Tensor) -> None:
@@ -602,6 +621,13 @@ class LearnableParametricLUT(nn.Module):
         current = torch.linalg.vector_norm(weight, dim=(1, 2))
         scale = target / (current + self.renorm_eps)
         return weight * scale.view(-1, 1, 1)
+
+    def scalar_trajectories(self, weight: Optional[Tensor] = None) -> Tensor:
+        if hasattr(self.param, "scalar_trajectory"):
+            return self.param.scalar_trajectory()
+        if weight is None:
+            weight = self.forward()
+        return weight.mean(dim=-1)
 
     def initialize_from_weight(self, weight: Tensor) -> None:
         self.param.initialize_from_weight(weight)

--- a/init.sh
+++ b/init.sh
@@ -1,0 +1,29 @@
+nohup setsid torchrun --standalone --nnodes=1 --nproc_per_node=8 ./examples/image/train.py --dataset=cifar10 --discrete_flow_matching --use_ema \
+--metric_induced --batch_size=256 --eval_batch_size=625 --lr=2e-4 --accum_iter=1 \
+--epochs=5900 --fid_samples=5000 --eval_frequency=50 --eval_start_epoch 5600 \
+--resume=./models/baseline.pth --output_dir=./output_dir/learned_emb_gamma1.0_lam_1.5 \
+--mi_use_gumbel --mi_gumbel_tau=1.0 --mi_gumbel_tau_start=2.0 \
+--mi_gumbel_tau_end=0.5 --mi_gumbel_tau_anneal_steps=10000 --mi_gumbel_tau_schedule=cosine \
+--mi_learnable_lut --mi_lut_num_channels 3 --mi_lut_param_mode none --mi_lut_init_method linear --mi_lut_init_noise_scale 0.1 \
+--mi_metric lp --mi_lp 2.0 --mi_lut_emb_dim 16 --mi_freeze_beta_schedule --compute_fid --save_eval_gif --sym_func --cfg_scale=0.0 \
+--mi_lut_weight_decay=0 --mi_lut_renorm_init_norm --mi_use_normalized_distance \
+--wandb --wandb_project 111 --wandb_run_name learned_emb_noise_renorm_16d\
+--no_cosine_attention --no_head_weight_norm --force_display_start_epoch 4500 \
+--t_bias_gamma 1.0 --t_weight_mode linear_t --t_weight_lambda 1.5 --t_weight_normalize \
+--lut_recon_weight=0.5 --lut_recon_sample_frac=0.25 --bf16
+
+git config --global user.name "zhengyuping00000"
+git config --global user.email "dd719876254@outlook.com"
+
+nohup setsid torchrun --standalone --nnodes=1 --nproc_per_node=8 ./examples/image/train.py --dataset=cifar10 --discrete_flow_matching --use_ema \
+--metric_induced --batch_size=625 --lr=2e-4 --accum_iter=1 \
+--epochs=5900 --fid_samples=5000 --eval_frequency=50 \
+--resume=./models/baseline.pth --output_dir=./output_dir/learned_emb_gamma1.0_lam_1.5 \
+--mi_use_gumbel --mi_gumbel_tau=1.0 --mi_gumbel_tau_start=2.0 \
+--mi_gumbel_tau_end=0.5 --mi_gumbel_tau_anneal_steps=10000 --mi_gumbel_tau_schedule=cosine \
+--mi_learnable_lut --mi_lut_num_channels 3 --mi_lut_param_mode none --mi_lut_init_method linear --mi_lut_init_noise_scale 0.1 \
+--mi_metric lp --mi_lp 2.0 --mi_lut_emb_dim 16 --mi_freeze_beta_schedule --compute_fid --save_eval_gif --sym_func --cfg_scale=0.0 \
+--mi_lut_weight_decay=0 --mi_lut_renorm_init_norm --mi_use_normalized_distance \
+--wandb --wandb_project 111 --wandb_run_name learned_emb_noise_renorm_16d\
+--no_cosine_attention --no_head_weight_norm --force_display_start_epoch 4500 \
+--bf16 --eval_only

--- a/tasks/lut-metrics/plan.md
+++ b/tasks/lut-metrics/plan.md
@@ -1,0 +1,28 @@
+# Implementation Plan
+
+## Step 1 – Update LUT regularizer input tensor
+- Modify `examples/image/training/train_loop.py::_compute_lut_regularizer_and_metrics` to obtain the LUT tensor via `lut()` under `torch.no_grad()` so the diagnostics observe renormalization and bounded-residual scaling.
+- Keep a fallback to `.weight` for modules without a callable forward, preserving device/dtype handling.
+
+## Step 2 – Derive scalar trajectories per LUT mode
+- Inside the same helper, derive per-channel scalar trajectories:
+  - For free/"none" LUTs (`LearnableScalarLUT`), average embeddings over the last dimension to recover the scalar baseline.
+  - For parametric LUTs, extend `_Line2DLUTParam` and `_Arc2DLUTParam` (and surface them through `LearnableParametricLUT`) with methods returning their underlying scalars (`tau` and `theta`).
+- Introduce a shared helper that maps any learnable LUT module to its scalar trajectories without duplicating param logic.
+
+## Step 3 – Rework penalties/metrics around scalar differences
+- Recompute `align_term`, `step_term`, `curvature_term`, and all derived metrics using the scalar trajectories and their finite differences (first/second order) plus tangent orientation vectors `[1, delta]` for angle-style summaries.
+- Ensure previously logged keys remain available while documenting the scalar-based semantics.
+
+## Step 4 – Adjust linear initialization noise handling
+- In `LearnableScalarLUT._linear_init`, scale Gaussian noise by `self.init_noise_scale` and short-circuit when the scale is effectively zero to maintain deterministic warm starts.
+- Confirm `reset_parameters` still refreshes buffers correctly.
+
+## Step 5 – Add regression tests
+- Extend `tests/path/test_learnable_lut.py` with a case asserting that `init_noise_scale=0` yields a noise-free baseline and that nonzero scales inject noise.
+- Add a new training-level unit test (e.g., `tests/training/test_lut_metrics.py`) covering:
+  - Metrics computed on a stub LUT whose forward output differs from raw parameters (verifying we now use `lut()`).
+  - Scalar-based penalties reacting to bounded-residual scaling (scale factor alters `lut_align` magnitude).
+
+## Step 6 – Verify formatting/tests
+- Run the relevant test suite (targeted unit tests) to confirm new behaviors.

--- a/tasks/lut-metrics/research.md
+++ b/tasks/lut-metrics/research.md
@@ -1,0 +1,21 @@
+# Research Notes
+
+## Relevant modules
+- `examples/image/training/train_loop.py::_compute_lut_regularizer_and_metrics`
+  - Currently pulls `lut.weight` directly and normalizes embeddings with `F.normalize` before computing align/step/curvature penalties and flip metric.
+  - Metrics derived from normalized vectors: cosines, flip rate, KS projection using all-ones vector applied to **raw** weight (not forward output).
+- `flow_matching/path/mixture.py::LearnableScalarLUT`
+  - `forward` optionally renormalizes to stored Frobenius norms (`renormalize_to_init_norm`) and/or applies bounded residual scaling (`bounded_residual_scale`).
+  - `_linear_init` always adds Gaussian noise scaled by fixed `1e-3`; ignores `init_noise_scale`.
+  - Param modes (`none`, `line2d`, `arc2d`) produce embeddings via scalar trajectories (tiled baseline, tau along basis, theta on arc).
+
+## Observations
+- Diagnostics never call `lut()`; renormalization/bounded residual scaling applied in `forward` are invisible.
+- After per-token normalization, scalar LUT baselines collapse to two orientations, so tiny jitter yields flip rate ~1 despite monotone scalar ordering.
+- Need scalar trajectory extraction per mode: likely available in param classes or can project using mode-specific helpers.
+- Linear init noise must respect `self.init_noise_scale` and allow zero noise.
+
+## Open questions / considerations
+- Determine best way to access mode-specific scalar trajectories without duplicating mode logic.
+- Ensure metrics remain device/dtype safe when invoking `lut()` under `torch.no_grad()`.
+- Need testing hook: either new unit test around diagnostics or integration in existing logging utilities.

--- a/tests/path/test_learnable_lut.py
+++ b/tests/path/test_learnable_lut.py
@@ -25,16 +25,19 @@ class TestLearnableScalarLUT(unittest.TestCase):
             embed_range="pm1",
             device=None,
             dtype=torch.float32,
+            init_noise_scale=0.0,
         )
         self.assertEqual(lut.num_channels, 3)
         self.assertEqual(lut.vocab_size, 256)
         self.assertEqual(lut.embed_range, "pm1")
-    self.assertEqual(lut.weight.shape, (3, 256, 1))
+        self.assertEqual(lut.weight.shape, (3, 256, 1))
 
-    # Check linear initialization bounds
-    self.assertAlmostEqual(lut.weight[0, 0, 0].item(), -1.0, places=6)
-    self.assertAlmostEqual(lut.weight[0, -1, 0].item(), 1.0, places=6)
-    self.assertTrue(torch.allclose(lut.weight[0], lut.weight[1]))  # All channels identical initially
+        # Check linear initialization bounds
+        self.assertAlmostEqual(lut.weight[0, 0, 0].item(), -1.0, places=6)
+        self.assertAlmostEqual(lut.weight[0, -1, 0].item(), 1.0, places=6)
+        self.assertTrue(
+            torch.allclose(lut.weight[0], lut.weight[1])
+        )  # All channels identical initially
         
     def test_init_unit_range(self):
         """Test initialization with [0, 1] range."""
@@ -44,10 +47,11 @@ class TestLearnableScalarLUT(unittest.TestCase):
             embed_range="unit",
             device=None,
             dtype=torch.float32,
+            init_noise_scale=0.0,
         )
         self.assertEqual(lut.embed_range, "unit")
-    self.assertAlmostEqual(lut.weight[0, 0, 0].item(), 0.0, places=6)
-    self.assertAlmostEqual(lut.weight[0, -1, 0].item(), 1.0, places=6)
+        self.assertAlmostEqual(lut.weight[0, 0, 0].item(), 0.0, places=6)
+        self.assertAlmostEqual(lut.weight[0, -1, 0].item(), 1.0, places=6)
         
     def test_invalid_params(self):
         """Test validation of constructor arguments."""
@@ -68,6 +72,7 @@ class TestLearnableScalarLUT(unittest.TestCase):
             embed_range="pm1",
             device=None,
             dtype=torch.float32,
+            init_noise_scale=0.0,
         )
         original_weight = lut.weight.clone()
         
@@ -77,7 +82,7 @@ class TestLearnableScalarLUT(unittest.TestCase):
         
         # Reset
         lut.reset_parameters()
-    self.assertTrue(torch.allclose(lut.weight, original_weight, atol=1e-6))
+        self.assertTrue(torch.allclose(lut.weight, original_weight, atol=1e-6))
     
     def test_device_dtype(self):
         """Test device and dtype propagation."""
@@ -143,6 +148,35 @@ class TestLearnableScalarLUT(unittest.TestCase):
         self.assertIsNotNone(lut.weight.grad)
         self.assertGreater(lut.weight.grad.abs().sum().item(), 0.0)
 
+    def test_linear_init_respects_noise_scale(self):
+        """Linear initialization should honor the configured noise scale."""
+
+        lut_deterministic = LearnableScalarLUT(
+            num_channels=2,
+            vocab_size=16,
+            emb_dim=3,
+            embed_range="pm1",
+            device=None,
+            dtype=torch.float32,
+            init_method="linear",
+            init_noise_scale=0.0,
+        )
+        baseline = lut_deterministic._linear_init_base()
+        self.assertTrue(torch.allclose(lut_deterministic.weight, baseline, atol=1e-7))
+
+        lut_noisy = LearnableScalarLUT(
+            num_channels=2,
+            vocab_size=16,
+            emb_dim=3,
+            embed_range="pm1",
+            device=None,
+            dtype=torch.float32,
+            init_method="linear",
+            init_noise_scale=0.02,
+        )
+        diff = (lut_noisy.weight - lut_noisy._linear_init_base()).abs()
+        self.assertGreater(diff.max().item(), 0.0)
+
 
 class TestMetricInducedPathWithLUT(unittest.TestCase):
     """Test MetricInducedGibbsProbPath integration with learnable LUT."""
@@ -190,14 +224,23 @@ class TestMetricInducedPathWithLUT(unittest.TestCase):
                 learnable_metric_dim=8,  # Conflict
             )
     
-    def test_lut_requires_lp_metric(self):
-        """Test that LUT requires 'lp' or 'euclidean' metric."""
-        with self.assertRaisesRegex(ValueError, "learnable_lut currently supports only 'lp' or 'euclidean'"):
+    def test_lut_requires_supported_metric(self):
+        """Test that LUT initialization rejects unsupported metrics."""
+        with self.assertRaisesRegex(ValueError, "learnable_lut supports metrics"):
             MetricInducedGibbsProbPath(
                 vocab_size=256,
-                metric="cosine",  # Incompatible
+                metric="manhattan",
                 learnable_lut=True,
             )
+
+        # Cosine metric is supported.
+        path = MetricInducedGibbsProbPath(
+            vocab_size=64,
+            metric="cosine",
+            learnable_lut=True,
+            lut_num_channels=2,
+        )
+        self.assertIsNotNone(path.learnable_lut)
     
     def test_lut_parameters_iterator(self):
         """Test lut_parameters() yields correct parameters."""
@@ -210,7 +253,7 @@ class TestMetricInducedPathWithLUT(unittest.TestCase):
         
         lut_params = list(path.lut_parameters())
         self.assertEqual(len(lut_params), 1)
-    self.assertEqual(lut_params[0].shape, (3, 128, 1))
+        self.assertEqual(lut_params[0].shape, (3, 128, 1))
         self.assertTrue(lut_params[0].requires_grad)
     
     def test_lut_parameters_empty_when_disabled(self):
@@ -326,8 +369,8 @@ class TestMetricInducedPathWithLUT(unittest.TestCase):
         # Channel 0: [0, 1, 2, 3]
         # Channel 1: [0, 10, 20, 30]
         with torch.no_grad():
-            path.learnable_lut.weight[0] = torch.tensor([0.0, 1.0, 2.0, 3.0])
-            path.learnable_lut.weight[1] = torch.tensor([0.0, 10.0, 20.0, 30.0])
+            path.learnable_lut.weight[0] = torch.tensor([0.0, 1.0, 2.0, 3.0]).view(vocab_size, 1)
+            path.learnable_lut.weight[1] = torch.tensor([0.0, 10.0, 20.0, 30.0]).view(vocab_size, 1)
         
         device = torch.device("cpu")
         dtype = torch.float32

--- a/tests/training/test_lut_metrics.py
+++ b/tests/training/test_lut_metrics.py
@@ -1,0 +1,98 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the CC-by-NC license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Unit tests for LUT geometry diagnostics used during training."""
+
+import types
+import unittest
+import sys
+from pathlib import Path
+import torch
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+examples_image_root = _PROJECT_ROOT / "examples" / "image"
+if str(examples_image_root) not in sys.path:
+    sys.path.insert(0, str(examples_image_root))
+
+# Provide a minimal stub for models.ema so train_loop imports succeed.
+if "models" not in sys.modules:
+    models_module = types.ModuleType("models")
+    ema_module = types.ModuleType("models.ema")
+
+    class _StubEMA:
+        def __init__(self, *args, **kwargs) -> None:  # pragma: no cover - simple stub
+            pass
+
+        def update(self, *args, **kwargs) -> None:  # pragma: no cover - simple stub
+            pass
+
+    ema_module.EMA = _StubEMA
+    models_module.ema = ema_module
+    sys.modules["models"] = models_module
+    sys.modules["models.ema"] = ema_module
+
+from examples.image.training.train_loop import _compute_lut_regularizer_and_metrics
+from flow_matching.path.mixture import LearnableScalarLUT
+
+
+class _DummyPath:
+    def __init__(self, lut: torch.nn.Module) -> None:
+        self.learnable_lut = lut
+
+
+class TestLUTRegularizerMetrics(unittest.TestCase):
+    """Tests ensuring LUT diagnostics operate on forward outputs and scalars."""
+
+    def test_metrics_use_forward_scaled_weights(self) -> None:
+        """Bounded residual scaling should influence the logged metrics."""
+
+        lut = LearnableScalarLUT(
+            num_channels=1,
+            vocab_size=4,
+            emb_dim=1,
+            embed_range="pm1",
+            device=None,
+            dtype=torch.float32,
+            bounded_residual_scale=True,
+            scale_baseline=2.0,
+            scale_epsilon=1.0,
+            init_method="linear",
+            init_noise_scale=0.0,
+        )
+
+        base_values = torch.tensor([[0.0, 1.0, -0.5, 0.0]], dtype=torch.float32).unsqueeze(-1)
+        with torch.no_grad():
+            lut.weight.copy_(base_values)
+            lut.scale_c.fill_(4.0)
+
+        path = _DummyPath(lut)
+        device = torch.device("cpu")
+        penalty, metrics = _compute_lut_regularizer_and_metrics(
+            path=path,
+            device=device,
+            reg_align=1.0,
+            reg_step=0.0,
+            reg_curv=0.0,
+            compute_metrics=True,
+        )
+
+        # Baseline (unscaled) negative slope magnitude.
+        base_scalar = base_values.squeeze(-1)
+        base_delta = base_scalar[:, 1:] - base_scalar[:, :-1]
+        base_align = torch.clamp(-base_delta, min=0.0).mean().item()
+
+        scale_factor = float(
+            lut.scale_baseline * (1.0 + lut.scale_epsilon * torch.tanh(lut.scale_c).item())
+        )
+        expected_align = base_align * scale_factor
+
+        self.assertAlmostEqual(metrics["lut_align"], expected_align, places=6)
+        self.assertNotAlmostEqual(metrics["lut_align"], base_align)
+        self.assertAlmostEqual(penalty.item(), expected_align, places=6)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- compute LUT regularizers and metrics from scalar trajectories obtained via the module forward output
- expose scalar trajectory helpers for learnable LUT implementations and honor the configured linear init noise scale
- expand LUT test coverage for noise-free init and diagnostic scaling behaviour

## Testing
- `pytest tests/path/test_learnable_lut.py tests/training/test_lut_metrics.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68fa12a17c508321aa2adbf289798e90

## Summary by Sourcery

Refine LUT diagnostics to use forward outputs and scalar trajectories, honor the configured noise scale in linear initialization, and bolster test coverage for LUT initialization and metrics.

New Features:
- Expose `scalar_trajectories` and `scalar_trajectory` helpers in `LearnableScalarLUT` and parametric LUT classes for scalar-based diagnostics.

Enhancements:
- Revamp `_compute_lut_regularizer_and_metrics` to invoke `lut()` and compute align, step, curvature penalties from per-channel scalar trajectories instead of raw embeddings.
- Update `LearnableScalarLUT._linear_init` to scale Gaussian noise by `init_noise_scale` and bypass noise when the scale is zero.

Documentation:
- Add detailed implementation plan and research notes outlining the LUT metrics refinements.

Tests:
- Extend `test_learnable_lut.py` with cases verifying noise-free and noisy linear initialization and supported metric rejection.
- Add `test_lut_metrics.py` to ensure diagnostics use forward-scaled weights and bounded-residual scaling in metric computations.